### PR TITLE
Add the subnet mask to the win_ip_r inventory

### DIFF
--- a/inventory/win_ip_r
+++ b/inventory/win_ip_r
@@ -53,9 +53,13 @@
 
 def inv_win_ip_r(info):
     routes = inv_tree_list("networking.routes:")
-    for _type, target, _mask, gateway, device in info:
+    for _type, target, mask, gateway, device in info:
         routes.append({
-            "target": target,
+            "target"  : "{target}/{subnet}".format(
+                target=target,
+                # Convert subnetmask to CIDR
+                subnet=sum([bin(int(x)).count("1") for x in mask.split(".")])
+            ),
             "device": device,
             "gateway": gateway,
             "type": _type,


### PR DESCRIPTION
Keep consistency with the lnx_ip_r inventory file by adding the subnet mask to the route, which is kinda useful information