### PR TITLE
Linux agent clean-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ tests/web/data/*
 htmlcov/
 artefacts/
 node_modules/
+.vscode/*
+*/.vscode/*

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -37,9 +37,9 @@ export MK_VARDIR=${MK_VARDIR:-/var/lib/check_mk_agent}
 
 # Provide information about the remote host. That helps when data
 # is being sent only once to each remote host.
-if [ "$REMOTE_HOST" ] ; then
+if [[ "$REMOTE_HOST" ]]; then
     export REMOTE=$REMOTE_HOST
-elif [ "$SSH_CLIENT" ] ; then
+elif [[ "$SSH_CLIENT" ]]; then
     export REMOTE=${SSH_CLIENT%% *}
 fi
 
@@ -69,110 +69,149 @@ SPOOLDIR=$MK_VARDIR/spool
 # When the nodes agent is executed by a e.g. docker node in a container,
 # then don't close stdin, because the agent is piped through it in this
 # case.
-if [ "$1" = -d ]
-then
-    set -xv
-elif [ -z "$MK_FROM_NODE" ]; then
-    exec </dev/null 2>/dev/null
+if [[ "$1" = -d ]]; then
+  set -xv
+elif [[ -z "$MK_FROM_NODE" ]]; then
+  exec </dev/null 2>/dev/null
 fi
 
 # Detect whether or not the agent is being executed in a container
 # environment.
-if [ -f /.dockerenv ]; then
-    IS_DOCKERIZED=1
+if [[ -f /.dockerenv ]]; then
+  IS_DOCKERIZED=1
 elif grep container=lxc /proc/1/environ >/dev/null 2>&1; then
-    # Works in lxc environment e.g. on Ubuntu bionic, but does not
-    # seem to work in proxmox (see CMK-1561)
-    IS_LXC_CONTAINER=1
+  # Works in lxc environment e.g. on Ubuntu bionic, but does not
+  # seem to work in proxmox (see CMK-1561)
+  IS_LXC_CONTAINER=1
 elif grep 'lxcfs /proc/cpuinfo fuse.lxcfs' /proc/mounts >/dev/null 2>&1; then
-    # Seems to work in proxmox
-    IS_LXC_CONTAINER=1
+  # Seems to work in proxmox
+  IS_LXC_CONTAINER=1
 else
-    unset IS_DOCKERIZED
-    unset IS_LXC_CONTAINER
+  unset IS_DOCKERIZED
+  unset IS_LXC_CONTAINER
+fi
+
+# Function to replace "if type [somecmd]" idiom
+# 'command -v' tends to be more robust vs 'which' and 'type' based tests
+inpath() {
+  command -v "${1:?No command to test}" >/dev/null 2>&1
+}
+
+# 'coreutils' 5.3.0 broke how 'stat' handled its output.  This was reverted
+# in STABLE in 5.9.4.  Just in case we happen across this version
+# we catch it and build a workaround to correct its behaviour
+# See: https://lists.gnu.org/archive/html/bug-coreutils/2005-12/msg00157.html
+if stat --version | head -n 1 | grep "5.3.0" >/dev/null 2>&1; then
+  stat() {
+    printf -- '%s\n' "$(command stat "${@}")"
+  }
 fi
 
 # Prefer (relatively) new /usr/bin/timeout from coreutils against
 # our shipped waitmax. waitmax is statically linked and crashes on
 # some Ubuntu versions recently.
-if type timeout >/dev/null 2>&1 ; then
-    function waitmax () {
-        timeout "$@"
-    }
-    export -f waitmax
+if inpath timeout; then
+  waitmax() {
+    timeout "$@"
+  }
+  export -f waitmax
 fi
 
-if [ -f "$MK_CONFDIR/encryption.cfg" ] ; then
-    source "$MK_CONFDIR/encryption.cfg"
+if [[ -f "$MK_CONFDIR/encryption.cfg" ]]; then
+  # shellcheck disable=SC1090
+  . "$MK_CONFDIR/encryption.cfg"
 fi
 
-if [ "$ENCRYPTED" == "yes" ] ; then
-    echo -n "00" # protocol version
-    exec > >(openssl enc -aes-256-cbc -md md5 -k "$PASSPHRASE" -nosalt)
+if [[ "$ENCRYPTED" == "yes" ]]; then
+  echo -n "00" # protocol version
+  exec > >(openssl enc -aes-256-cbc -md md5 -k "$PASSPHRASE" -nosalt)
 fi
-
 
 RTC_PLUGINS=""
-if [ -e "$MK_CONFDIR/real_time_checks.cfg" ]; then
-    . "$MK_CONFDIR/real_time_checks.cfg"
+if [[ -e "$MK_CONFDIR/real_time_checks.cfg" ]]; then
+  # shellcheck disable=SC1090
+  . "$MK_CONFDIR/real_time_checks.cfg"
 fi
-
 
 #
 # CHECK SECTIONS
 #
 
-function section_mem()
-{
-    if [ -z "$IS_DOCKERIZED" ]; then
-        echo '<<<mem>>>'
-        grep -E -v '^Swap:|^Mem:|total:' < /proc/meminfo
-    else
-        echo '<<<docker_container_mem>>>'
-        cat /sys/fs/cgroup/memory/memory.stat
-        echo -n "usage_in_bytes "
-        cat /sys/fs/cgroup/memory/memory.usage_in_bytes
-        echo -n "limit_in_bytes "
-        cat /sys/fs/cgroup/memory/memory.limit_in_bytes
-        grep -F 'MemTotal:' /proc/meminfo
-    fi
+get-cifs-mounts() {
+  sed -n '/ cifs\? /s/[^ ]* \([^ ]*\) .*/\1/p' < /proc/mounts \
+    | sed 's/\\040/ /g'
 }
 
-function section_cpu()
-{
-    if [ "$(uname -m)" = "armv7l" ]; then
-        CPU_REGEX='^processor'
-    else
-        CPU_REGEX='^CPU|^processor'
-    fi
-    NUM_CPUS=$(grep -c -E $CPU_REGEX < /proc/cpuinfo)
-
-    if [ -z "$IS_DOCKERIZED" ] && [ -z "$IS_LXC_CONTAINER" ]; then
-        echo '<<<cpu>>>'
-        echo "$(cat /proc/loadavg) $NUM_CPUS"
-        if [ -f "/proc/sys/kernel/threads-max" ]; then
-            cat /proc/sys/kernel/threads-max
-        fi
-    else
-        if [ -n "$IS_DOCKERIZED" ]; then
-            echo '<<<docker_container_cpu>>>'
-        else
-            echo '<<<lxc_container_cpu>>>'
-        fi
-        grep "^cpu " /proc/stat
-        echo "num_cpus $NUM_CPUS"
-        cat /sys/fs/cgroup/cpuacct/cpuacct.stat
-    fi
+get-nfs-mounts() {
+  sed -n '/ nfs4\? /s/[^ ]* \([^ ]*\) .*/\1/p' < /proc/mounts \
+    | sed 's/\\040/ /g'
 }
 
-function section_uptime()
-{
-    echo '<<<uptime>>>'
-    if [ -z "$IS_DOCKERIZED" ]; then
-        cat /proc/uptime
-    else
-        echo "$(($(date +%s) - $(stat -c %Z /dev/pts)))"
+# This function ensures that a file is executable and
+# does not have certain patterns within its name
+is_valid_plugin() {
+  case "${1:?No plugin defined}" in
+    (*dpkg-new|*dpkg-old|*dpkg-temp)
+      return 1
+    ;;
+    (*)
+      if [[ -x "${1}" ]]; then
+        return 0
+      else
+        return 1
+      fi
+    ;;
+  esac
+}
+
+section_mem() {
+  if [[ -z "$IS_DOCKERIZED" ]]; then
+    echo '<<<mem>>>'
+    grep -E -v '^Swap:|^Mem:|total:' < /proc/meminfo
+  else
+    echo '<<<docker_container_mem>>>'
+    cat /sys/fs/cgroup/memory/memory.stat
+    echo -n "usage_in_bytes "
+    cat /sys/fs/cgroup/memory/memory.usage_in_bytes
+    echo -n "limit_in_bytes "
+    cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+    grep -F 'MemTotal:' /proc/meminfo
+  fi
+}
+
+section_cpu() {
+  if [[ "$(uname -m)" = "armv7l" ]]; then
+    CPU_REGEX='^processor'
+  else
+    CPU_REGEX='^CPU|^processor'
+  fi
+  NUM_CPUS=$(grep -c -E $CPU_REGEX < /proc/cpuinfo)
+
+  if [[ -z "$IS_DOCKERIZED" ]] && [[ -z "$IS_LXC_CONTAINER" ]]; then
+    echo '<<<cpu>>>'
+    echo "$(cat /proc/loadavg) $NUM_CPUS"
+    if [[ -f "/proc/sys/kernel/threads-max" ]]; then
+      cat /proc/sys/kernel/threads-max
     fi
+  else
+    if [[ -n "$IS_DOCKERIZED" ]]; then
+      echo '<<<docker_container_cpu>>>'
+    else
+      echo '<<<lxc_container_cpu>>>'
+    fi
+    grep "^cpu " /proc/stat
+    echo "num_cpus $NUM_CPUS"
+    cat /sys/fs/cgroup/cpuacct/cpuacct.stat
+  fi
+}
+
+section_uptime() {
+  echo '<<<uptime>>>'
+  if [[ -z "$IS_DOCKERIZED" ]]; then
+    cat /proc/uptime
+  else
+    echo "$(($(date +%s) - $(stat -c %Z /dev/pts)))"
+  fi
 }
 
 # Print out Partitions / Filesystems. (-P gives non-wrapped POSIXed output)
@@ -181,49 +220,47 @@ function section_uptime()
 # settings, accessing those mounts from the agent would leave you with
 # thousands of agent processes and, ultimately, a dead monitored system.
 # These should generally be monitored on the NFS server, not on the clients.
-function section_df()
-{
-    if [ -n "$IS_DOCKERIZED" ]; then
-        return
-    fi
+section_df() {
+  if [[ -n "$IS_DOCKERIZED" ]]; then
+    return
+  fi
 
-    # The exclusion list is getting a bit of a problem. -l should hide any remote FS but seems
-    # to be all but working.
-    local excludefs="-x smbfs -x cifs -x iso9660 -x udf -x nfsv4 -x nfs -x mvfs -x prl_fs -x squashfs"
-    if [ -n "$IS_LXC_CONTAINER" ]; then
-        excludefs+=" -x zfs"
-    fi
+  # The exclusion list is getting a bit of a problem. -l should hide any remote FS but seems
+  # to be all but working.
+  local excludefs="-x smbfs -x cifs -x iso9660 -x udf -x nfsv4 -x nfs -x mvfs -x prl_fs -x squashfs"
+  if [[ -n "$IS_LXC_CONTAINER" ]]; then
+    excludefs+=" -x zfs"
+  fi
 
-    echo '<<<df>>>'
-    df -PTlk $excludefs | sed 1d
+  echo '<<<df>>>'
+  df -PTlk "${excludefs}" | sed 1d
 
-    # df inodes information
-    echo '<<<df>>>'
-    echo '[df_inodes_start]'
-    df -PTli $excludefs | sed 1d
-    echo '[df_inodes_end]'
+  # df inodes information
+  echo '<<<df>>>'
+  echo '[df_inodes_start]'
+  df -PTli "${excludefs}" | sed 1d
+  echo '[df_inodes_end]'
 }
 
-function sections_systemd()
-{
-    if type systemctl >/dev/null 2>&1 ; then
-        echo '<<<systemd_units>>>'
-        systemctl --all --no-pager
-    fi
+sections_systemd() {
+  if inpath systemctl; then
+    echo '<<<systemd_units>>>'
+    systemctl --all --no-pager
+  fi
 }
 
-function run_mrpe() {
-    local descr=$1
-    shift
-    local cmdline=$*
+run_mrpe() {
+  local descr=$1
+  shift
+  local cmdline=$*
 
-    echo '<<<mrpe>>>'
+  echo '<<<mrpe>>>'
 
-    PLUGIN=${cmdline%% *}
-    OUTPUT=$(eval "$cmdline")
+  PLUGIN=${cmdline%% *}
+  OUTPUT=$(eval "$cmdline")
 
-    echo -n "(${PLUGIN##*/}) $descr $? $OUTPUT" | tr \\n \\1
-    echo
+  echo -n "(${PLUGIN##*/}) $descr $? $OUTPUT" | tr \\n \\1
+  echo
 }
 
 export -f run_mrpe
@@ -235,77 +272,76 @@ export -f run_mrpe
 #   -ma mrpe-mode with age: stores exit code with the cache and adds the cache age
 #   NAME is the name of the section (also used as cache file name)
 #   MAXAGE is the maximum cache livetime in seconds
-function run_cached () {
-    local NOW
-    NOW=$(date +%s)
-    local section=
-    local mrpe=0
-    local append_age=0
-    # TODO: this function is unable to handle mulitple args at once
-    #       for example: -s -m won't work, it is read as single token "-s -m"
-    if [ "$1" = -s ] ; then local section="echo '<<<$2:cached($NOW,$3)>>>' ; " ; shift ; fi
-    if [ "$1" = -m ] ; then local mrpe=1 ; shift ; fi
-    if [ "$1" = "-ma" ] ; then local mrpe=1 ; local append_age=1 ; shift ; fi
-    local NAME=$1
-    local MAXAGE=$2
-    shift 2
-    local CMDLINE=$section$*
+run_cached () {
+  local NOW
+  NOW=$(date +%s)
+  local section=
+  local mrpe=0
+  local append_age=0
+  # TODO: this function is unable to handle mulitple args at once
+  #       for example: -s -m won't work, it is read as single token "-s -m"
+  if [[ "$1" = -s ]]; then local section="echo '<<<$2:cached($NOW,$3)>>>' ; " ; shift ; fi
+  if [[ "$1" = -m ]]; then local mrpe=1 ; shift ; fi
+  if [[ "$1" = "-ma" ]]; then local mrpe=1 ; local append_age=1 ; shift ; fi
+  local NAME=$1
+  local MAXAGE=$2
+  shift 2
+  local CMDLINE=$section$*
 
-    if [ ! -d "$MK_VARDIR/cache" ]; then mkdir -p "$MK_VARDIR/cache" ; fi
-    if [ "$mrpe" = 1 ] ; then
-        CACHEFILE="$MK_VARDIR/cache/mrpe_$NAME.cache"
+  if [[ ! -d "$MK_VARDIR/cache" ]]; then mkdir -p "$MK_VARDIR/cache" ; fi
+  if [[ "$mrpe" = 1 ]]; then
+    CACHEFILE="$MK_VARDIR/cache/mrpe_$NAME.cache"
+  else
+    CACHEFILE="$MK_VARDIR/cache/$NAME.cache"
+  fi
+
+  # Check if the creation of the cache takes suspiciously long and kill the
+  # process if the age (access time) of $CACHEFILE.new is twice the MAXAGE.
+  # Output the evantually already cached section anyways and start the cache
+  # update again.
+  if [[ -e "$CACHEFILE.new" ]]; then
+    local CF_ATIME
+    CF_ATIME=$(stat -c %X "$CACHEFILE.new")
+    if [[ $((NOW - CF_ATIME)) -ge $((MAXAGE * 2)) ]]; then
+      # Kill the process still accessing that file in case
+      # it is still running. This avoids overlapping processes!
+      fuser -k -9 "$CACHEFILE.new" >/dev/null 2>&1
+      rm -f "$CACHEFILE.new"
+    fi
+  fi
+
+  # Check if cache file exists and is recent enough
+  if [[ -s "$CACHEFILE" ]]; then
+    local MTIME
+    MTIME=$(stat -c %Y "$CACHEFILE")
+    local AGE
+    AGE=$((NOW - MTIME))
+    if [[ "$AGE" -le "$MAXAGE" ]]; then local USE_CACHEFILE=1 ; fi
+    # Output the file in any case, even if it is
+    # outdated. The new file will not yet be available
+    if [[ $append_age -eq 1 ]]; then
+      # insert the cached-string before the pipe (first -e)
+      # or, if no pipe found (-e t) append it (third -e),
+      # but only once and on the second line (2!b) (first line is section header,
+      # all further lines are long output)
+      sed -e "2s/|/ (Cached: ${AGE}\/${MAXAGE}s)|/" -e t -e "2s/$/ (Cached: ${AGE}\/${MAXAGE}s)/" < "$CACHEFILE"
     else
-        CACHEFILE="$MK_VARDIR/cache/$NAME.cache"
+      CACHE_INFO=":cached($MTIME,$MAXAGE)"
+      # insert the cache info in the section header (^= after '!'),
+      # if none is present (^= before '!')
+      sed -e '/^<<<.*\(:cached(\).*>>>/!s/^<<<\([^>]*\)>>>$/<<<\1'$CACHE_INFO'>>>/' "$CACHEFILE"
     fi
+  fi
 
-    # Check if the creation of the cache takes suspiciously long and kill the
-    # process if the age (access time) of $CACHEFILE.new is twice the MAXAGE.
-    # Output the evantually already cached section anyways and start the cache
-    # update again.
-    if [ -e "$CACHEFILE.new" ] ; then
-        local CF_ATIME
-        CF_ATIME=$(stat -c %X "$CACHEFILE.new")
-        if [ $((NOW - CF_ATIME)) -ge $((MAXAGE * 2)) ] ; then
-            # Kill the process still accessing that file in case
-            # it is still running. This avoids overlapping processes!
-            fuser -k -9 "$CACHEFILE.new" >/dev/null 2>&1
-            rm -f "$CACHEFILE.new"
-        fi
+  # Cache file outdated and new job not yet running? Start it
+  if [[ -z "$USE_CACHEFILE" ]] && [[ ! -e "$CACHEFILE.new" ]]; then
+    # When the command fails, the output is throws away ignored
+    if [[ $mrpe -eq 1 ]]; then
+      echo "set -o noclobber ; exec > \"$CACHEFILE.new\" || exit 1 ; run_mrpe $NAME \"$CMDLINE\" && mv \"$CACHEFILE.new\" \"$CACHEFILE\" || rm -f \"$CACHEFILE\" \"$CACHEFILE.new\"" | nohup /bin/bash >/dev/null 2>&1 &
+    else
+      echo "set -o noclobber ; exec > \"$CACHEFILE.new\" || exit 1 ; $CMDLINE && mv \"$CACHEFILE.new\" \"$CACHEFILE\" || rm -f \"$CACHEFILE\" \"$CACHEFILE.new\"" | nohup /bin/bash >/dev/null 2>&1 &
     fi
-
-
-    # Check if cache file exists and is recent enough
-    if [ -s "$CACHEFILE" ] ; then
-        local MTIME
-        MTIME=$(stat -c %Y "$CACHEFILE")
-        local AGE
-        AGE=$((NOW - MTIME))
-        if [ "$AGE" -le "$MAXAGE" ] ; then local USE_CACHEFILE=1 ; fi
-        # Output the file in any case, even if it is
-        # outdated. The new file will not yet be available
-        if [ $append_age -eq 1 ] ; then
-            # insert the cached-string before the pipe (first -e)
-            # or, if no pipe found (-e t) append it (third -e),
-            # but only once and on the second line (2!b) (first line is section header,
-            # all further lines are long output)
-            sed -e "2s/|/ (Cached: ${AGE}\/${MAXAGE}s)|/" -e t -e "2s/$/ (Cached: ${AGE}\/${MAXAGE}s)/" < "$CACHEFILE"
-        else
-            CACHE_INFO=":cached($MTIME,$MAXAGE)"
-            # insert the cache info in the section header (^= after '!'),
-            # if none is present (^= before '!')
-            sed -e '/^<<<.*\(:cached(\).*>>>/!s/^<<<\([^>]*\)>>>$/<<<\1'$CACHE_INFO'>>>/' "$CACHEFILE"
-        fi
-    fi
-
-    # Cache file outdated and new job not yet running? Start it
-    if [ -z "$USE_CACHEFILE" ] && [ ! -e "$CACHEFILE.new" ] ; then
-        # When the command fails, the output is throws away ignored
-        if [ $mrpe -eq 1 ] ; then
-            echo "set -o noclobber ; exec > \"$CACHEFILE.new\" || exit 1 ; run_mrpe $NAME \"$CMDLINE\" && mv \"$CACHEFILE.new\" \"$CACHEFILE\" || rm -f \"$CACHEFILE\" \"$CACHEFILE.new\"" | nohup /bin/bash >/dev/null 2>&1 &
-        else
-            echo "set -o noclobber ; exec > \"$CACHEFILE.new\" || exit 1 ; $CMDLINE && mv \"$CACHEFILE.new\" \"$CACHEFILE\" || rm -f \"$CACHEFILE\" \"$CACHEFILE.new\"" | nohup /bin/bash >/dev/null 2>&1 &
-        fi
-    fi
+  fi
 }
 
 # Make run_cached available for subshells (plugins, local checks, etc.)
@@ -314,71 +350,67 @@ export -f run_cached
 # Implements Real-Time Check feature of the Check_MK agent which can send
 # some section data in 1 second resolution. Useful for fast notifications and
 # detailed graphing (if you configure your RRDs to this resolution).
-function run_real_time_checks()
-{
-    PIDFILE=$MK_VARDIR/real_time_checks.pid
-    echo $$ > "$PIDFILE"
+run_real_time_checks() {
+  PIDFILE=$MK_VARDIR/real_time_checks.pid
+  echo $$ > "$PIDFILE"
 
+  if [[ "$PASSPHRASE" != "" ]]; then
+    # new mechanism to set the passphrase has priority
+    RTC_SECRET=$PASSPHRASE
+  fi
 
-    if [ "$PASSPHRASE" != "" ] ; then
-        # new mechanism to set the passphrase has priority
-        RTC_SECRET=$PASSPHRASE
+  if [[ "$ENCRYPTED_RT" != "no" ]]; then
+    PROTOCOL=00
+  else
+    PROTOCOL=99
+  fi
+
+  while true; do
+    # terminate when pidfile is gone or other Real-Time Check process started or configured timeout
+    if [[ ! -e "$PIDFILE" ]] || [[ "$(<"$PIDFILE")" -ne $$ ]] || [[ "$RTC_TIMEOUT" -eq 0 ]]; then
+      exit 1
     fi
 
-    if [ "$ENCRYPTED_RT" != "no" ] ; then
-        PROTOCOL=00
-    else
-        PROTOCOL=99
-    fi
-
-
-    while true; do
-        # terminate when pidfile is gone or other Real-Time Check process started or configured timeout
-        if [ ! -e "$PIDFILE" ] || [ "$(<"$PIDFILE")" -ne $$ ] || [ "$RTC_TIMEOUT" -eq 0 ]; then
-            exit 1
+    for SECTION in $RTC_SECTIONS; do
+      # Be aware of maximum packet size. Maybe we need to check the size of the section
+      # output and do some kind of nicer error handling.
+      # 2 bytes: protocol version, 10 bytes: timestamp, rest: encrypted data
+      # dd is used to concatenate the output of all commands to a single write/block => udp packet
+      { echo -n $PROTOCOL ;
+        date +%s | tr -d '\n' ;
+        if [[ "$ENCRYPTED_RT" != "no" ]]; then
+          export RTC_SECRET=$RTC_SECRET ; section_"$SECTION" | openssl enc -aes-256-cbc -md md5 -pass env:RTC_SECRET -nosalt ;
+        else
+          section_"$SECTION" ;
         fi
-
-        for SECTION in $RTC_SECTIONS; do
-            # Be aware of maximum packet size. Maybe we need to check the size of the section
-            # output and do some kind of nicer error handling.
-            # 2 bytes: protocol version, 10 bytes: timestamp, rest: encrypted data
-            # dd is used to concatenate the output of all commands to a single write/block => udp packet
-            { echo -n $PROTOCOL ;
-              date +%s | tr -d '\n' ;
-              if [ "$ENCRYPTED_RT" != "no" ] ; then
-                  export RTC_SECRET=$RTC_SECRET ; section_"$SECTION" | openssl enc -aes-256-cbc -md md5 -pass env:RTC_SECRET -nosalt ;
-              else
-                  section_"$SECTION" ;
-              fi
-            } | dd bs=9999 iflag=fullblock 2>/dev/null >"/dev/udp/${REMOTE}/${RTC_PORT}"
-        done
-
-
-        # Plugins
-        if cd "$PLUGINSDIR" ; then
-            for PLUGIN in $RTC_PLUGINS; do
-                if [ ! -f $PLUGIN ] ; then
-                    continue
-                fi
-
-                # Be aware of maximum packet size. Maybe we need to check the size of the section
-                # output and do some kind of nicer error handling.
-                # 2 bytes: protocol version, 10 bytes: timestamp, rest: encrypted data
-                # dd is used to concatenate the output of all commands to a single write/block => udp packet
-                { echo -n $PROTOCOL ;
-                  date +%s | tr -d '\n' ;
-                  if [ "$ENCRYPTED_RT" != "no" ] ; then
-                      export RTC_SECRET=$RTC_SECRET ; ./$PLUGIN | openssl enc -aes-256-cbc -md md5 -pass env:RTC_SECRET -nosalt ;
-                  else
-                      ./"$PLUGIN";
-                  fi
-                } | dd bs=9999 iflag=fullblock 2>/dev/null >"/dev/udp/${REMOTE}/${RTC_PORT}"
-            done
-        fi
-
-        sleep 1
-        RTC_TIMEOUT=$((RTC_TIMEOUT-1))
+      } | dd bs=9999 iflag=fullblock 2>/dev/null >"/dev/udp/${REMOTE}/${RTC_PORT}"
     done
+
+    # Plugins
+    if cd "$PLUGINSDIR" ; then
+      for PLUGIN in $RTC_PLUGINS; do
+        if [[ ! -f $PLUGIN ]]; then
+          continue
+        fi
+
+        # Be aware of maximum packet size. Maybe we need to check the size of the section
+        # output and do some kind of nicer error handling.
+        # 2 bytes: protocol version, 10 bytes: timestamp, rest: encrypted data
+        # dd is used to concatenate the output of all commands to a single write/block => udp packet
+        { echo -n $PROTOCOL ;
+          date +%s | tr -d '\n' ;
+          if [[ "$ENCRYPTED_RT" != "no" ]]; then
+            export RTC_SECRET=$RTC_SECRET ; ./$PLUGIN | openssl enc -aes-256-cbc -md md5 -pass env:RTC_SECRET -nosalt ;
+          else
+            ./"$PLUGIN";
+          fi
+        } | dd bs=9999 iflag=fullblock 2>/dev/null >"/dev/udp/${REMOTE}/${RTC_PORT}"
+      done
+    fi
+
+    sleep 1
+    RTC_TIMEOUT=$((RTC_TIMEOUT-1))
+  done
 }
 
 echo "<<<check_mk>>>"
@@ -392,10 +424,9 @@ echo "PluginsDirectory: $PLUGINSDIR"
 echo "LocalDirectory: $LOCALDIR"
 
 # If we are called via xinetd, try to find only_from configuration
-if [ -n "$REMOTE_HOST" ]
-then
-    echo -n 'OnlyFrom: '
-    sed -n '/^service[[:space:]]*'$XINETD_SERVICE_NAME'/,/}/s/^[[:space:]]*only_from[[:space:]]*=[[:space:]]*\(.*\)/\1/p' /etc/xinetd.d/* | head -n1; echo
+if [[ -n "$REMOTE_HOST" ]]; then
+  echo -n 'OnlyFrom: '
+  sed -n '/^service[[:space:]]*'$XINETD_SERVICE_NAME'/,/}/s/^[[:space:]]*only_from[[:space:]]*=[[:space:]]*\(.*\)/\1/p' /etc/xinetd.d/* | head -n1; echo
 fi
 
 section_df
@@ -403,50 +434,32 @@ section_df
 sections_systemd
 
 # Filesystem usage for ZFS
-if type zfs > /dev/null 2>&1 ; then
-    echo '<<<zfsget>>>'
-    zfs get -t filesystem,volume -Hp name,quota,used,avail,mountpoint,type 2>/dev/null
-    echo '[df]'
-    df -PTlk -t zfs | sed 1d
+if inpath zfs > /dev/null 2>&1 ; then
+  echo '<<<zfsget>>>'
+  zfs get -t filesystem,volume -Hp name,quota,used,avail,mountpoint,type 2>/dev/null
+  echo '[df]'
+  df -PTlk -t zfs | sed 1d
 fi
 
 # Check NFS mounts by accessing them with stat -f (System
 # call statfs()). If this lasts more then 2 seconds we
 # consider it as hanging. We need waitmax.
-if type waitmax >/dev/null
-then
-    STAT_VERSION=$(stat --version | head -1 | cut -d" " -f4)
-    STAT_BROKE="5.3.0"
+if inpath waitmax; then
+  echo '<<<nfsmounts>>>'
+  while read -r mountPoint; do
+    waitmax -s 9 5 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
+      || echo "${mountPoint} hanging 0 0 0 0"
+  done < <(get-nfs-mounts)
 
-    echo '<<<nfsmounts>>>'
-    sed -n '/ nfs4\? /s/[^ ]* \([^ ]*\) .*/\1/p' < /proc/mounts |
-        sed 's/\\040/ /g' |
-        while read MP
-    do
-        if [ "$STAT_VERSION" != "$STAT_BROKE" ]; then
-            waitmax -s 9 5 stat -f -c "$MP ok %b %f %a %s" "$MP" || \
-                echo "$MP hanging 0 0 0 0"
-        else
-            waitmax -s 9 5 stat -f -c "$MP ok %b %f %a %s" "$MP" && \
-                printf '\n'|| echo "$MP hanging 0 0 0 0"
-        fi
-    done
-
-    echo '<<<cifsmounts>>>'
-    sed -n '/ cifs\? /s/[^ ]* \([^ ]*\) .*/\1/p' < /proc/mounts |
-        sed 's/\\040/ /g' |
-        while read MP
-    do
-        if [ ! -r "$MP" ]; then
-            echo "$MP Permission denied"
-        elif [ "$STAT_VERSION" != "$STAT_BROKE" ]; then
-            waitmax -s 9 2 stat -f -c "$MP ok %b %f %a %s" "$MP" || \
-                echo "$MP hanging 0 0 0 0"
-        else
-            waitmax -s 9 2 stat -f -c "$MP ok %b %f %a %s" "$MP" && \
-                printf '\n'|| echo "$MP hanging 0 0 0 0"
-        fi
-    done
+  echo '<<<cifsmounts>>>'
+  while read -r mountPoint; do
+    if [[ ! -r "${mountPoint}" ]]; then
+      echo "${mountPoint} Permission denied"
+    else
+      waitmax -s 9 2 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
+        || echo "${mountPoint} hanging 0 0 0 0"
+    fi
+  done < <(get-cifs-mounts)
 fi
 
 # Check mount options. Filesystems may switch to 'ro' in case
@@ -456,7 +469,8 @@ grep ^/dev < /proc/mounts | grep -v " squashfs "
 
 # processes including username, without kernel processes
 echo '<<<ps>>>'
-ps ax -o user:32,vsz,rss,cputime,etime,pid,command --columns 10000 | sed -e 1d -e 's/ *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) */(\1,\2,\3,\4\/\5,\6) /'
+ps ax -o user:32,vsz,rss,cputime,etime,pid,command --columns 10000 \
+  | sed -e 1d -e 's/ *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) */(\1,\2,\3,\4\/\5,\6) /'
 
 # Memory usage
 section_mem
@@ -468,134 +482,129 @@ section_cpu
 section_uptime
 
 # New variant: Information about speed and state in one section
-if type ip > /dev/null
-then
-    echo '<<<lnx_if>>>'
-    echo "[start_iplink]"
-    ip address
-    echo "[end_iplink]"
+if inpath ip; then
+  echo '<<<lnx_if>>>'
+  echo "[start_iplink]"
+  ip address
+  echo "[end_iplink]"
 fi
 
 echo '<<<lnx_if:sep(58)>>>'
 sed 1,2d /proc/net/dev
-if type ethtool > /dev/null
-then
-    sed -e 1,2d /proc/net/dev | cut -d':' -f1 | sort | while read eth; do
-        echo "[$eth]"
-        ethtool "$eth" | grep -E '(Speed|Duplex|Link detected|Auto-negotiation):'
-        echo -e "\tAddress: $(cat "/sys/class/net/$eth/address")\n"
-    done
+if inpath ethtool; then
+  sed -e 1,2d /proc/net/dev | cut -d':' -f1 | sort | while read -r eth; do
+    echo "[$eth]"
+    ethtool "$eth" | grep -E '(Speed|Duplex|Link detected|Auto-negotiation):'
+    echo -e "\tAddress: $(cat "/sys/class/net/$eth/address")\n"
+  done
 fi
 
-
 # Current state of bonding interfaces
-if [ -e /proc/net/bonding ] ; then
-    echo '<<<lnx_bonding:sep(58)>>>'
-    pushd /proc/net/bonding > /dev/null
+if [[ -e /proc/net/bonding ]]; then
+  echo '<<<lnx_bonding:sep(58)>>>'
+  (
+    cd /proc/net/bonding || return
     head -v -n 1000 ./*
-    popd > /dev/null
+  )
 fi
 
 # Same for Open vSwitch bonding
-if type ovs-appctl > /dev/null ; then
-    BONDS=$(ovs-appctl bond/list)
-    COL=$(echo "$BONDS" | awk '{for(i=1;i<=NF;i++) {if($i == "bond") printf("%d", i)} exit 0}')
-    echo '<<<ovs_bonding:sep(58)>>>'
-    for bond in $(echo "$BONDS" | sed -e 1d | cut -f"${COL}") ; do
-        echo "[$bond]"
-        ovs-appctl bond/show "$bond"
-    done
+if inpath ovs-appctl > /dev/null ; then
+  BONDS=$(ovs-appctl bond/list)
+  COL=$(echo "$BONDS" | awk '{for(i=1;i<=NF;i++) {if($i == "bond") printf("%d", i)} exit 0}')
+  echo '<<<ovs_bonding:sep(58)>>>'
+  for bond in $(echo "$BONDS" | sed -e 1d | cut -f"${COL}"); do
+    echo "[$bond]"
+    ovs-appctl bond/show "$bond"
+  done
 fi
 
-
 # Number of TCP connections in the various states
-if type waitmax >/dev/null ; then
-    echo '<<<tcp_conn_stats>>>'
-    THIS=$(waitmax 5 cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | awk ' /:/ { c[$4]++; } END { for (x in c) { print x, c[x]; } }')
-    if [ $? == 0 ] ; then
-        echo "$THIS"
-    elif type ss > /dev/null ; then
-        ss -ant |grep -v ^State | awk ' /:/ { c[$1]++; } END { for (x in c) { print x, c[x]; } }' | sed -e 's/^ESTAB/01/g;s/^SYN-SENT/02/g;s/^SYN-RECV/03/g;s/^FIN-WAIT-1/04/g;s/^FIN-WAIT-2/05/g;s/^TIME-WAIT/06/g;s/^CLOSED/07/g;s/^CLOSE-WAIT/08/g;s/^LAST-ACK/09/g;s/^LISTEN/0A/g;s/^CLOSING/0B/g;'
-    fi
+if inpath waitmax; then
+  echo '<<<tcp_conn_stats>>>'
+  THIS=$(waitmax 5 cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | awk ' /:/ { c[$4]++; } END { for (x in c) { print x, c[x]; } }')
+  if [[ $? == 0 ]]; then
+    echo "$THIS"
+  elif inpath ss > /dev/null ; then
+    ss -ant \
+      | grep -v ^State \
+      | awk ' /:/ { c[$1]++; } END { for (x in c) { print x, c[x]; } }' \
+      | sed -e 's/^ESTAB/01/g;s/^SYN-SENT/02/g;s/^SYN-RECV/03/g;s/^FIN-WAIT-1/04/g;s/^FIN-WAIT-2/05/g;s/^TIME-WAIT/06/g;s/^CLOSED/07/g;s/^CLOSE-WAIT/08/g;s/^LAST-ACK/09/g;s/^LISTEN/0A/g;s/^CLOSING/0B/g;'
+  fi
 fi
 
 # Linux Multipathing
-if type multipath >/dev/null ; then
-    if [ -f /etc/multipath.conf ] ; then
-        echo '<<<multipath>>>'
-        multipath -l
-    fi
+if inpath multipath; then
+  if [[ -f /etc/multipath.conf ]]; then
+    echo '<<<multipath>>>'
+    multipath -l
+  fi
 fi
 
 # Performancecounter Platten
-if [ -z "$IS_DOCKERIZED" ]; then
-    echo '<<<diskstat>>>'
-    date +%s
-    grep -E ' (x?[shv]d[a-z]*[0-9]*|cciss/c[0-9]+d[0-9]+|emcpower[a-z]+|dm-[0-9]+|VxVM.*|mmcblk.*|dasd[a-z]*|bcache[0-9]+|nvme[0-9]+n[0-9]+) ' < /proc/diskstats
-    if type dmsetup >/dev/null ; then
-        echo '[dmsetup_info]'
-        dmsetup info -c --noheadings --separator ' ' -o name,devno,vg_name,lv_name
-    fi
-    if [ -d /dev/vx/dsk ] ; then
-        echo '[vx_dsk]'
-        stat -c "%t %T %n" /dev/vx/dsk/*/*
-    fi
+if [[ -z "$IS_DOCKERIZED" ]]; then
+  echo '<<<diskstat>>>'
+  date +%s
+  grep -E ' (x?[shv]d[a-z]*[0-9]*|cciss/c[0-9]+d[0-9]+|emcpower[a-z]+|dm-[0-9]+|VxVM.*|mmcblk.*|dasd[a-z]*|bcache[0-9]+|nvme[0-9]+n[0-9]+) ' < /proc/diskstats
+  if inpath dmsetup; then
+    echo '[dmsetup_info]'
+    dmsetup info -c --noheadings --separator ' ' -o name,devno,vg_name,lv_name
+  fi
+  if [[ -d /dev/vx/dsk ]]; then
+    echo '[vx_dsk]'
+    stat -c "%t %T %n" /dev/vx/dsk/*/*
+  fi
 else
-    echo '<<<docker_container_diskstat>>>'
-    echo "[time]"
-    date +%s
-    for F in io_service_bytes io_serviced; do
-        echo "[$F]"
-        cat "/sys/fs/cgroup/blkio/blkio.throttle.$F"
-    done
-    echo "[names]"
-    for F in /sys/block/*; do
-        echo -n "${F##*/} " ;
-        cat "$F/dev";
-    done
+  echo '<<<docker_container_diskstat>>>'
+  echo "[time]"
+  date +%s
+  for F in io_service_bytes io_serviced; do
+    echo "[$F]"
+    cat "/sys/fs/cgroup/blkio/blkio.throttle.$F"
+  done
+  echo "[names]"
+  for F in /sys/block/*; do
+    echo -n "${F##*/} " ;
+    cat "$F/dev";
+  done
 fi
 
-
 # Performancecounter Kernel
-if [ -z "$IS_DOCKERIZED" ] && [ -z "$IS_LXC_CONTAINER" ]; then
+if [[ -z "$IS_DOCKERIZED" ]] && [[ -z "$IS_LXC_CONTAINER" ]]; then
     echo '<<<kernel>>>'
     date +%s
     cat /proc/vmstat /proc/stat
 fi
 
 # Hardware sensors via IPMI (need ipmitool)
-if type ipmitool > /dev/null
-then
-    run_cached -s "ipmi:sep(124)" 300 "waitmax 300 ipmitool sensor list | grep -v 'command failed' | egrep -v '^[^ ]+ na ' | grep -v ' discrete '"
-    # readable discrete sensor states
-    run_cached -s "ipmi_discrete:sep(124)" 300 "waitmax 300 ipmitool sdr elist compact"
+if inpath ipmitool; then
+  run_cached -s "ipmi:sep(124)" 300 "waitmax 300 ipmitool sensor list | grep -v 'command failed' | grep -E -v '^[^ ]+ na ' | grep -v ' discrete '"
+  # readable discrete sensor states
+  run_cached -s "ipmi_discrete:sep(124)" 300 "waitmax 300 ipmitool sdr elist compact"
 fi
-
 
 # IPMI data via ipmi-sensors (of freeipmi). Please make sure, that if you
 # have installed freeipmi that IPMI is really support by your hardware.
-if (type ipmi-sensors && ls /dev/ipmi*) &>/dev/null
-then
-    echo '<<<ipmi_sensors>>>'
-    # Newer ipmi-sensors version have new output format; Legacy format can be used
-    if ipmi-sensors --help | grep -q legacy-output; then
-        IPMI_FORMAT="--legacy-output"
-    else
-        IPMI_FORMAT=""
-    fi
-    if ipmi-sensors --help | grep -q " \-\-groups"; then
-        IPMI_GROUP_OPT="-g"
-    else
-        IPMI_GROUP_OPT="-t"
-    fi
+if (inpath ipmi-sensors && ls /dev/ipmi*) &>/dev/null; then
+  echo '<<<ipmi_sensors>>>'
+  # Newer ipmi-sensors version have new output format; Legacy format can be used
+  if ipmi-sensors --help | grep -q legacy-output; then
+    IPMI_FORMAT="--legacy-output"
+  else
+    IPMI_FORMAT=""
+  fi
+  if ipmi-sensors --help | grep -q " \-\-groups"; then
+    IPMI_GROUP_OPT="-g"
+  else
+    IPMI_GROUP_OPT="-t"
+  fi
 
-    # At least with ipmi-sensors 0.7.16 this group is Power_Unit instead of "Power Unit"
-    run_cached -s ipmi_sensors 300 "for class in Temperature Power_Unit Fan
-    do
-        ipmi-sensors $IPMI_FORMAT --sdr-cache-directory /var/cache $IPMI_GROUP_OPT \"\$class\" | sed -e 's/ /_/g' -e 's/:_\?/ /g' -e 's@ \([^(]*\)_(\([^)]*\))@ \2_\1@'
-        # In case of a timeout immediately leave loop.
-        if [ $? = 255 ] ; then break ; fi
-    done"
+  # At least with ipmi-sensors 0.7.16 this group is Power_Unit instead of "Power Unit"
+  run_cached -s ipmi_sensors 300 "for class in Temperature Power_Unit Fan; do
+      ipmi-sensors $IPMI_FORMAT --sdr-cache-directory /var/cache $IPMI_GROUP_OPT \"\$class\" | sed -e 's/ /_/g' -e 's/:_\?/ /g' -e 's@ \([^(]*\)_(\([^)]*\))@ \2_\1@'
+      # In case of a timeout immediately leave loop.
+      if [[ $? = 255 ]]; then break ; fi
+  done"
 fi
 
 # RAID status of Linux software RAID
@@ -603,121 +612,112 @@ echo '<<<md>>>'
 cat /proc/mdstat
 
 # RAID status of Linux RAID via device mapper
-if type dmraid >/dev/null && DMSTATUS=$(waitmax 3 dmraid -r)
-then
-    echo '<<<dmraid>>>'
+if inpath dmraid && DMSTATUS=$(waitmax 3 dmraid -r); then
+  echo '<<<dmraid>>>'
 
-    # Output name and status
-    waitmax 20 dmraid -s | grep -e ^name -e ^status
+  # Output name and status
+  waitmax 20 dmraid -s | grep -e ^name -e ^status
 
-    # Output disk names of the RAID disks
-    DISKS=$(echo "$DMSTATUS" | cut -f1 -d":")
+  # Output disk names of the RAID disks
+  DISKS=$(echo "$DMSTATUS" | cut -f1 -d":")
 
-    for disk in $DISKS ; do
-        device=$(cat /sys/block/"$(basename "$disk")"/device/model )
-        status=$(echo "$DMSTATUS" | grep "^${disk}")
-        echo "${status} Model: ${device}"
-    done
+  for disk in $DISKS ; do
+    device=$(cat /sys/block/"$(basename "$disk")"/device/model )
+    status=$(echo "$DMSTATUS" | grep "^${disk}")
+    echo "${status} Model: ${device}"
+  done
 fi
 
 # RAID status of LSI controllers via cfggen
-if type cfggen > /dev/null ; then
-   echo '<<<lsi>>>'
-   cfggen 0 DISPLAY | egrep '(Target ID|State|Volume ID|Status of volume)[[:space:]]*:' | sed -e 's/ *//g' -e 's/:/ /'
+if inpath cfggen > /dev/null ; then
+  echo '<<<lsi>>>'
+  cfggen 0 DISPLAY | grep -E '(Target ID|State|Volume ID|Status of volume)[[:space:]]*:' \
+    | sed -e 's/ *//g' -e 's/:/ /'
 fi
 
 # RAID status of LSI MegaRAID controller via MegaCli. You can download that tool from:
 # http://www.lsi.com/downloads/Public/MegaRAID%20Common%20Files/8.02.16_MegaCLI.zip
-if type MegaCli >/dev/null ; then
-    MegaCli_bin="MegaCli"
-elif type MegaCli64 >/dev/null ; then
-    MegaCli_bin="MegaCli64"
-elif type megacli >/dev/null ; then
-    MegaCli_bin="megacli"
-elif type storcli >/dev/null ; then
-    MegaCli_bin="storcli"
-elif type storcli64 >/dev/null ; then
-    MegaCli_bin="storcli64"
-else
-    MegaCli_bin="unknown"
-fi
+for cliAlt in MegaCli MegaCli64 megacli storcli storcli64; do
+  if inpath "${cliAlt}"; then
+    lsicli() { "${cliAlt}"; }
+    break
+  fi
+done
 
-if [ "$MegaCli_bin" != "unknown" ]; then
-    echo '<<<megaraid_pdisks>>>'
-    for part in $($MegaCli_bin -EncInfo -aALL -NoLog < /dev/null \
-        | sed -rn 's/:/ /g; s/[[:space:]]+/ /g; s/^ //; s/ $//; s/Number of enclosures on adapter ([0-9]+).*/adapter \1/g; /^(Enclosure|Device ID|adapter) [0-9]+$/ p'); do
-        [ "$part" = adapter ] && echo ""
-        [ "$part" = 'Enclosure' ] && echo -ne "\ndev2enc"
-        echo -n " $part"
-    done
-    echo
-    $MegaCli_bin -PDList -aALL -NoLog < /dev/null | egrep 'Enclosure|Raw Size|Slot Number|Device Id|Firmware state|Inquiry|Adapter'
-    echo '<<<megaraid_ldisks>>>'
-    $MegaCli_bin -LDInfo -Lall -aALL -NoLog < /dev/null | egrep 'Size|State|Number|Adapter|Virtual'
-    echo '<<<megaraid_bbu>>>'
-    $MegaCli_bin -AdpBbuCmd -GetBbuStatus -aALL -NoLog < /dev/null | grep -v Exit
+if inpath lsicli; then
+  echo '<<<megaraid_pdisks>>>'
+  for part in $(lsicli -EncInfo -aALL -NoLog < /dev/null \
+    | sed -rn 's/:/ /g; s/[[:space:]]+/ /g; s/^ //; s/ $//; s/Number of enclosures on adapter ([0-9]+).*/adapter \1/g; /^(Enclosure|Device ID|adapter) [0-9]+$/ p'); do
+    [ "$part" = adapter ] && echo ""
+    [ "$part" = 'Enclosure' ] && echo -ne "\ndev2enc"
+    echo -n " $part"
+  done
+  echo
+  lsicli -PDList -aALL -NoLog < /dev/null | grep -E 'Enclosure|Raw Size|Slot Number|Device Id|Firmware state|Inquiry|Adapter'
+  echo '<<<megaraid_ldisks>>>'
+  lsicli -LDInfo -Lall -aALL -NoLog < /dev/null | grep -E 'Size|State|Number|Adapter|Virtual'
+  echo '<<<megaraid_bbu>>>'
+  lsicli -AdpBbuCmd -GetBbuStatus -aALL -NoLog < /dev/null | grep -v Exit
 fi
 
 # RAID status of 3WARE disk controller (by Radoslaw Bak)
-if type tw_cli > /dev/null ; then
-    for C in $(tw_cli show | awk 'NR < 4 { next } { print $1 }'); do
-        echo '<<<3ware_info>>>'
-        tw_cli "/$C" show all | egrep 'Model =|Firmware|Serial'
-        echo '<<<3ware_disks>>>'
-        tw_cli "/$C" show drivestatus | egrep 'p[0-9]' | sed "s/^/$C\//"
-        echo '<<<3ware_units>>>'
-        tw_cli "/$C" show unitstatus | egrep 'u[0-9]' | sed "s/^/$C\//"
-    done
+if inpath tw_cli > /dev/null ; then
+  for C in $(tw_cli show | awk 'NR < 4 { next } { print $1 }'); do
+    echo '<<<3ware_info>>>'
+    tw_cli "/$C" show all | grep -E 'Model =|Firmware|Serial'
+    echo '<<<3ware_disks>>>'
+    tw_cli "/$C" show drivestatus | grep -E 'p[0-9]' | sed "s/^/$C\//"
+    echo '<<<3ware_units>>>'
+    tw_cli "/$C" show unitstatus | grep -E 'u[0-9]' | sed "s/^/$C\//"
+  done
 fi
 
 # RAID controllers from areca (Taiwan)
 # cli64 can be found at ftp://ftp.areca.com.tw/RaidCards/AP_Drivers/Linux/CLI/
-if type cli64 >/dev/null ; then
-    run_cached -s arc_raid_status 300 "cli64 rsf info | tail -n +3 | head -n -2"
+if inpath cli64; then
+  run_cached -s arc_raid_status 300 "cli64 rsf info | tail -n +3 | head -n -2"
 fi
 
 # VirtualBox Guests. Section must always been output. Otherwise the
 # check would not be executed in case no guest additions are installed.
 # And that is something the check wants to detect
 echo '<<<vbox_guest>>>'
-if type VBoxControl >/dev/null 2>&1 && lsmod | grep vboxguest >/dev/null 2>&1; then
-    VBoxControl -nologo guestproperty enumerate | cut -d, -f1,2
-    [ "${PIPESTATUS[0]}" = 0 ] || echo "ERROR"
+if inpath VBoxControl && lsmod | grep vboxguest >/dev/null 2>&1; then
+  VBoxControl -nologo guestproperty enumerate | cut -d, -f1,2
+  [ "${PIPESTATUS[0]}" = 0 ] || echo "ERROR"
 fi
 
 # OpenVPN Clients. Currently we assume that the configuration # is in
 # /etc/openvpn. We might find a safer way to find the configuration later.
-if [ -e /etc/openvpn/openvpn-status.log ] ; then
-    echo '<<<openvpn_clients:sep(44)>>>'
-    sed -n -e '/CLIENT LIST/,/ROUTING TABLE/p' < /etc/openvpn/openvpn-status.log  | sed -e 1,3d -e '$d'
+if [[ -e /etc/openvpn/openvpn-status.log ]]; then
+  echo '<<<openvpn_clients:sep(44)>>>'
+  sed -n -e '/CLIENT LIST/,/ROUTING TABLE/p' < /etc/openvpn/openvpn-status.log  | sed -e 1,3d -e '$d'
 fi
 
 # Time synchronization with NTP
-if type ntpq > /dev/null 2>&1 ; then
-   # remove heading, make first column space separated
-   run_cached -s ntp 30 "waitmax 5 ntpq -np | sed -e 1,2d -e 's/^\(.\)/\1 /' -e 's/^ /%/' || true"
+if inpath ntpq; then
+  # remove heading, make first column space separated
+  run_cached -s ntp 30 "waitmax 5 ntpq -np | sed -e 1,2d -e 's/^\(.\)/\1 /' -e 's/^ /%/' || true"
 fi
 
 # Time synchronization with Chrony
-if type chronyc > /dev/null 2>&1 ; then
-    # Force successful exit code. Otherwise section will be missing if daemon not running
-    #
-    # The "| cat" has been added for some kind of regression in RedHat 7.5. The
-    # SELinux rules shipped with that release were denying the chronyc call
-    # without cat.
-    run_cached -s chrony 30 "waitmax 5 chronyc -n tracking | cat || true"
+if inpath chronyc; then
+  # Force successful exit code. Otherwise section will be missing if daemon not running
+  #
+  # The "| cat" has been added for some kind of regression in RedHat 7.5. The
+  # SELinux rules shipped with that release were denying the chronyc call
+  # without cat.
+  run_cached -s chrony 30 "waitmax 5 chronyc -n tracking | cat || true"
 fi
 
-if type nvidia-settings >/dev/null && [ -S /tmp/.X11-unix/X0 ]
-then
-    echo '<<<nvidia>>>'
-    for var in GPUErrors GPUCoreTemp
-    do
-        DISPLAY=:0 waitmax 2 nvidia-settings -t -q $var | sed "s/^/$var: /"
-    done
+if inpath nvidia-settings && [[ -S /tmp/.X11-unix/X0 ]]; then
+  echo '<<<nvidia>>>'
+  for var in GPUErrors GPUCoreTemp; do
+    DISPLAY=:0 waitmax 2 nvidia-settings -t -q $var | sed "s/^/$var: /"
+  done
 fi
 
-if [ -z "$IS_DOCKERIZED" ] && [ -z "$IS_LXC_CONTAINER" ] && [ -e /proc/drbd ]; then
+if [[ -z "$IS_DOCKERIZED" ]] && [[ -z "$IS_LXC_CONTAINER" ]] && [[ -e /proc/drbd ]]; then
   echo '<<<drbd>>>'
   cat /proc/drbd
 fi
@@ -725,17 +725,17 @@ fi
 # Heartbeat monitoring
 # Different handling for heartbeat clusters with and without CRM
 # for the resource state
-if [ -S /var/run/heartbeat/crm/cib_ro -o -S /var/run/crm/cib_ro ] || pgrep crmd > /dev/null 2>&1; then
+if [[ -S /var/run/heartbeat/crm/cib_ro || -S /var/run/crm/cib_ro ]] || pgrep crmd > /dev/null 2>&1; then
   echo '<<<heartbeat_crm>>>'
   TZ=UTC crm_mon -1 -r | grep -v ^$ | sed 's/^ //; /^\sResource Group:/,$ s/^\s//; s/^\s/_/g'
 fi
-if type cl_status > /dev/null 2>&1; then
+if inpath cl_status > /dev/null 2>&1; then
   echo '<<<heartbeat_rscstatus>>>'
   cl_status rscstatus
 
   echo '<<<heartbeat_nodes>>>'
   for NODE in $(cl_status listnodes); do
-    if [ "$NODE" != "$(echo "$HOSTNAME" | tr '[:upper:]' '[:lower:]')" ]; then
+    if [[ "$NODE" != "$(echo "$HOSTNAME" | tr '[:upper:]' '[:lower:]')" ]]; then
       STATUS=$(cl_status nodestatus "$NODE")
       echo -n "$NODE $STATUS"
       for LINK in $(cl_status listhblinks "$NODE" 2>/dev/null); do
@@ -748,535 +748,498 @@ fi
 
 # Postfix mailqueue monitoring
 # Determine the number of mails and their size in several postfix mail queues
-function read_postfix_queue_dirs {
-    postfix_queue_dir=$1
-    if [ -n "$postfix_queue_dir" ]; then
-        echo '<<<postfix_mailq>>>'
-        if [ ! -z "$2" ]; then
-            echo "[[[${2}]]]"
-        fi
-        for queue in deferred active
-        do
-            count=$(find "${postfix_queue_dir}/$queue" -type f | wc -l)
-            size=$(du -s "${postfix_queue_dir}/$queue" | awk '{print $1 }')
-            if [ -z "$size" ]; then
-                size=0
-            fi
-            if [ -z "$count" ]; then
-                echo "Mail queue is empty"
-            else
-                echo "QUEUE_${queue} $size $count"
-            fi
-        done
+read_postfix_queue_dirs() {
+  local postfix_queue_dir
+  postfix_queue_dir="${1}"
+  if [[ -n "${postfix_queue_dir}" ]]; then
+    echo '<<<postfix_mailq>>>'
+    if [[ -n "${2}" ]]; then
+      echo "[[[${2}]]]"
     fi
+    for queue in deferred active; do
+      count=$(find "${postfix_queue_dir}/$queue" -type f | wc -l)
+      size=$(du -s "${postfix_queue_dir}/$queue" | awk '{print $1 }')
+      if [[ -z "$count" ]]; then
+        echo "Mail queue is empty"
+      else
+        echo "QUEUE_${queue} ${size:-0} ${count}"
+      fi
+    done
+  fi
 }
 
 # Postfix mailqueue monitoring
 # Determine the number of mails and their size in several postfix mail queues
-if type postconf >/dev/null ; then
-    # Check if multi_instance_directories exists in main.cf and is not empty
-    # always takes the last entry, multiple entries possible
-    multi_instances_dirs=$(postconf -c /etc/postfix 2>/dev/null | grep ^multi_instance_directories | sed 's/.*=[[:space:]]*//g')
-    if [ ! -z "$multi_instances_dirs" ]; then
-        for queue_dir in $multi_instances_dirs
-        do
-            if [ -n "$queue_dir" ]; then
-                postfix_queue_dir=$(postconf -c "$queue_dir" 2>/dev/null | grep ^queue_directory | sed 's/.*=[[:space:]]*//g')
-                read_postfix_queue_dirs "$postfix_queue_dir" "$queue_dir"
-            fi
-        done
+if inpath postconf; then
+  # Check if multi_instance_directories exists in main.cf and is not empty
+  # always takes the last entry, multiple entries possible
+  multi_instances_dirs=$(postconf -c /etc/postfix 2>/dev/null | grep ^multi_instance_directories | sed 's/.*=[[:space:]]*//g')
+  if [[ -n "${multi_instances_dirs}" ]]; then
+    for queue_dir in ${multi_instances_dirs}; do
+      if [[ -n "${queue_dir}" ]]; then
+        postfix_queue_dir=$(postconf -c "${queue_dir}" 2>/dev/null | grep ^queue_directory | sed 's/.*=[[:space:]]*//g')
+        read_postfix_queue_dirs "${postfix_queue_dir}" "${queue_dir}"
+      fi
+    done
+  else
+    postfix_queue_dir=$(postconf -h queue_directory 2>/dev/null)
+    read_postfix_queue_dirs "$postfix_queue_dir"
+  fi
 
-    else
-        postfix_queue_dir=$(postconf -h queue_directory 2>/dev/null)
-        read_postfix_queue_dirs "$postfix_queue_dir"
-    fi
-
-elif [ -x /usr/sbin/ssmtp ] ; then
-    echo '<<<postfix_mailq>>>'
-    mailq 2>&1 | sed 's/^[^:]*: \(.*\)/\1/' | tail -n 6
-
+elif [[ -x /usr/sbin/ssmtp ]]; then
+  echo '<<<postfix_mailq>>>'
+  mailq 2>&1 | sed 's/^[^:]*: \(.*\)/\1/' | tail -n 6
 fi
 
 # Postfix status monitoring. Can handle multiple instances.
-if type postfix >/dev/null ; then
-    echo "<<<postfix_mailq_status:sep(58)>>>"
-    for i in /var/spool/postfix*/; do
-        if [ -e "$i/pid/master.pid" ]; then
-            if [ -r "$i/pid/master.pid" ]; then
-                postfix_pid=$(sed 's/ //g' < "$i/pid/master.pid") # handle possible spaces in output
-                if readlink -- "/proc/${postfix_pid}/exe" | grep -q ".*postfix/\(s\?bin/\)\?master.*"; then
-                    echo "$i:the Postfix mail system is running:PID:$postfix_pid" | sed 's/\/var\/spool\///g'
-                else
-                    echo "$i:PID file exists but instance is not running!" | sed 's/\/var\/spool\///g'
-                fi
-            else
-                echo "$i:PID file exists but is not readable"
-            fi
+if inpath postfix; then
+  echo "<<<postfix_mailq_status:sep(58)>>>"
+  for i in /var/spool/postfix*/; do
+    if [[ -e "$i/pid/master.pid" ]]; then
+      if [[ -r "$i/pid/master.pid" ]]; then
+        postfix_pid=$(sed 's/ //g' < "$i/pid/master.pid") # handle possible spaces in output
+        if readlink -- "/proc/${postfix_pid}/exe" | grep -q ".*postfix/\(s\?bin/\)\?master.*"; then
+          echo "$i:the Postfix mail system is running:PID:$postfix_pid" \
+            | sed 's/\/var\/spool\///g'
         else
-            echo "$i:the Postfix mail system is not running" | sed 's/\/var\/spool\///g'
+          echo "$i:PID file exists but instance is not running!" \
+            | sed 's/\/var\/spool\///g'
         fi
-    done
+      else
+        echo "$i:PID file exists but is not readable"
+      fi
+    else
+      echo "$i:the Postfix mail system is not running" \
+        | sed 's/\/var\/spool\///g'
+    fi
+  done
 fi
 
 # Check status of qmail mailqueue
-if type qmail-qstat >/dev/null
-then
-   echo "<<<qmail_stats>>>"
-   qmail-qstat
+if inpath qmail-qstat; then
+  echo "<<<qmail_stats>>>"
+  qmail-qstat
 fi
 
 # Nullmailer queue monitoring
-if type nullmailer-send >/dev/null && [ -d /var/spool/nullmailer/queue ]
-then
-    echo '<<<nullmailer_mailq>>>'
-    COUNT=$(find /var/spool/nullmailer/queue -type f | wc -l)
-    SIZE=$(du -s /var/spool/nullmailer/queue | awk '{print $1 }')
-    echo "$SIZE $COUNT"
+if inpath nullmailer-send && [[ -d /var/spool/nullmailer/queue ]]; then
+  echo '<<<nullmailer_mailq>>>'
+  COUNT=$(find /var/spool/nullmailer/queue -type f | wc -l)
+  SIZE=$(du -s /var/spool/nullmailer/queue | awk '{print $1 }')
+  echo "$SIZE $COUNT"
 fi
 
 # Check status of OMD sites and Check_MK Notification spooler
-if type omd >/dev/null
-then
-    run_cached -s omd_status 60 "omd status --bare --auto || true"
-    echo '<<<mknotifyd:sep(0)>>>'
-    for statefile in /omd/sites/*/var/log/mknotifyd.state ; do
-	if [ -e "$statefile" ] ; then
-	    site=${statefile%/var/log*}
-	    site=${site#/omd/sites/}
-	    echo "[$site]"
-	    grep -v '^#' < "$statefile"
-        fi
-    done
+if inpath omd; then
+  run_cached -s omd_status 60 "omd status --bare --auto || true"
+  echo '<<<mknotifyd:sep(0)>>>'
+  for statefile in /omd/sites/*/var/log/mknotifyd.state ; do
+    if [[ -e "$statefile" ]]; then
+      site=${statefile%/var/log*}
+      site=${site#/omd/sites/}
+      echo "[$site]"
+      grep -v '^#' < "$statefile"
+    fi
+  done
 
-    echo '<<<omd_apache:sep(124)>>>'
-    for statsfile in /omd/sites/*/var/log/apache/stats; do
-	if [ -e "$statsfile" ] ; then
-	    site=${statsfile%/var/log*}
-	    site=${site#/omd/sites/}
-	    echo "[$site]"
-            cat "$statsfile"
-            > "$statsfile"
-            # prevent next section to fail caused by a missing newline at the end of the statsfile
-            echo
-        fi
-    done
+  echo '<<<omd_apache:sep(124)>>>'
+  for statsfile in /omd/sites/*/var/log/apache/stats; do
+    if [[ -e "$statsfile" ]]; then
+      site=${statsfile%/var/log*}
+      site=${site#/omd/sites/}
+      echo "[$site]"
+      cat "$statsfile"
+      : > "$statsfile"
+      # prevent next section to fail caused by a missing newline at the end of the statsfile
+      echo
+    fi
+  done
 fi
-
 
 # Welcome the ZFS check on Linux
 # We do not endorse running ZFS on linux if your vendor doesnt support it ;)
 # check zpool status
-if type zpool >/dev/null; then
-    echo "<<<zpool_status>>>"
-    zpool status -x
-    echo "<<<zpool>>>"
-    zpool list
+if inpath zpool; then
+  echo "<<<zpool_status>>>"
+  zpool status -x
+  echo "<<<zpool>>>"
+  zpool list
 fi
-
 
 # Veritas Cluster Server
 # Software is always installed in /opt/VRTSvcs.
 # Secure mode must be off to allow root to execute commands
-if [ -x /opt/VRTSvcs/bin/haclus ]
-then
-    echo "<<<veritas_vcs>>>"
-    vcshost=$(hostname | cut -d. -f1)
-    waitmax -s 9 2 /opt/VRTSvcs/bin/haclus -display -localclus | grep -e ClusterName -e ClusState
-    waitmax -s 9 2 /opt/VRTSvcs/bin/hasys -display -attribute SysState
-    waitmax -s 9 2 /opt/VRTSvcs/bin/hagrp -display -sys "$vcshost" -attribute State -localclus
-    waitmax -s 9 2 /opt/VRTSvcs/bin/hares -display -sys "$vcshost" -attribute State -localclus
-    waitmax -s 9 2 /opt/VRTSvcs/bin/hagrp -display -attribute TFrozen -attribute Frozen
+if [[ -x /opt/VRTSvcs/bin/haclus ]]; then
+  echo "<<<veritas_vcs>>>"
+  vcshost=$(hostname | cut -d. -f1)
+  waitmax -s 9 2 /opt/VRTSvcs/bin/haclus -display -localclus | grep -e ClusterName -e ClusState
+  waitmax -s 9 2 /opt/VRTSvcs/bin/hasys -display -attribute SysState
+  waitmax -s 9 2 /opt/VRTSvcs/bin/hagrp -display -sys "$vcshost" -attribute State -localclus
+  waitmax -s 9 2 /opt/VRTSvcs/bin/hares -display -sys "$vcshost" -attribute State -localclus
+  waitmax -s 9 2 /opt/VRTSvcs/bin/hagrp -display -attribute TFrozen -attribute Frozen
 fi
-
 
 # Fileinfo-Check: put patterns for files into /etc/check_mk/fileinfo.cfg
-function replace_datevariable()
-{
-    # Replace the date variable of the input, e.g. $DATE:%Y%m%d$, by
-    # the current date. If there's no match just return the input.
-    local file_name="$1"
-    # shellcheck disable=SC2016
-    local pattern='(\$DATE:(.*)\$)'
+replace_datevariable() {
+  # Replace the date variable of the input, e.g. $DATE:%Y%m%d$, by
+  # the current date. If there's no match just return the input.
+  local file_name="$1"
+  # shellcheck disable=SC2016
+  local pattern='(\$DATE:(.*)\$)'
 
-    if [[ ! $file_name =~ $pattern ]]; then
-        echo "$file_name"
-    else
-        date_variable="${BASH_REMATCH[1]}"
-        format_string="${BASH_REMATCH[2]}"
-        echo "${file_name/$date_variable/$(date +"$format_string")}"
-    fi
+  if [[ ! $file_name =~ $pattern ]]; then
+    echo "$file_name"
+  else
+    date_variable="${BASH_REMATCH[1]}"
+    format_string="${BASH_REMATCH[2]}"
+    echo "${file_name/$date_variable/$(date +"$format_string")}"
+  fi
 }
 
-if [ -r "$MK_CONFDIR/fileinfo.cfg" ]; then
-    echo '<<<fileinfo:sep(124)>>>'
+if [[ -r "$MK_CONFDIR/fileinfo.cfg" ]]; then
+  echo '<<<fileinfo:sep(124)>>>'
 
-    old_state=$(set +o)
-    set +f
+  old_state=$(set +o)
+  set +f
 
-    # let the shell do all the expansion, and pipe all files to perl
-    (cat "$MK_CONFDIR/fileinfo.cfg" "$MK_CONFDIR/fileinfo.d/*" 2>/dev/null) | while read -r pattern; do
-        case $pattern in
-            /*) pattern=$(replace_datevariable "$pattern")
-                for f in $pattern; do echo $f; done
-                ;;
-        esac
-    done | perl -e  '
-           print time."\n";
-           print "[[[header]]]\n";
-           print "name|status|size|time\n";
-           print "[[[content]]]\n";
-           while (<>) {
-               chomp $_;
-               if (-d $_) { next; }
-               if (not -f $_) {
-                   print "$_|missing\n";
-                   next;
-               }
-               ($device, $inode, $mode, $nlink, $uid, $gid, $rdev, $size,
-                $atime, $mtime, $ctime, $blksize, $blocks) = stat($_);
-               if ($!) {
-                   print "$_|stat failed\n";
-               } else {
-                   print "$_|ok|$size|$mtime\n";
-               }
-           }'
-    set +vx; eval "$old_state"
+  # let the shell do all the expansion, and pipe all files to perl
+  (cat "$MK_CONFDIR/fileinfo.cfg" "$MK_CONFDIR/fileinfo.d/*" 2>/dev/null) | while read -r pattern; do
+      case $pattern in
+        (/*) pattern=$(replace_datevariable "$pattern")
+          for f in $pattern; do echo "$f"; done
+        ;;
+      esac
+  done | perl -e  '
+          print time."\n";
+          print "[[[header]]]\n";
+          print "name|status|size|time\n";
+          print "[[[content]]]\n";
+          while (<>) {
+              chomp $_;
+              if (-d $_) { next; }
+              if (not -f $_) {
+                  print "$_|missing\n";
+                  next;
+              }
+              ($device, $inode, $mode, $nlink, $uid, $gid, $rdev, $size,
+              $atime, $mtime, $ctime, $blksize, $blocks) = stat($_);
+              if ($!) {
+                  print "$_|stat failed\n";
+              } else {
+                  print "$_|ok|$size|$mtime\n";
+              }
+          }'
+  set +vx; eval "$old_state"
 fi
-
 
 # Get stats about OMD monitoring cores running on this machine.
 # Since cd is a shell builtin the check does not affect the performance
 # on non-OMD machines.
-if cd /omd/sites
-then
-    echo '<<<livestatus_status:sep(59)>>>'
-    for site in *
-    do
-        if [ -S "/omd/sites/$site/tmp/run/live" ] ; then
-            echo "[$site]"
-            echo -e "GET status" | \
-                waitmax 3 "/omd/sites/$site/bin/unixcat" "/omd/sites/$site/tmp/run/live"
-        fi
-    done
+if cd /omd/sites; then
+  echo '<<<livestatus_status:sep(59)>>>'
+  for site in *; do
+    if [[ -S "/omd/sites/$site/tmp/run/live" ]]; then
+      echo "[$site]"
+      echo -e "GET status" \
+        | waitmax 3 "/omd/sites/$site/bin/unixcat" "/omd/sites/$site/tmp/run/live"
+    fi
+  done
 
-    echo '<<<livestatus_ssl_certs:sep(124)>>>'
-    for site in *
-    do
-        echo "[$site]"
-        for PEM_PATH in "/omd/sites/$site/etc/ssl/ca.pem" "/omd/sites/$site/etc/ssl/sites/$site.pem"; do
-            if [ -f "$PEM_PATH" ]; then
-                CERT_DATE=$(openssl x509 -enddate -noout -in "$PEM_PATH")
-                CERT_DATE=${CERT_DATE/notAfter=/}
-                echo "$PEM_PATH|$(date --date="$CERT_DATE" --utc +%s)"
-            fi
-        done
+  echo '<<<livestatus_ssl_certs:sep(124)>>>'
+  for site in *; do
+    echo "[$site]"
+    for PEM_PATH in "/omd/sites/$site/etc/ssl/ca.pem" "/omd/sites/$site/etc/ssl/sites/$site.pem"; do
+      if [[ -f "$PEM_PATH" ]]; then
+        CERT_DATE=$(openssl x509 -enddate -noout -in "$PEM_PATH")
+        CERT_DATE=${CERT_DATE/notAfter=/}
+        echo "$PEM_PATH|$(date --date="$CERT_DATE" --utc +%s)"
+      fi
     done
+  done
 
-    echo '<<<mkeventd_status:sep(0)>>>'
-    for site in *
-    do
-        if [ -S "/omd/sites/$site/tmp/run/mkeventd/status" ] ; then
-            echo "[\"$site\"]"
-            echo -e "GET status\nOutputFormat: json" \
-                | waitmax 3 "/omd/sites/$site/bin/unixcat" "/omd/sites/$site/tmp/run/mkeventd/status"
-        fi
-    done
+  echo '<<<mkeventd_status:sep(0)>>>'
+  for site in *; do
+    if [[ -S "/omd/sites/$site/tmp/run/mkeventd/status" ]]; then
+      echo "[\"$site\"]"
+      echo -e "GET status\nOutputFormat: json" \
+        | waitmax 3 "/omd/sites/$site/bin/unixcat" "/omd/sites/$site/tmp/run/mkeventd/status"
+    fi
+  done
 fi
 
 # Collect states of configured Check_MK site backup jobs
 if ls /omd/sites/*/var/check_mk/backup/*.state >/dev/null 2>&1; then
-    echo "<<<mkbackup>>>"
-    for F in /omd/sites/*/var/check_mk/backup/*.state; do
-        SITE=${F#/*/*/*}
-        SITE=${SITE%%/*}
+  echo "<<<mkbackup>>>"
+  for F in /omd/sites/*/var/check_mk/backup/*.state; do
+    SITE=${F#/*/*/*}
+    SITE=${SITE%%/*}
 
-        JOB_IDENT=${F%.state}
-        JOB_IDENT=${JOB_IDENT##*/}
+    JOB_IDENT=${F%.state}
+    JOB_IDENT=${JOB_IDENT##*/}
 
-        if [ "$JOB_IDENT" != "restore" ]; then
-            echo "[[[site:$SITE:$JOB_IDENT]]]"
-            cat "$F"
-            echo
-        fi
-    done
+    if [[ "$JOB_IDENT" != "restore" ]]; then
+      echo "[[[site:$SITE:$JOB_IDENT]]]"
+      cat "$F"
+      echo
+    fi
+  done
 fi
 
 # Collect states of configured CMA backup jobs
-if type mkbackup >/dev/null && ls /var/lib/mkbackup/*.state >/dev/null 2>&1; then
-    echo "<<<mkbackup>>>"
-    for F in /var/lib/mkbackup/*.state; do
-        JOB_IDENT=${F%.state}
-        JOB_IDENT=${JOB_IDENT##*/}
+if inpath mkbackup && ls /var/lib/mkbackup/*.state >/dev/null 2>&1; then
+  echo "<<<mkbackup>>>"
+  for F in /var/lib/mkbackup/*.state; do
+    JOB_IDENT=${F%.state}
+    JOB_IDENT=${JOB_IDENT##*/}
 
-        if [ "$JOB_IDENT" != "restore" ]; then
-            echo "[[[system:$JOB_IDENT]]]"
-            cat "$F"
-            echo
-        fi
-    done
+    if [[ "$JOB_IDENT" != "restore" ]]; then
+      echo "[[[system:$JOB_IDENT]]]"
+      cat "$F"
+      echo
+    fi
+  done
 fi
 
 # Get statistics about monitored jobs. Below the job directory there
 # is a sub directory per user that ran a job. That directory must be
 # owned by the user so that a symlink or hardlink attack for reading
 # arbitrary files can be avoided.
-if pushd "$MK_VARDIR/job" >/dev/null; then
+(
+  cd "$MK_VARDIR/job" || return
     echo '<<<job>>>'
-    for username in *
-    do
-        if [ -d "$username" ] && cd "$username" ; then
-            if [ $EUID -eq 0 ]; then
-                su -s "$SHELL" "$username" -c "head -n -0 -v *"
-            else
-                head -n -0 -v ./*
-            fi
-            cd ..
+    for username in *; do
+      if [[ -d "$username" ]] && cd "$username" ; then
+        if [[ $EUID -eq 0 ]]; then
+          su -s "$SHELL" "$username" -c "head -n -0 -v *"
+        else
+          head -n -0 -v ./*
         fi
+        cd ..
+      fi
     done
-    popd > /dev/null
-fi
+)
 
 # Gather thermal information provided e.g. by acpi
 # At the moment only supporting thermal sensors
-if [ -z "$IS_DOCKERIZED" ] && [ -z "$IS_LXC_CONTAINER" ] && ls /sys/class/thermal/thermal_zone* >/dev/null 2>&1; then
-    echo '<<<lnx_thermal:sep(124)>>>'
-    for F in /sys/class/thermal/thermal_zone*; do
-        line="${F##*/}"
-        if [ ! -e "$F/mode" ] ; then line="${line}|-" ; else line="${line}|$(cat "$F"/mode)"; fi
-        line="${line}|$(cat "$F"/{type,temp} | tr \\n "|")"
-        for G in $(ls "$F"/trip_point_*_{temp,type}); do
-            line="${line}$(< "$G" tr \\n "|")"
-        done
-        echo "${line%?}"
+if [[ -z "$IS_DOCKERIZED" ]] && [[ -z "$IS_LXC_CONTAINER" ]] && ls /sys/class/thermal/thermal_zone* >/dev/null 2>&1; then
+  echo '<<<lnx_thermal:sep(124)>>>'
+  for F in /sys/class/thermal/thermal_zone*; do
+    line="${F##*/}"
+    if [[ ! -e "$F/mode" ]]; then
+      line="${line}|-"
+    else
+      line="${line}|$(cat "$F"/mode)"
+    fi
+    line="${line}|$(cat "$F"/{type,temp} | tr \\n "|")"
+    for G in "$F"/trip_point_*_{temp,type}; do
+      line="${line}$(< "$G" tr \\n "|")"
     done
+    echo "${line%?}"
+  done
 fi
 
 # Libelle Business Shadow
-if type trd >/dev/null; then
-   echo "<<<libelle_business_shadow:sep(58)>>>"
-   trd -s
+if inpath trd; then
+  echo "<<<libelle_business_shadow:sep(58)>>>"
+  trd -s
 fi
 
 # HTTP Accelerator Statistics
-if type varnishstat >/dev/null; then
-   echo "<<<varnish>>>"
-   varnishstat -1
+if inpath varnishstat; then
+  echo "<<<varnish>>>"
+  varnishstat -1
 fi
 
 # Proxmox Cluster
-if type pvecm > /dev/null 2>&1 ; then
-    echo "<<<pvecm_status:sep(58)>>>"
-    pvecm status
-    echo "<<<pvecm_nodes>>>"
-    pvecm nodes
+if inpath pvecm; then
+  echo "<<<pvecm_status:sep(58)>>>"
+  pvecm status
+  echo "<<<pvecm_nodes>>>"
+  pvecm nodes
 fi
 
 for HAPROXY_SOCK in /run/haproxy/admin.sock /var/lib/haproxy/stats; do
-    if [ -r "$HAPROXY_SOCK" ] && type socat >/dev/null 2>&1; then
-        echo "<<<haproxy:sep(44)>>>"
-        echo "show stat" | socat - "UNIX-CONNECT:$HAPROXY_SOCK"
-    fi
+  if [[ -r "$HAPROXY_SOCK" ]] && type socat >/dev/null 2>&1; then
+    echo "<<<haproxy:sep(44)>>>"
+    echo "show stat" | socat - "UNIX-CONNECT:$HAPROXY_SOCK"
+  fi
 done
 
 # Start new liveupdate process in background on each agent execution. Starting
 # a new live update process will terminate the old one automatically after
 # max. 1 sec.
-if [ -e "$MK_CONFDIR/real_time_checks.cfg" ]; then
-    if [ -z "$REMOTE" ]; then
-        echo "ERROR: \$REMOTE not specified. Not starting Real-Time Checks." >&2
-    elif ! type openssl >/dev/null; then
-        echo "ERROR: openssl command is missing. Not starting Real-Time Checks." >&2
-    else
-        run_real_time_checks >/dev/null &
-    fi
+if [[ -e "$MK_CONFDIR/real_time_checks.cfg" ]]; then
+  if [[ -z "$REMOTE" ]]; then
+    echo "ERROR: \$REMOTE not specified. Not starting Real-Time Checks." >&2
+  elif ! inpath openssl; then
+    echo "ERROR: openssl command is missing. Not starting Real-Time Checks." >&2
+  else
+    run_real_time_checks >/dev/null &
+  fi
 fi
 
 # MK's Remote Plugin Executor
-if [ -e "$MK_CONFDIR/mrpe.cfg" ]
-then
-    grep -Ev '^[[:space:]]*($|#)' "$MK_CONFDIR/mrpe.cfg" | \
-    while read descr cmdline
-    do
-        interval=
-        args="-m"
-        # NOTE: Due to an escaping-related bug in some old bash versions
-        # (3.2.x), we have to use an intermediate variable for the pattern.
-        pattern='\(([^\)]*)\)[[:space:]](.*)'
-        if [[ $cmdline =~ $pattern ]]
-        then
+if [[ -e "$MK_CONFDIR/mrpe.cfg" ]]; then
+  grep -Ev '^[[:space:]]*($|#)' "$MK_CONFDIR/mrpe.cfg" | \
+  while read -r descr cmdline; do
+    interval=
+    args="-m"
+    # NOTE: Due to an escaping-related bug in some old bash versions
+    # (3.2.x), we have to use an intermediate variable for the pattern.
+    pattern='\(([^\)]*)\)[[:space:]](.*)'
+    if [[ $cmdline =~ $pattern ]]; then
+      parameters=${BASH_REMATCH[1]}
+      cmdline=${BASH_REMATCH[2]}
+
+      # split multiple parameter assignments
+      for par in $(echo "$parameters" | tr ":" "\n"); do
+        # split each assignment
+        key=$(echo "$par" | cut -d= -f1)
+        value=$(echo "$par" | cut -d= -f2)
+
+        if [[ "$key" = "interval" ]]; then
+          interval=$value
+        elif [[ "$key" = "appendage" ]]; then
+          args="-ma"
+        fi
+      done
+    fi
+
+    if [[ -z "$interval" ]]; then
+      run_mrpe "$descr" "$cmdline"
+    else
+      run_cached "$args" "$descr" "$interval" "$cmdline"
+    fi
+  done
+fi
+
+# MK's runas Executor
+if [[ -e "$MK_CONFDIR/runas.cfg" ]]; then
+  grep -Ev '^[[:space:]]*($|#)' "$MK_CONFDIR/runas.cfg" | \
+  while read -r type user include; do
+    if [[ -d "$include" || ( "$type" == "mrpe" && -f "$include" ) ]]; then
+      PREFIX=""
+      if [[ "$user" != "-" ]]; then
+        PREFIX="su $user -c "
+      fi
+
+      # mrpe includes
+      if [[ "$type" == "mrpe" ]]; then
+        grep -Ev '^[[:space:]]*($|#)' "$include" | \
+        while read -r descr cmdline; do
+          interval=
+          # NOTE: Due to an escaping-related bug in some old bash
+          # versions (3.2.x), we have to use an intermediate variable
+          # for the pattern.
+          pattern='\(([^\)]*)\)[[:space:]](.*)'
+          if [[ $cmdline =~ $pattern ]]; then
             parameters=${BASH_REMATCH[1]}
             cmdline=${BASH_REMATCH[2]}
 
             # split multiple parameter assignments
-            for par in $(echo "$parameters" | tr ":" "\n")
-            do
-                # split each assignment
-                key=$(echo "$par" | cut -d= -f1)
-                value=$(echo "$par" | cut -d= -f2)
-
-                if [ "$key" = "interval" ] ; then
-                    interval=$value
-                elif [ "$key" = "appendage" ] ; then
-                    args="-ma"
-                fi
+            for par in $(echo "$parameters" | tr ":" "\n"); do
+              # split each assignment
+              IFS='=' read -r key value <<< "${par}"
+              if [[ "$key" = "interval" ]]; then
+                  interval=$value
+              # no other parameters supported currently
+              fi
             done
-        fi
+          fi
 
-        if [ -z "$interval" ]
-        then
+          if [[ -n "$PREFIX" ]]; then
+            cmdline="$PREFIX\'$cmdline\'"
+          fi
+          if [[ -z "$interval" ]]; then
             run_mrpe "$descr" "$cmdline"
-        else
-            run_cached "$args" "$descr" "$interval" "$cmdline"
+          else
+            run_cached -m "$descr" "$interval" "$cmdline"
+          fi
+        done
+
+      # local and plugin includes
+      elif [[ "$type" == "local" || "$type" == "plugin" ]]; then
+        if [[ "$type" == "local" ]]; then
+          echo "<<<local>>>"
         fi
-    done
+
+        find "$include" -executable -type f | \
+        while read -r filename; do
+          if [[ -n "$PREFIX" ]]; then
+            cmdline="$PREFIX\"$filename\""
+          else
+            cmdline=$filename
+          fi
+
+          $cmdline
+        done
+      fi
+    fi
+  done
 fi
-
-# MK's runas Executor
-if [ -e "$MK_CONFDIR/runas.cfg" ]
-then
-    grep -Ev '^[[:space:]]*($|#)' "$MK_CONFDIR/runas.cfg" | \
-    while read type user include
-    do
-        if [ -d "$include" -o \( "$type" == "mrpe" -a -f "$include" \) ] ; then
-            PREFIX=""
-            if [ "$user" != "-" ] ; then
-                PREFIX="su $user -c "
-            fi
-
-            # mrpe includes
-            if [ "$type" == "mrpe" ] ; then
-                grep -Ev '^[[:space:]]*($|#)' "$include" | \
-                while read descr cmdline
-                do
-                    interval=
-                    # NOTE: Due to an escaping-related bug in some old bash
-                    # versions (3.2.x), we have to use an intermediate variable
-                    # for the pattern.
-                    pattern='\(([^\)]*)\)[[:space:]](.*)'
-                    if [[ $cmdline =~ $pattern ]]
-                    then
-                        parameters=${BASH_REMATCH[1]}
-                        cmdline=${BASH_REMATCH[2]}
-
-                        # split multiple parameter assignments
-                        for par in $(echo "$parameters" | tr ":" "\n")
-                        do
-                            # split each assignment
-                            IFS='=' read key value <<< $par
-                            if [ "$key" = "interval" ]
-                            then
-                                interval=$value
-                            # no other parameters supported currently
-                            fi
-                        done
-                    fi
-
-                    if [ -n "$PREFIX" ] ; then
-                        cmdline="$PREFIX\'$cmdline\'"
-                    fi
-                    if [ -z "$interval" ]
-                    then
-                        run_mrpe "$descr" "$cmdline"
-                    else
-                        run_cached -m "$descr" "$interval" "$cmdline"
-                    fi
-                done
-
-            # local and plugin includes
-            elif [ "$type" == "local" -o "$type" == "plugin" ] ; then
-                if [ "$type" == "local" ] ; then
-                    echo "<<<local>>>"
-                fi
-
-                find "$include" -executable -type f | \
-                while read filename
-                do
-                    if [ -n "$PREFIX" ] ; then
-                        cmdline="$PREFIX\"$filename\""
-                    else
-                        cmdline=$filename
-                    fi
-
-                    $cmdline
-                done
-            fi
-        fi
-    done
-fi
-
-function is_valid_plugin () {
-    # NOTE: Due to an escaping-related bug in some old bash versions
-    # (3.2.x), we have to use an intermediate variable for the pattern.
-    pattern='\.dpkg-(new|old|temp)$'
-    #TODO Maybe we should change this mechanism
-    # shellcheck disable=SC2015
-    [[ -f "$1" && -x "$1" && ! "$1" =~ $pattern ]] && true || false
-}
 
 # Local checks
 echo '<<<local>>>'
-if cd "$LOCALDIR" ; then
-    for skript in ./*; do
-        if is_valid_plugin "$skript"; then
-            ./"$skript"
-        fi
-    done
-    # Call some plugins only every X'th second
-    for skript in [1-9]*/* ; do
-        if is_valid_plugin "$skript"; then
-            run_cached "local_${skript//\//\\}" "${skript%/*}" "$skript"
-        fi
-    done
+if cd "$LOCALDIR"; then
+  for skript in ./*; do
+    if is_valid_plugin "$skript"; then
+      ./"$skript"
+    fi
+  done
+  # Call some plugins only every X'th second
+  for skript in [1-9]*/* ; do
+    if is_valid_plugin "$skript"; then
+      run_cached "local_${skript//\//\\}" "${skript%/*}" "$skript"
+    fi
+  done
 fi
 
 # Plugins
 if cd "$PLUGINSDIR"; then
-    for skript in ./*; do
-        if is_valid_plugin "$skript"; then
-            ./"$skript"
-        fi
-    done
-    # Call some plugins only every Xth second
-    for skript in [1-9]*/* ; do
-        if is_valid_plugin "$skript"; then
-            run_cached "plugins_${skript//\//\\}" "${skript%/*}" "$skript"
-        fi
-    done
+  for skript in ./*; do
+    if is_valid_plugin "$skript"; then
+      ./"$skript"
+    fi
+  done
+  # Call some plugins only every Xth second
+  for skript in [1-9]*/* ; do
+    if is_valid_plugin "$skript"; then
+      run_cached "plugins_${skript//\//\\}" "${skript%/*}" "$skript"
+    fi
+  done
 fi
 
 # Agent output snippets created by cronjobs, etc.
-if [ -d "$SPOOLDIR" ]
-then
-    pushd "$SPOOLDIR" > /dev/null
+if [[ -d "$SPOOLDIR" ]]; then
+  (
+    cd "$SPOOLDIR" || return
     now=$(date +%s)
 
-    for file in *
-    do
-        test "$file" = "*" && break
-        # output every file in this directory. If the file is prefixed
-        # with a number, then that number is the maximum age of the
-        # file in seconds. If the file is older than that, it is ignored.
-        maxage=""
-        part="$file"
+    for file in *; do
+      test "$file" = "*" && break
+      # output every file in this directory. If the file is prefixed
+      # with a number, then that number is the maximum age of the
+      # file in seconds. If the file is older than that, it is ignored.
+      maxage=""
+      part="$file"
 
-        # Each away all digits from the front of the filename and
-        # collect them in the variable maxage.
-        while [ "${part/#[0-9]/}" != "$part" ]
-        do
-            maxage=$maxage${part:0:1}
-            part=${part:1}
-        done
+      # Each away all digits from the front of the filename and
+      # collect them in the variable maxage.
+      while [[ "${part/#[0-9]/}" != "$part" ]]; do
+        maxage=$maxage${part:0:1}
+        part=${part:1}
+      done
 
-        # If there is at least one digit, than we honor that.
-        if [ "$maxage" ] ; then
-            mtime=$(stat -c %Y "$file")
-            if [ $((now - mtime)) -gt "$maxage" ] ; then
-                continue
-            fi
+      # If there is at least one digit, than we honor that.
+      if [[ "$maxage" ]]; then
+        mtime=$(stat -c %Y "$file")
+        if [[ $((now - mtime)) -gt "$maxage" ]]; then
+          continue
         fi
+      fi
 
-        # Output the file
-        cat "$file"
+      # Output the file
+      cat "$file"
     done
-    popd > /dev/null
+  )
 fi


### PR DESCRIPTION
The agents are full of mixed coding styles.  In this pull/merge request, I propose working towards loosely abiding by Google's Shell Style Guidelines (which aren't perfect, but a reasonable starting point)

https://google.github.io/styleguide/shell.xml

This merge request takes care of large amounts of the rewrite for the Linux agent only.  In the future, it might be desirable to automate this using something like shfmt.

https://github.com/mvdan/sh#shfmt

I have also made the following changes:

* added a function, inpath(), to clean up the "if type blah >/dev/null 2>&1" idiom.
* Split the 'stat' v.5.3.0 issue out of the nfs/cifs reporting and dealt with it separately.  It is now a conditional over-ride function, otherwise, 'stat' is called as usual
* Put the commands for pulling a list of nfs mounts and cifs mounts into their own functions, not necessarily for re-use, more for cleanliness.  Look at the nfs/cifs section now - much tidier.
* Re-written is_valid_plugin() to not require special handling for bash 3.2
* Cleaned up the handling of LSI Megacli
* Made multiple other corrections to eliminate the majority of issues indicated by Shellcheck

This is not a completed re-write, not all Shellcheck indicated issues are fixed, there is still plenty left for me to do, but I would prefer to continue from here making smaller pull/merge requests rather than substantial changes like this.  This seems to work fine in my testing.