### PR TITLE
local printers should be checked against localhost

### DIFF
--- a/agents/plugins/mk_cups_queues
+++ b/agents/plugins/mk_cups_queues
@@ -29,7 +29,7 @@ if type lpstat > /dev/null 2>&1 ; then
     CPRINTCONF=/etc/cups/printers.conf
     if  [ -r "$CPRINTCONF" ] ; then
         LOCAL_PRINTERS=$(grep -E "<(Default)?Printer .*>" $CPRINTCONF | awk '{print $2}' | sed -e 's/>//')
-        lpstat -p | while read LINE
+        lpstat -h localhost -p | while read LINE
         do
             PRINTER=$(echo "$LINE" | awk '{print $2}')
             if echo "$LOCAL_PRINTERS" | grep -q "$PRINTER"; then
@@ -37,7 +37,7 @@ if type lpstat > /dev/null 2>&1 ; then
             fi
         done
         echo '---'
-        lpstat -o | while read LINE
+        lpstat -h localhost -o | while read LINE
         do
             PRINTER=${LINE%%-*}
             if echo "$LOCAL_PRINTERS" | grep -q "$PRINTER"; then


### PR DESCRIPTION
After testing for a local printers.conf lpstat should talk to localhost and not the ServerName from client.conf that may be also configured.