### PR TITLE
Checks: Firewall Interface: Avoid exception if interface doesn't exists anymore

### DIFF
--- a/checks/firewall_if.include
+++ b/checks/firewall_if.include
@@ -33,6 +33,10 @@ def check_firewall_if(item, params, parsed):
 
     this_time = time.time()
 
+    if not item in parsed:
+        yield 3, "interface %s not found" % item
+        return
+
     for what in parsed[item]:
 
         counter = parsed[item][what]


### PR DESCRIPTION
Currently checkmk throws a KeyError if a pfsense interface doesn't exists anymore.
This fix changes the behavior to return "Unknown - interface .. not found" instead of check error.