### PR TITLE
Check ceph_df: wrong maximum pool size

### DIFF
--- a/checks/ceph_df
+++ b/checks/ceph_df
@@ -117,8 +117,11 @@ def parse_ceph_df(info):
             size_mb = parse_byte_values(data["SIZE"])
             avail_mb = parse_byte_values(data["AVAIL"])
         else:
-            size_mb = parse_byte_values(data["MAX AVAIL"])
-            avail_mb = size_mb - parse_byte_values(data["USED"])
+            avail_mb = parse_byte_values(data["MAX AVAIL"])
+            size_mb = avail_mb + parse_byte_values(data["USED"])
+
+            #size_mb = parse_byte_values(data["MAX AVAIL"])
+            #avail_mb = size_mb - parse_byte_values(data["USED"])
         mps.append((mp, size_mb, avail_mb, 0))
     return mps
 


### PR DESCRIPTION
the parameter "max avail" of "ceph df" shows, how much space currently is available.
so, it is possible, that you get a message like "CRIT - 92% used ..." when you have 52% space left