### PR TITLE
corrects typo

### DIFF
--- a/cmk/gui/plugins/metrics/check_mk.py
+++ b/cmk/gui/plugins/metrics/check_mk.py
@@ -628,7 +628,7 @@ metric_info["server_latency"] = {
 }
 
 metric_info["e2e_latency"] = {
-    "title": _("Ent-to-end latency"),
+    "title": _("End-to-end latency"),
     "unit": "s",
     "color": "21/b",
 }

--- a/locale/de/LC_MESSAGES/multisite.po
+++ b/locale/de/LC_MESSAGES/multisite.po
@@ -14308,7 +14308,7 @@ msgid "English"
 msgstr "Englisch"
 
 #, fuzzy
-msgid "Ent-to-end latency"
+msgid "End-to-end latency"
 msgstr "Leselatenz"
 
 msgid "Enter"


### PR DESCRIPTION
metric has nothing to do with https://en.wikipedia.org/wiki/Ent