### PR TITLE
Scan function scan_canon_printers is not working

### DIFF
--- a/checks/printer_pages.include
+++ b/checks/printer_pages.include
@@ -38,7 +38,7 @@ def scan_ricoh_printer(oid):
 def scan_canon_printer(oid):
     return "canon" in oid(".1.3.6.1.2.1.1.1.0").lower() \
            and oid(".1.3.6.1.4.1.1602.1.1.1.1.0") is not None \
-           and oid(".1.3.6.1.4.1.1602.1.11.1.3.1.4") is not None
+           and oid(".1.3.6.1.4.1.1602.1.11.1.3.1.4.301") is not None
 
 
 def scan_generic_printer(oid):


### PR DESCRIPTION
The requested OID is a complete table and cannot fetched with snmpget
as it is done on a snmp scan. The 301 is the complete pages count of
the machine. The canon_scan function was not working because of this
small error.