### PR TITLE
Added hook function to docker-entrypoint.sh

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
 set -e -o pipefail
 
+HOOKROOT=/docker-entrypoint.d
+
+function exec_hook() {
+    HOOKDIR=$HOOKROOT/$1
+    if pushd $HOOKDIR 2>&1>/dev/null; then 
+        for hook in ./*; do
+            echo "### Running $HOOKDIR/$hook"
+           ./$hook
+        done
+    fi
+    popd 2>&1>/dev/null
+}
+
+
+
+exec_hook pre-create
+
 if [ -z "$CMK_SITE_ID" ]; then
     echo "ERROR: No site ID given"
     exit 1
@@ -43,6 +60,8 @@ if [ ! -d "/opt/omd/sites/$CMK_SITE_ID/etc" ] ; then
     fi
 fi
 
+exec_hook post-create
+
 # In case of an update (see update procedure docs) the container is started
 # with the data volume mounted (the site is not re-created). In this
 # situation only the site data directory is available and the "system level"
@@ -72,8 +91,12 @@ if [ -n "$1" ]; then
     exec "$@"
 fi
 
+exec_hook pre-start
+
 echo "### STARTING SITE"
 omd start "$CMK_SITE_ID"
+
+exec_hook post-start
 
 echo "### STARTING CRON"
 cron -f &


### PR DESCRIPTION
This hook allows to execute custom hook scripts during the container startup at

- pre-create
- post-create
- pre-start
- post-start

At these steps, all scripts within `docker-entrypoint.d/hook-name` are executed. 

```
root@7ac2dc47037e:/# tree docker-entrypoint.d/
docker-entrypoint.d/
|-- post-create
|   |-- 01_foo.sh
|   |-- 02_bar.sh
|   `-- 03_baz.sh
|-- post-start
|   |-- 01_foo.sh
|   |-- 02_bar.sh
|   `-- 03_baz.sh
|-- pre-create
|   |-- 01_foo.sh
|   |-- 02_bar.sh
|   `-- 03_baz.sh
`-- pre-start
    |-- 01_foo.sh
    |-- 02_bar.sh
    `-- 03_baz.sh
```
