### PR TITLE
Move 'then' and 'do' to same line as per style guide

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -37,9 +37,9 @@ export MK_VARDIR=${MK_VARDIR:-/var/lib/check_mk_agent}
 
 # Provide information about the remote host. That helps when data
 # is being sent only once to each remote host.
-if [ "$REMOTE_HOST" ] ; then
+if [ "$REMOTE_HOST" ]; then
     export REMOTE=$REMOTE_HOST
-elif [ "$SSH_CLIENT" ] ; then
+elif [ "$SSH_CLIENT" ]; then
     export REMOTE=${SSH_CLIENT%% *}
 fi
 
@@ -69,8 +69,7 @@ SPOOLDIR=$MK_VARDIR/spool
 # When the nodes agent is executed by a e.g. docker node in a container,
 # then don't close stdin, because the agent is piped through it in this
 # case.
-if [ "$1" = -d ]
-then
+if [ "$1" = -d ]; then
     set -xv
 elif [ -z "$MK_FROM_NODE" ]; then
     exec </dev/null 2>/dev/null
@@ -95,18 +94,18 @@ fi
 # Prefer (relatively) new /usr/bin/timeout from coreutils against
 # our shipped waitmax. waitmax is statically linked and crashes on
 # some Ubuntu versions recently.
-if type timeout >/dev/null 2>&1 ; then
+if type timeout >/dev/null 2>&1; then
     function waitmax () {
         timeout "$@"
     }
     export -f waitmax
 fi
 
-if [ -f "$MK_CONFDIR/encryption.cfg" ] ; then
+if [ -f "$MK_CONFDIR/encryption.cfg" ]; then
     source "$MK_CONFDIR/encryption.cfg"
 fi
 
-if [ "$ENCRYPTED" == "yes" ] ; then
+if [ "$ENCRYPTED" == "yes" ]; then
     echo -n "00" # protocol version
     exec > >(openssl enc -aes-256-cbc -md md5 -k "$PASSPHRASE" -nosalt)
 fi
@@ -206,7 +205,7 @@ function section_df()
 
 function sections_systemd()
 {
-    if type systemctl >/dev/null 2>&1 ; then
+    if type systemctl >/dev/null 2>&1; then
         echo '<<<systemd_units>>>'
         systemctl --all --no-pager
     fi
@@ -243,16 +242,16 @@ function run_cached () {
     local append_age=0
     # TODO: this function is unable to handle mulitple args at once
     #       for example: -s -m won't work, it is read as single token "-s -m"
-    if [ "$1" = -s ] ; then local section="echo '<<<$2:cached($NOW,$3)>>>' ; " ; shift ; fi
-    if [ "$1" = -m ] ; then local mrpe=1 ; shift ; fi
-    if [ "$1" = "-ma" ] ; then local mrpe=1 ; local append_age=1 ; shift ; fi
+    if [ "$1" = -s ]; then local section="echo '<<<$2:cached($NOW,$3)>>>' ; " ; shift ; fi
+    if [ "$1" = -m ]; then local mrpe=1 ; shift ; fi
+    if [ "$1" = "-ma" ]; then local mrpe=1 ; local append_age=1 ; shift ; fi
     local NAME=$1
     local MAXAGE=$2
     shift 2
     local CMDLINE=$section$*
 
     if [ ! -d "$MK_VARDIR/cache" ]; then mkdir -p "$MK_VARDIR/cache" ; fi
-    if [ "$mrpe" = 1 ] ; then
+    if [ "$mrpe" = 1 ]; then
         CACHEFILE="$MK_VARDIR/cache/mrpe_$NAME.cache"
     else
         CACHEFILE="$MK_VARDIR/cache/$NAME.cache"
@@ -262,10 +261,10 @@ function run_cached () {
     # process if the age (access time) of $CACHEFILE.new is twice the MAXAGE.
     # Output the evantually already cached section anyways and start the cache
     # update again.
-    if [ -e "$CACHEFILE.new" ] ; then
+    if [ -e "$CACHEFILE.new" ]; then
         local CF_ATIME
         CF_ATIME=$(stat -c %X "$CACHEFILE.new")
-        if [ $((NOW - CF_ATIME)) -ge $((MAXAGE * 2)) ] ; then
+        if [ $((NOW - CF_ATIME)) -ge $((MAXAGE * 2)) ]; then
             # Kill the process still accessing that file in case
             # it is still running. This avoids overlapping processes!
             fuser -k -9 "$CACHEFILE.new" >/dev/null 2>&1
@@ -275,15 +274,15 @@ function run_cached () {
 
 
     # Check if cache file exists and is recent enough
-    if [ -s "$CACHEFILE" ] ; then
+    if [ -s "$CACHEFILE" ]; then
         local MTIME
         MTIME=$(stat -c %Y "$CACHEFILE")
         local AGE
         AGE=$((NOW - MTIME))
-        if [ "$AGE" -le "$MAXAGE" ] ; then local USE_CACHEFILE=1 ; fi
+        if [ "$AGE" -le "$MAXAGE" ]; then local USE_CACHEFILE=1 ; fi
         # Output the file in any case, even if it is
         # outdated. The new file will not yet be available
-        if [ $append_age -eq 1 ] ; then
+        if [ $append_age -eq 1 ]; then
             # insert the cached-string before the pipe (first -e)
             # or, if no pipe found (-e t) append it (third -e),
             # but only once and on the second line (2!b) (first line is section header,
@@ -302,9 +301,9 @@ function run_cached () {
     fi
 
     # Cache file outdated and new job not yet running? Start it
-    if [ -z "$USE_CACHEFILE" ] && [ ! -e "$CACHEFILE.new" ] ; then
+    if [ -z "$USE_CACHEFILE" ] && [ ! -e "$CACHEFILE.new" ]; then
         # When the command fails, the output is throws away ignored
-        if [ $mrpe -eq 1 ] ; then
+        if [ $mrpe -eq 1 ]; then
             echo "set -o noclobber ; exec > \"$CACHEFILE.new\" || exit 1 ; run_mrpe $NAME \"$CMDLINE\" && mv \"$CACHEFILE.new\" \"$CACHEFILE\" || rm -f \"$CACHEFILE\" \"$CACHEFILE.new\"" | nohup /bin/bash >/dev/null 2>&1 &
         else
             echo "set -o noclobber ; exec > \"$CACHEFILE.new\" || exit 1 ; $CMDLINE && mv \"$CACHEFILE.new\" \"$CACHEFILE\" || rm -f \"$CACHEFILE\" \"$CACHEFILE.new\"" | nohup /bin/bash >/dev/null 2>&1 &
@@ -324,12 +323,12 @@ function run_real_time_checks()
     echo $$ > "$PIDFILE"
 
 
-    if [ "$PASSPHRASE" != "" ] ; then
+    if [ "$PASSPHRASE" != "" ]; then
         # new mechanism to set the passphrase has priority
         RTC_SECRET=$PASSPHRASE
     fi
 
-    if [ "$ENCRYPTED_RT" != "no" ] ; then
+    if [ "$ENCRYPTED_RT" != "no" ]; then
         PROTOCOL=00
     else
         PROTOCOL=99
@@ -349,7 +348,7 @@ function run_real_time_checks()
             # dd is used to concatenate the output of all commands to a single write/block => udp packet
             { echo -n $PROTOCOL ;
               date +%s | tr -d '\n' ;
-              if [ "$ENCRYPTED_RT" != "no" ] ; then
+              if [ "$ENCRYPTED_RT" != "no" ]; then
                   export RTC_SECRET=$RTC_SECRET ; section_"$SECTION" | openssl enc -aes-256-cbc -md md5 -pass env:RTC_SECRET -nosalt ;
               else
                   section_"$SECTION" ;
@@ -359,9 +358,9 @@ function run_real_time_checks()
 
 
         # Plugins
-        if cd "$PLUGINSDIR" ; then
+        if cd "$PLUGINSDIR"; then
             for PLUGIN in $RTC_PLUGINS; do
-                if [ ! -f $PLUGIN ] ; then
+                if [ ! -f $PLUGIN ]; then
                     continue
                 fi
 
@@ -371,7 +370,7 @@ function run_real_time_checks()
                 # dd is used to concatenate the output of all commands to a single write/block => udp packet
                 { echo -n $PROTOCOL ;
                   date +%s | tr -d '\n' ;
-                  if [ "$ENCRYPTED_RT" != "no" ] ; then
+                  if [ "$ENCRYPTED_RT" != "no" ]; then
                       export RTC_SECRET=$RTC_SECRET ; ./$PLUGIN | openssl enc -aes-256-cbc -md md5 -pass env:RTC_SECRET -nosalt ;
                   else
                       ./"$PLUGIN";
@@ -396,8 +395,7 @@ echo "PluginsDirectory: $PLUGINSDIR"
 echo "LocalDirectory: $LOCALDIR"
 
 # If we are called via xinetd, try to find only_from configuration
-if [ -n "$REMOTE_HOST" ]
-then
+if [ -n "$REMOTE_HOST" ]; then
     echo -n 'OnlyFrom: '
     sed -n '/^service[[:space:]]*'$XINETD_SERVICE_NAME'/,/}/s/^[[:space:]]*only_from[[:space:]]*=[[:space:]]*\(.*\)/\1/p' /etc/xinetd.d/* | head -n1; echo
 fi
@@ -407,7 +405,7 @@ section_df
 sections_systemd
 
 # Filesystem usage for ZFS
-if type zfs > /dev/null 2>&1 ; then
+if type zfs > /dev/null 2>&1; then
     echo '<<<zfsget>>>'
     zfs get -t filesystem,volume -Hp name,quota,used,avail,mountpoint,type 2>/dev/null
     echo '[df]'
@@ -417,16 +415,14 @@ fi
 # Check NFS mounts by accessing them with stat -f (System
 # call statfs()). If this lasts more then 2 seconds we
 # consider it as hanging. We need waitmax.
-if type waitmax >/dev/null
-then
+if type waitmax >/dev/null; then
     STAT_VERSION=$(stat --version | head -1 | cut -d" " -f4)
     STAT_BROKE="5.3.0"
 
     echo '<<<nfsmounts>>>'
     sed -n '/ nfs4\? /s/[^ ]* \([^ ]*\) .*/\1/p' < /proc/mounts |
         sed 's/\\040/ /g' |
-        while read MP
-    do
+        while read MP; do
         if [ "$STAT_VERSION" != "$STAT_BROKE" ]; then
             waitmax -s 9 5 stat -f -c "$MP ok %b %f %a %s" "$MP" || \
                 echo "$MP hanging 0 0 0 0"
@@ -439,8 +435,7 @@ then
     echo '<<<cifsmounts>>>'
     sed -n '/ cifs\? /s/[^ ]* \([^ ]*\) .*/\1/p' < /proc/mounts |
         sed 's/\\040/ /g' |
-        while read MP
-    do
+        while read MP; do
         if [ ! -r "$MP" ]; then
             echo "$MP Permission denied"
         elif [ "$STAT_VERSION" != "$STAT_BROKE" ]; then
@@ -460,7 +455,19 @@ grep ^/dev < /proc/mounts | grep -v " squashfs "
 
 # processes including username, without kernel processes
 echo '<<<ps>>>'
-ps ax -o user:32,vsz,rss,cputime,etime,pid,command --columns 10000 | sed -e 1d -e 's/ *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) */(\1,\2,\3,\4\/\5,\6) /'
+if [[ -e /proc/self/ns ]]; then
+  # Only report processes of the current process namespace
+  # in case the system supports namespaces
+  nsPID=$(stat -Lc %i /proc/self/ns/pid)
+  #shellcheck disable=SC2009
+  ps ax -o pidns,user:32,vsz,rss,cputime,etime,pid,command --columns 10000 \
+    | grep "^${nsPID}" \
+    | cut -f "2-" -d " " \
+    | sed -e 1d -e 's/ *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) */(\1,\2,\3,\4\/\5,\6) /'
+else
+  ps ax -o user:32,vsz,rss,cputime,etime,pid,command --columns 10000 \
+    | sed -e 1d -e 's/ *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) */(\1,\2,\3,\4\/\5,\6) /'
+fi
 
 # Memory usage
 section_mem
@@ -472,8 +479,7 @@ section_cpu
 section_uptime
 
 # New variant: Information about speed and state in one section
-if type ip > /dev/null
-then
+if type ip > /dev/null; then
     echo '<<<lnx_if>>>'
     echo "[start_iplink]"
     ip address
@@ -482,8 +488,7 @@ fi
 
 echo '<<<lnx_if:sep(58)>>>'
 sed 1,2d /proc/net/dev
-if type ethtool > /dev/null
-then
+if type ethtool > /dev/null; then
     sed -e 1,2d /proc/net/dev | cut -d':' -f1 | sort | while read eth; do
         echo "[$eth]"
         ethtool "$eth" | grep -E '(Speed|Duplex|Link detected|Auto-negotiation):'
@@ -493,7 +498,7 @@ fi
 
 
 # Current state of bonding interfaces
-if [ -e /proc/net/bonding ] ; then
+if [ -e /proc/net/bonding ]; then
     echo '<<<lnx_bonding:sep(58)>>>'
     pushd /proc/net/bonding > /dev/null
     head -v -n 1000 ./*
@@ -501,7 +506,7 @@ if [ -e /proc/net/bonding ] ; then
 fi
 
 # Same for Open vSwitch bonding
-if type ovs-appctl > /dev/null ; then
+if type ovs-appctl > /dev/null; then
     BONDS=$(ovs-appctl bond/list)
     COL=$(echo "$BONDS" | awk '{for(i=1;i<=NF;i++) {if($i == "bond") printf("%d", i)} exit 0}')
     echo '<<<ovs_bonding:sep(58)>>>'
@@ -513,19 +518,19 @@ fi
 
 
 # Number of TCP connections in the various states
-if type waitmax >/dev/null ; then
+if type waitmax >/dev/null; then
     echo '<<<tcp_conn_stats>>>'
     THIS=$(waitmax 5 cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | awk ' /:/ { c[$4]++; } END { for (x in c) { print x, c[x]; } }')
-    if [ $? == 0 ] ; then
+    if [ $? == 0 ]; then
         echo "$THIS"
-    elif type ss > /dev/null ; then
+    elif type ss > /dev/null; then
         ss -ant |grep -v ^State | awk ' /:/ { c[$1]++; } END { for (x in c) { print x, c[x]; } }' | sed -e 's/^ESTAB/01/g;s/^SYN-SENT/02/g;s/^SYN-RECV/03/g;s/^FIN-WAIT-1/04/g;s/^FIN-WAIT-2/05/g;s/^TIME-WAIT/06/g;s/^CLOSED/07/g;s/^CLOSE-WAIT/08/g;s/^LAST-ACK/09/g;s/^LISTEN/0A/g;s/^CLOSING/0B/g;'
     fi
 fi
 
 # Linux Multipathing
-if type multipath >/dev/null ; then
-    if [ -f /etc/multipath.conf ] ; then
+if type multipath >/dev/null; then
+    if [ -f /etc/multipath.conf ]; then
         echo '<<<multipath>>>'
         multipath -l
     fi
@@ -536,11 +541,11 @@ if [ -z "$IS_DOCKERIZED" ]; then
     echo '<<<diskstat>>>'
     date +%s
     grep -E ' (x?[shv]d[a-z]*[0-9]*|cciss/c[0-9]+d[0-9]+|emcpower[a-z]+|dm-[0-9]+|VxVM.*|mmcblk.*|dasd[a-z]*|bcache[0-9]+|nvme[0-9]+n[0-9]+) ' < /proc/diskstats
-    if type dmsetup >/dev/null ; then
+    if type dmsetup >/dev/null; then
         echo '[dmsetup_info]'
         dmsetup info -c --noheadings --separator ' ' -o name,devno,vg_name,lv_name
     fi
-    if [ -d /dev/vx/dsk ] ; then
+    if [ -d /dev/vx/dsk ]; then
         echo '[vx_dsk]'
         stat -c "%t %T %n" /dev/vx/dsk/*/*
     fi
@@ -568,8 +573,7 @@ if [ -z "$IS_DOCKERIZED" ] && [ -z "$IS_LXC_CONTAINER" ]; then
 fi
 
 # Hardware sensors via IPMI (need ipmitool)
-if type ipmitool > /dev/null
-then
+if type ipmitool > /dev/null; then
     run_cached -s "ipmi:sep(124)" 300 "waitmax 300 ipmitool sensor list | grep -v 'command failed' | egrep -v '^[^ ]+ na ' | grep -v ' discrete '"
     # readable discrete sensor states
     run_cached -s "ipmi_discrete:sep(124)" 300 "waitmax 300 ipmitool sdr elist compact"
@@ -578,8 +582,7 @@ fi
 
 # IPMI data via ipmi-sensors (of freeipmi). Please make sure, that if you
 # have installed freeipmi that IPMI is really support by your hardware.
-if (type ipmi-sensors && ls /dev/ipmi*) &>/dev/null
-then
+if (type ipmi-sensors && ls /dev/ipmi*) &>/dev/null; then
     echo '<<<ipmi_sensors>>>'
     # Newer ipmi-sensors version have new output format; Legacy format can be used
     if ipmi-sensors --help | grep -q legacy-output; then
@@ -594,11 +597,10 @@ then
     fi
 
     # At least with ipmi-sensors 0.7.16 this group is Power_Unit instead of "Power Unit"
-    run_cached -s ipmi_sensors 300 "for class in Temperature Power_Unit Fan
-    do
+    run_cached -s ipmi_sensors 300 "for class in Temperature Power_Unit Fan; do
         ipmi-sensors $IPMI_FORMAT --sdr-cache-directory /var/cache $IPMI_GROUP_OPT \"\$class\" | sed -e 's/ /_/g' -e 's/:_\?/ /g' -e 's@ \([^(]*\)_(\([^)]*\))@ \2_\1@'
         # In case of a timeout immediately leave loop.
-        if [ $? = 255 ] ; then break ; fi
+        if [ $? = 255 ]; then break ; fi
     done"
 fi
 
@@ -607,8 +609,7 @@ echo '<<<md>>>'
 cat /proc/mdstat
 
 # RAID status of Linux RAID via device mapper
-if type dmraid >/dev/null && DMSTATUS=$(waitmax 3 dmraid -r)
-then
+if type dmraid >/dev/null && DMSTATUS=$(waitmax 3 dmraid -r); then
     echo '<<<dmraid>>>'
 
     # Output name and status
@@ -625,22 +626,22 @@ then
 fi
 
 # RAID status of LSI controllers via cfggen
-if type cfggen > /dev/null ; then
+if type cfggen > /dev/null; then
    echo '<<<lsi>>>'
    cfggen 0 DISPLAY | egrep '(Target ID|State|Volume ID|Status of volume)[[:space:]]*:' | sed -e 's/ *//g' -e 's/:/ /'
 fi
 
 # RAID status of LSI MegaRAID controller via MegaCli. You can download that tool from:
 # http://www.lsi.com/downloads/Public/MegaRAID%20Common%20Files/8.02.16_MegaCLI.zip
-if type MegaCli >/dev/null ; then
+if type MegaCli >/dev/null; then
     MegaCli_bin="MegaCli"
-elif type MegaCli64 >/dev/null ; then
+elif type MegaCli64 >/dev/null; then
     MegaCli_bin="MegaCli64"
-elif type megacli >/dev/null ; then
+elif type megacli >/dev/null; then
     MegaCli_bin="megacli"
-elif type storcli >/dev/null ; then
+elif type storcli >/dev/null; then
     MegaCli_bin="storcli"
-elif type storcli64 >/dev/null ; then
+elif type storcli64 >/dev/null; then
     MegaCli_bin="storcli64"
 else
     MegaCli_bin="unknown"
@@ -663,7 +664,7 @@ if [ "$MegaCli_bin" != "unknown" ]; then
 fi
 
 # RAID status of 3WARE disk controller (by Radoslaw Bak)
-if type tw_cli > /dev/null ; then
+if type tw_cli > /dev/null; then
     for C in $(tw_cli show | awk 'NR < 4 { next } { print $1 }'); do
         echo '<<<3ware_info>>>'
         tw_cli "/$C" show all | egrep 'Model =|Firmware|Serial'
@@ -676,7 +677,7 @@ fi
 
 # RAID controllers from areca (Taiwan)
 # cli64 can be found at ftp://ftp.areca.com.tw/RaidCards/AP_Drivers/Linux/CLI/
-if type cli64 >/dev/null ; then
+if type cli64 >/dev/null; then
     run_cached -s arc_raid_status 300 "cli64 rsf info | tail -n +3 | head -n -2"
 fi
 
@@ -691,19 +692,19 @@ fi
 
 # OpenVPN Clients. Currently we assume that the configuration # is in
 # /etc/openvpn. We might find a safer way to find the configuration later.
-if [ -e /etc/openvpn/openvpn-status.log ] ; then
+if [ -e /etc/openvpn/openvpn-status.log ]; then
     echo '<<<openvpn_clients:sep(44)>>>'
     sed -n -e '/CLIENT LIST/,/ROUTING TABLE/p' < /etc/openvpn/openvpn-status.log  | sed -e 1,3d -e '$d'
 fi
 
 # Time synchronization with NTP
-if type ntpq > /dev/null 2>&1 ; then
+if type ntpq > /dev/null 2>&1; then
    # remove heading, make first column space separated
    run_cached -s ntp 30 "waitmax 5 ntpq -np | sed -e 1,2d -e 's/^\(.\)/\1 /' -e 's/^ /%/' || true"
 fi
 
 # Time synchronization with Chrony
-if type chronyc > /dev/null 2>&1 ; then
+if type chronyc > /dev/null 2>&1; then
     # Force successful exit code. Otherwise section will be missing if daemon not running
     #
     # The "| cat" has been added for some kind of regression in RedHat 7.5. The
@@ -712,11 +713,9 @@ if type chronyc > /dev/null 2>&1 ; then
     run_cached -s chrony 30 "waitmax 5 chronyc -n tracking | cat || true"
 fi
 
-if type nvidia-settings >/dev/null && [ -S /tmp/.X11-unix/X0 ]
-then
+if type nvidia-settings >/dev/null && [ -S /tmp/.X11-unix/X0 ]; then
     echo '<<<nvidia>>>'
-    for var in GPUErrors GPUCoreTemp
-    do
+    for var in GPUErrors GPUCoreTemp; do
         DISPLAY=:0 waitmax 2 nvidia-settings -t -q $var | sed "s/^/$var: /"
     done
 fi
@@ -759,8 +758,7 @@ function read_postfix_queue_dirs {
         if [ ! -z "$2" ]; then
             echo "[[[${2}]]]"
         fi
-        for queue in deferred active
-        do
+        for queue in deferred active; do
             count=$(find "${postfix_queue_dir}/$queue" -type f | wc -l)
             size=$(du -s "${postfix_queue_dir}/$queue" | awk '{print $1 }')
             if [ -z "$size" ]; then
@@ -777,13 +775,12 @@ function read_postfix_queue_dirs {
 
 # Postfix mailqueue monitoring
 # Determine the number of mails and their size in several postfix mail queues
-if type postconf >/dev/null ; then
+if type postconf >/dev/null; then
     # Check if multi_instance_directories exists in main.cf and is not empty
     # always takes the last entry, multiple entries possible
     multi_instances_dirs=$(postconf -c /etc/postfix 2>/dev/null | grep ^multi_instance_directories | sed 's/.*=[[:space:]]*//g')
     if [ ! -z "$multi_instances_dirs" ]; then
-        for queue_dir in $multi_instances_dirs
-        do
+        for queue_dir in $multi_instances_dirs; do
             if [ -n "$queue_dir" ]; then
                 postfix_queue_dir=$(postconf -c "$queue_dir" 2>/dev/null | grep ^queue_directory | sed 's/.*=[[:space:]]*//g')
                 read_postfix_queue_dirs "$postfix_queue_dir" "$queue_dir"
@@ -795,14 +792,14 @@ if type postconf >/dev/null ; then
         read_postfix_queue_dirs "$postfix_queue_dir"
     fi
 
-elif [ -x /usr/sbin/ssmtp ] ; then
+elif [ -x /usr/sbin/ssmtp ]; then
     echo '<<<postfix_mailq>>>'
     mailq 2>&1 | sed 's/^[^:]*: \(.*\)/\1/' | tail -n 6
 
 fi
 
 # Postfix status monitoring. Can handle multiple instances.
-if type postfix >/dev/null ; then
+if type postfix >/dev/null; then
     echo "<<<postfix_mailq_status:sep(58)>>>"
     for i in /var/spool/postfix*/; do
         if [ -e "$i/pid/master.pid" ]; then
@@ -823,15 +820,13 @@ if type postfix >/dev/null ; then
 fi
 
 # Check status of qmail mailqueue
-if type qmail-qstat >/dev/null
-then
+if type qmail-qstat >/dev/null; then
    echo "<<<qmail_stats>>>"
    qmail-qstat
 fi
 
 # Nullmailer queue monitoring
-if type nullmailer-send >/dev/null && [ -d /var/spool/nullmailer/queue ]
-then
+if type nullmailer-send >/dev/null && [ -d /var/spool/nullmailer/queue ]; then
     echo '<<<nullmailer_mailq>>>'
     COUNT=$(find /var/spool/nullmailer/queue -type f | wc -l)
     SIZE=$(du -s /var/spool/nullmailer/queue | awk '{print $1 }')
@@ -839,12 +834,11 @@ then
 fi
 
 # Check status of OMD sites and Check_MK Notification spooler
-if type omd >/dev/null
-then
+if type omd >/dev/null; then
     run_cached -s omd_status 60 "omd status --bare --auto || true"
     echo '<<<mknotifyd:sep(0)>>>'
     for statefile in /omd/sites/*/var/log/mknotifyd.state ; do
-	if [ -e "$statefile" ] ; then
+	if [ -e "$statefile" ]; then
 	    site=${statefile%/var/log*}
 	    site=${site#/omd/sites/}
 	    echo "[$site]"
@@ -854,7 +848,7 @@ then
 
     echo '<<<omd_apache:sep(124)>>>'
     for statsfile in /omd/sites/*/var/log/apache/stats; do
-	if [ -e "$statsfile" ] ; then
+	if [ -e "$statsfile" ]; then
 	    site=${statsfile%/var/log*}
 	    site=${site#/omd/sites/}
 	    echo "[$site]"
@@ -881,8 +875,7 @@ fi
 # Veritas Cluster Server
 # Software is always installed in /opt/VRTSvcs.
 # Secure mode must be off to allow root to execute commands
-if [ -x /opt/VRTSvcs/bin/haclus ]
-then
+if [ -x /opt/VRTSvcs/bin/haclus ]; then
     echo "<<<veritas_vcs>>>"
     vcshost=$(hostname | cut -d. -f1)
     waitmax -s 9 2 /opt/VRTSvcs/bin/haclus -display -localclus | grep -e ClusterName -e ClusState
@@ -951,12 +944,10 @@ fi
 # Get stats about OMD monitoring cores running on this machine.
 # Since cd is a shell builtin the check does not affect the performance
 # on non-OMD machines.
-if cd /omd/sites
-then
+if cd /omd/sites; then
     echo '<<<livestatus_status:sep(59)>>>'
-    for site in *
-    do
-        if [ -S "/omd/sites/$site/tmp/run/live" ] ; then
+    for site in *; do
+        if [ -S "/omd/sites/$site/tmp/run/live" ]; then
             echo "[$site]"
             echo -e "GET status" | \
                 waitmax 3 "/omd/sites/$site/bin/unixcat" "/omd/sites/$site/tmp/run/live"
@@ -964,8 +955,7 @@ then
     done
 
     echo '<<<livestatus_ssl_certs:sep(124)>>>'
-    for site in *
-    do
+    for site in *; do
         echo "[$site]"
         for PEM_PATH in "/omd/sites/$site/etc/ssl/ca.pem" "/omd/sites/$site/etc/ssl/sites/$site.pem"; do
             if [ -f "$PEM_PATH" ]; then
@@ -977,9 +967,8 @@ then
     done
 
     echo '<<<mkeventd_status:sep(0)>>>'
-    for site in *
-    do
-        if [ -S "/omd/sites/$site/tmp/run/mkeventd/status" ] ; then
+    for site in *; do
+        if [ -S "/omd/sites/$site/tmp/run/mkeventd/status" ]; then
             echo "[\"$site\"]"
             echo -e "GET status\nOutputFormat: json" \
                 | waitmax 3 "/omd/sites/$site/bin/unixcat" "/omd/sites/$site/tmp/run/mkeventd/status"
@@ -1026,9 +1015,8 @@ fi
 # arbitrary files can be avoided.
 if pushd "$MK_VARDIR/job" >/dev/null; then
     echo '<<<job>>>'
-    for username in *
-    do
-        if [ -d "$username" ] && cd "$username" ; then
+    for username in *; do
+        if [ -d "$username" ] && cd "$username"; then
             if [ $EUID -eq 0 ]; then
                 su -s "$SHELL" "$username" -c "head -n -0 -v *"
             else
@@ -1046,7 +1034,7 @@ if [ -z "$IS_DOCKERIZED" ] && [ -z "$IS_LXC_CONTAINER" ] && ls /sys/class/therma
     echo '<<<lnx_thermal:sep(124)>>>'
     for F in /sys/class/thermal/thermal_zone*; do
         line="${F##*/}"
-        if [ ! -e "$F/mode" ] ; then line="${line}|-" ; else line="${line}|$(cat "$F"/mode)"; fi
+        if [ ! -e "$F/mode" ]; then line="${line}|-" ; else line="${line}|$(cat "$F"/mode)"; fi
         line="${line}|$(cat "$F"/{type,temp} | tr \\n "|")"
         for G in $(ls "$F"/trip_point_*_{temp,type}); do
             line="${line}$(< "$G" tr \\n "|")"
@@ -1068,7 +1056,7 @@ if type varnishstat >/dev/null; then
 fi
 
 # Proxmox Cluster
-if type pvecm > /dev/null 2>&1 ; then
+if type pvecm > /dev/null 2>&1; then
     echo "<<<pvecm_status:sep(58)>>>"
     pvecm status
     echo "<<<pvecm_nodes>>>"
@@ -1096,38 +1084,33 @@ if [ -e "$MK_CONFDIR/real_time_checks.cfg" ]; then
 fi
 
 # MK's Remote Plugin Executor
-if [ -e "$MK_CONFDIR/mrpe.cfg" ]
-then
+if [ -e "$MK_CONFDIR/mrpe.cfg" ]; then
     grep -Ev '^[[:space:]]*($|#)' "$MK_CONFDIR/mrpe.cfg" | \
-    while read descr cmdline
-    do
+    while read descr cmdline; do
         interval=
         args="-m"
         # NOTE: Due to an escaping-related bug in some old bash versions
         # (3.2.x), we have to use an intermediate variable for the pattern.
         pattern='\(([^\)]*)\)[[:space:]](.*)'
-        if [[ $cmdline =~ $pattern ]]
-        then
+        if [[ $cmdline =~ $pattern ]]; then
             parameters=${BASH_REMATCH[1]}
             cmdline=${BASH_REMATCH[2]}
 
             # split multiple parameter assignments
-            for par in $(echo "$parameters" | tr ":" "\n")
-            do
+            for par in $(echo "$parameters" | tr ":" "\n"); do
                 # split each assignment
                 key=$(echo "$par" | cut -d= -f1)
                 value=$(echo "$par" | cut -d= -f2)
 
-                if [ "$key" = "interval" ] ; then
+                if [ "$key" = "interval" ]; then
                     interval=$value
-                elif [ "$key" = "appendage" ] ; then
+                elif [ "$key" = "appendage" ]; then
                     args="-ma"
                 fi
             done
         fi
 
-        if [ -z "$interval" ]
-        then
+        if [ -z "$interval" ]; then
             run_mrpe "$descr" "$cmdline"
         else
             run_cached "$args" "$descr" "$interval" "$cmdline"
@@ -1136,50 +1119,43 @@ then
 fi
 
 # MK's runas Executor
-if [ -e "$MK_CONFDIR/runas.cfg" ]
-then
+if [ -e "$MK_CONFDIR/runas.cfg" ]; then
     grep -Ev '^[[:space:]]*($|#)' "$MK_CONFDIR/runas.cfg" | \
-    while read type user include
-    do
-        if [ -d "$include" -o \( "$type" == "mrpe" -a -f "$include" \) ] ; then
+    while read type user include; do
+        if [ -d "$include" -o \( "$type" == "mrpe" -a -f "$include" \) ]; then
             PREFIX=""
-            if [ "$user" != "-" ] ; then
+            if [ "$user" != "-" ]; then
                 PREFIX="su $user -c "
             fi
 
             # mrpe includes
-            if [ "$type" == "mrpe" ] ; then
+            if [ "$type" == "mrpe" ]; then
                 grep -Ev '^[[:space:]]*($|#)' "$include" | \
-                while read descr cmdline
-                do
+                while read descr cmdline; do
                     interval=
                     # NOTE: Due to an escaping-related bug in some old bash
                     # versions (3.2.x), we have to use an intermediate variable
                     # for the pattern.
                     pattern='\(([^\)]*)\)[[:space:]](.*)'
-                    if [[ $cmdline =~ $pattern ]]
-                    then
+                    if [[ $cmdline =~ $pattern ]]; then
                         parameters=${BASH_REMATCH[1]}
                         cmdline=${BASH_REMATCH[2]}
 
                         # split multiple parameter assignments
-                        for par in $(echo "$parameters" | tr ":" "\n")
-                        do
+                        for par in $(echo "$parameters" | tr ":" "\n"); do
                             # split each assignment
                             IFS='=' read key value <<< $par
-                            if [ "$key" = "interval" ]
-                            then
+                            if [ "$key" = "interval" ]; then
                                 interval=$value
                             # no other parameters supported currently
                             fi
                         done
                     fi
 
-                    if [ -n "$PREFIX" ] ; then
+                    if [ -n "$PREFIX" ]; then
                         cmdline="$PREFIX\'$cmdline\'"
                     fi
-                    if [ -z "$interval" ]
-                    then
+                    if [ -z "$interval" ]; then
                         run_mrpe "$descr" "$cmdline"
                     else
                         run_cached -m "$descr" "$interval" "$cmdline"
@@ -1187,15 +1163,14 @@ then
                 done
 
             # local and plugin includes
-            elif [ "$type" == "local" -o "$type" == "plugin" ] ; then
-                if [ "$type" == "local" ] ; then
+            elif [ "$type" == "local" -o "$type" == "plugin" ]; then
+                if [ "$type" == "local" ]; then
                     echo "<<<local>>>"
                 fi
 
                 find "$include" -executable -type f | \
-                while read filename
-                do
-                    if [ -n "$PREFIX" ] ; then
+                while read filename; do
+                    if [ -n "$PREFIX" ]; then
                         cmdline="$PREFIX\"$filename\""
                     else
                         cmdline=$filename
@@ -1219,7 +1194,7 @@ function is_valid_plugin () {
 
 # Local checks
 echo '<<<local>>>'
-if cd "$LOCALDIR" ; then
+if cd "$LOCALDIR"; then
     for skript in ./*; do
         if is_valid_plugin "$skript"; then
             ./"$skript"
@@ -1249,13 +1224,11 @@ if cd "$PLUGINSDIR"; then
 fi
 
 # Agent output snippets created by cronjobs, etc.
-if [ -d "$SPOOLDIR" ]
-then
+if [ -d "$SPOOLDIR" ]; then
     pushd "$SPOOLDIR" > /dev/null
     now=$(date +%s)
 
-    for file in *
-    do
+    for file in *; do
         test "$file" = "*" && break
         # output every file in this directory. If the file is prefixed
         # with a number, then that number is the maximum age of the
@@ -1265,16 +1238,15 @@ then
 
         # Each away all digits from the front of the filename and
         # collect them in the variable maxage.
-        while [ "${part/#[0-9]/}" != "$part" ]
-        do
+        while [ "${part/#[0-9]/}" != "$part" ]; do
             maxage=$maxage${part:0:1}
             part=${part:1}
         done
 
         # If there is at least one digit, than we honor that.
-        if [ "$maxage" ] ; then
+        if [ "$maxage" ]; then
             mtime=$(stat -c %Y "$file")
-            if [ $((now - mtime)) -gt "$maxage" ] ; then
+            if [ $((now - mtime)) -gt "$maxage" ]; then
                 continue
             fi
         fi

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -455,19 +455,7 @@ grep ^/dev < /proc/mounts | grep -v " squashfs "
 
 # processes including username, without kernel processes
 echo '<<<ps>>>'
-if [[ -e /proc/self/ns ]]; then
-  # Only report processes of the current process namespace
-  # in case the system supports namespaces
-  nsPID=$(stat -Lc %i /proc/self/ns/pid)
-  #shellcheck disable=SC2009
-  ps ax -o pidns,user:32,vsz,rss,cputime,etime,pid,command --columns 10000 \
-    | grep "^${nsPID}" \
-    | cut -f "2-" -d " " \
-    | sed -e 1d -e 's/ *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) */(\1,\2,\3,\4\/\5,\6) /'
-else
-  ps ax -o user:32,vsz,rss,cputime,etime,pid,command --columns 10000 \
-    | sed -e 1d -e 's/ *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) */(\1,\2,\3,\4\/\5,\6) /'
-fi
+ps ax -o user:32,vsz,rss,cputime,etime,pid,command --columns 10000 | sed -e 1d -e 's/ *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) *\([^ ]*\) */(\1,\2,\3,\4\/\5,\6) /'
 
 # Memory usage
 section_mem


### PR DESCRIPTION
Hi,
first simplified pull request.  This one simply moves 'then' and 'do' to be the same line as the loop declaration, as per the Google Style Guide:

https://google.github.io/styleguide/shell.xml#Loops

Note: I have only applied this change to the Linux agent.  Others are free to apply the same change to the other agents.  You're looking for things like:

\n^then$
\n^do$
\n\s+then$
\n\s+do$

Rawiri