### PR TITLE
check_mk_agent.freebsd: add zfs_arc_cache section

### DIFF
--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -148,6 +148,9 @@ if type zfs > /dev/null 2>&1 ; then
        zfs get -Hp name,quota,used,avail,mountpoint,type
     echo '[df]'
     df -kP -t zfs | sed 1d
+    # arc stats for zfs_arc_cache
+    echo '<<<zfs_arc_cache>>>'
+    sysctl -q kstat.zfs.misc.arcstats |  sed -e 's/kstat.zfs.misc.arcstats.//g' -e 's/: / = /g'
 fi
 
 # Check NFS mounts by accessing them with stat -f (System


### PR DESCRIPTION
This PR adds the zfs_arc_cache section to the check_mk_agent.freebsd with data in the expected format.

Currently this section exists only in the solaris agent. 

Thanks for your work!