### PR TITLE
correct wording on eternus storage - Channel Module is normally called Controller Module

### DIFF
--- a/checkman/fjdarye100_cmods
+++ b/checkman/fjdarye100_cmods
@@ -10,7 +10,7 @@ description:
  This is an adaption of the corresponding fjdarye60 check.
 
 item:
- The index of the channel module in the SNMP table. It is of type
+ The index of the controller module in the SNMP table. It is of type
  integer. The first module has an index of {0}.
 
 inventory:

--- a/checkman/fjdarye100_cmods_mem
+++ b/checkman/fjdarye100_cmods_mem
@@ -10,7 +10,7 @@ description:
  This is an adaption of the corresponding fjdarye60 check.
 
 item:
- The index of the channel module memory in the SNMP table. It is of type
+ The index of the controller module memory in the SNMP table. It is of type
  integer. The first module has an index of {0}.
 
 inventory:

--- a/checkman/fjdarye101_cmods
+++ b/checkman/fjdarye101_cmods
@@ -10,7 +10,7 @@ description:
  This is an adaption of the corresponding fjdarye60 check.
 
 item:
- The index of the channel module in the SNMP table. It is of type
+ The index of the controller module in the SNMP table. It is of type
  integer. The first module has an index of {0}.
 
 inventory:

--- a/checkman/fjdarye101_cmods_mem
+++ b/checkman/fjdarye101_cmods_mem
@@ -10,7 +10,7 @@ description:
  This is an adaption of the corresponding fjdarye60 check.
 
 item:
- The index of the channel module memory in the SNMP table. It is of type
+ The index of the controller module memory in the SNMP table. It is of type
  integer. The first module has an index of {0}.
 
 inventory:

--- a/checkman/fjdarye500_cmods
+++ b/checkman/fjdarye500_cmods
@@ -10,7 +10,7 @@ description:
  This is an adaption of the corresponding fjdarye500 check.
 
 item:
- The index of the channel module in the SNMP table. It is of type
+ The index of the controller module in the SNMP table. It is of type
  integer. The first module has an index of {0}.
 
 inventory:

--- a/checkman/fjdarye500_cmods_flash
+++ b/checkman/fjdarye500_cmods_flash
@@ -1,4 +1,4 @@
-title: Fujitsu ETERNUS DX500 S3 storage systems: Flash of channel modules
+title: Fujitsu ETERNUS DX500 S3 storage systems: Flash of controller modules
 agents: snmp
 catalog: hw/storagehw/fujitsu
 license: GPL
@@ -9,7 +9,7 @@ description:
  FJDARY-E150-SNMPV2.MIB like the ETERNUS DX500 S3.
 
 item:
- The index of the channel module flash in the SNMP table. It is of type
+ The index of the controller module flash in the SNMP table. It is of type
  integer. The first module has an index of {0}.
 
 inventory:

--- a/checkman/fjdarye500_cmods_mem
+++ b/checkman/fjdarye500_cmods_mem
@@ -10,7 +10,7 @@ description:
  This is an adaption of the corresponding fjdarye60 check.
 
 item:
- The index of the channel module memory in the SNMP table. It is of type
+ The index of the controller module memory in the SNMP table. It is of type
  integer. The first module has an index of {0}.
 
 inventory:

--- a/checkman/fjdarye60_cmods
+++ b/checkman/fjdarye60_cmods
@@ -9,7 +9,7 @@ description:
  FJDARY-E60.MIB like the ETERNUS DX60 and DX80.
 
 item:
- The index of the channel module in the SNMP table. It is of type
+ The index of the controller module in the SNMP table. It is of type
  integer. The first module has an index of {0}.
 
 inventory:

--- a/checkman/fjdarye60_cmods_flash
+++ b/checkman/fjdarye60_cmods_flash
@@ -1,4 +1,4 @@
-title: Fujitsu ETERNUS DX storage systems: Flash of channel modules
+title: Fujitsu ETERNUS DX storage systems: Flash of controller modules
 agents: snmp
 catalog: hw/storagehw/fujitsu
 license: GPL
@@ -9,7 +9,7 @@ description:
  FJDARY-E60.MIB like the ETERNUS DX60 and DX80.
 
 item:
- The index of the channel module flash in the SNMP table. It is of type
+ The index of the controller module flash in the SNMP table. It is of type
  integer. The first module has an index of {0}.
 
 inventory:

--- a/checkman/fjdarye60_cmods_mem
+++ b/checkman/fjdarye60_cmods_mem
@@ -9,7 +9,7 @@ description:
  FJDARY-E60.MIB like the ETERNUS DX60 and DX80.
 
 item:
- The index of the channel module memory in the SNMP table. It is of type
+ The index of the controller module memory in the SNMP table. It is of type
  integer. The first module has an index of {0}.
 
 inventory:

--- a/checks/fjdarye100_cmods
+++ b/checks/fjdarye100_cmods
@@ -42,7 +42,7 @@ check_includes['fjdarye100_cmods'] = ["fjdarye.include"]
 check_info["fjdarye100_cmods"] = {
     'check_function': check_fjdarye_item,
     'inventory_function': inventory_fjdarye_item,
-    'service_description': 'Channel Module %s',
+    'service_description': 'Controller Module %s',
     # 1: fjdaryCmIndex, 3: fjdaryCmStatus
     'snmp_info': ('.1.3.6.1.4.1.211.1.21.1.100.2.1.2.1', [1, 3]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.2.1.1.2.0") == ".1.3.6.1.4.1.211.1.21.1.100",

--- a/checks/fjdarye100_cmods_mem
+++ b/checks/fjdarye100_cmods_mem
@@ -44,7 +44,7 @@ check_includes['fjdarye100_cmods_mem'] = ["fjdarye.include"]
 check_info["fjdarye100_cmods_mem"] = {
     'check_function': check_fjdarye_item,
     'inventory_function': inventory_fjdarye_item,
-    'service_description': 'Channel Module Memory %s',
+    'service_description': 'Controller Module Memory %s',
     # 1: fjdaryCmmemoryIndex, 3: fjdaryCmmemoryStatus
     'snmp_info': ('.1.3.6.1.4.1.211.1.21.1.100.2.4.2.1', [1, 3]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.2.1.1.2.0") == ".1.3.6.1.4.1.211.1.21.1.100",

--- a/checks/fjdarye101_cmods
+++ b/checks/fjdarye101_cmods
@@ -28,7 +28,7 @@ check_info["fjdarye101_cmods"] = {
     'check_function': check_fjdarye_item,
     'inventory_function': inventory_fjdarye_item,
     'includes': ["fjdarye.include"],
-    'service_description': 'Channel Module %s',
+    'service_description': 'Controller Module %s',
     # 1: fjdaryCmIndex, 3: fjdaryCmStatus
     'snmp_info': ('.1.3.6.1.4.1.211.1.21.1.101.2.1.2.1', [1, 3]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.2.1.1.2.0") == ".1.3.6.1.4.1.211.1.21.1.101",

--- a/checks/fjdarye101_cmods_mem
+++ b/checks/fjdarye101_cmods_mem
@@ -28,7 +28,7 @@ check_info["fjdarye101_cmods_mem"] = {
     'check_function': check_fjdarye_item,
     'inventory_function': inventory_fjdarye_item,
     'includes': ["fjdarye.include"],
-    'service_description': 'Channel Module Memory %s',
+    'service_description': 'Controller Module Memory %s',
     # 1: fjdaryCmmemoryIndex, 3: fjdaryCmmemoryStatus
     'snmp_info': ('.1.3.6.1.4.1.211.1.21.1.101.2.4.2.1', [1, 3]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.2.1.1.2.0") == ".1.3.6.1.4.1.211.1.21.1.101",

--- a/checks/fjdarye500_cmods
+++ b/checks/fjdarye500_cmods
@@ -27,7 +27,7 @@
 check_info['fjdarye500_cmods'] = {
     'inventory_function': inventory_fjdarye_item,
     'check_function': check_fjdarye_item,
-    'service_description': 'Channel Module %s',
+    'service_description': 'Controller Module %s',
     'snmp_info': ('.1.3.6.1.4.1.211.1.21.1.150.2.1.2.1', [1, 3]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.2.1.1.2.0") == ".1.3.6.1.4.1.211.1.21.1.150",
     'includes': ["fjdarye.include"],

--- a/checks/fjdarye500_cmods_flash
+++ b/checks/fjdarye500_cmods_flash
@@ -27,7 +27,7 @@
 check_info['fjdarye500_cmods_flash'] = {
     'inventory_function': inventory_fjdarye_item,
     'check_function': check_fjdarye_item,
-    'service_description': 'Channel Module Flash %s',
+    'service_description': 'Controller Module Flash %s',
     'snmp_info': ('.1.3.6.1.4.1.211.1.21.1.150.2.4.2.1', [1, 3]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.2.1.1.2.0") == ".1.3.6.1.4.1.211.1.21.1.150",
     'includes': ["fjdarye.include"],

--- a/checks/fjdarye500_cmods_mem
+++ b/checks/fjdarye500_cmods_mem
@@ -27,7 +27,7 @@
 check_info['fjdarye500_cmods_mem'] = {
     'inventory_function': inventory_fjdarye_item,
     'check_function': check_fjdarye_item,
-    'service_description': 'Channel Module Memory %s',
+    'service_description': 'Controller Module Memory %s',
     'snmp_info': ('.1.3.6.1.4.1.211.1.21.1.150.2.4.2.1', [1, 3]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.2.1.1.2.0") == ".1.3.6.1.4.1.211.1.21.1.150",
     'includes': ["fjdarye.include"],

--- a/checks/fjdarye60_cmods
+++ b/checks/fjdarye60_cmods
@@ -30,7 +30,7 @@ check_includes['fjdarye60_cmods'] = ["fjdarye.include"]
 check_info["fjdarye60_cmods"] = {
     'check_function': check_fjdarye_item,
     'inventory_function': inventory_fjdarye_item,
-    'service_description': 'Channel Module %s',
+    'service_description': 'Controller Module %s',
     # 1: fjdaryCmIndex, 3: fjdaryCmStatus
     'snmp_info': ('.1.3.6.1.4.1.211.1.21.1.60.2.1.2.1', [1, 3]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.2.1.1.2.0") == ".1.3.6.1.4.1.211.1.21.1.60",

--- a/checks/fjdarye60_cmods_flash
+++ b/checks/fjdarye60_cmods_flash
@@ -30,7 +30,7 @@ check_includes['fjdarye60_cmods_flash'] = ["fjdarye.include"]
 check_info["fjdarye60_cmods_flash"] = {
     'check_function': check_fjdarye_item,
     'inventory_function': inventory_fjdarye_item,
-    'service_description': 'Channel Module Flash %s',
+    'service_description': 'Controller Module Flash %s',
     # 1: fjdaryCmflashIndex, 3: fjdaryCmflashStatus
     'snmp_info': ('.1.3.6.1.4.1.211.1.21.1.60.2.4.2.1', [1, 3]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.2.1.1.2.0") == ".1.3.6.1.4.1.211.1.21.1.60",

--- a/checks/fjdarye60_cmods_mem
+++ b/checks/fjdarye60_cmods_mem
@@ -30,7 +30,7 @@ check_includes['fjdarye60_cmods_mem'] = ["fjdarye.include"]
 check_info["fjdarye60_cmods_mem"] = {
     'check_function': check_fjdarye_item,
     'inventory_function': inventory_fjdarye_item,
-    'service_description': 'Channel Module Memory %s',
+    'service_description': 'Controller Module Memory %s',
     # 1: fjdaryCmmemoryIndex, 3: fjdaryCmmemoryStatus
     'snmp_info': ('.1.3.6.1.4.1.211.1.21.1.60.2.3.2.1', [1, 3]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.2.1.1.2.0") == ".1.3.6.1.4.1.211.1.21.1.60",


### PR DESCRIPTION
What is called Channel Module in Check_MK Repository is normally called Controller Module in Fujitsu Wording.
The wording is: Controller Module (CM#0 or CM#1) - then Channel Adapter (CA#0 or CA#1) and each Channel Adapter has Ports.
There is no Channel Module so i corrected this