### PR TITLE
Add new plugin for McAfee virus pattern age for both Virusscan and ENS

### DIFF
--- a/agents/windows/plugins/mcafee_av_client.bat
+++ b/agents/windows/plugins/mcafee_av_client.bat
@@ -1,7 +1,10 @@
 @echo off
 rem #  -----------------------------------------------------------------------------
 rem #  Check_MK windows agent plugin to gather information about signature date
-rem #  of Mcafee Anti-Virus software.
+rem #  of McAfee Virusscan Anti-Virus software.
+rem #
+rem #  Superseded by the mcafee_av_client.ps1 plugin which checks signature dates 
+rem #  of both Virusscan and Endpoint Security
 rem #  -----------------------------------------------------------------------------
 
 

--- a/agents/windows/plugins/mcafee_av_client.ps1
+++ b/agents/windows/plugins/mcafee_av_client.ps1
@@ -1,0 +1,36 @@
+#  -----------------------------------------------------------------------------
+#  Check_MK windows agent plugin to gather information about signature date
+#  of Mcafee Virusscan 8.8 or ENS Anti-Virus software.
+#
+#  Supersedes the mcafee_av_client.bat plugin
+#  -----------------------------------------------------------------------------
+
+$dateval=""
+$key="registry::HKLM\SOFTWARE\McAfee\AvEngine"
+$p=get-itemproperty $key -ea 0
+if ($p) {
+  $dateval = $p.AVDatDate
+} else {
+  $key="registry::HKLM\SOFTWARE\Wow6432Node\McAfee\AvEngine"
+  $p=get-itemproperty $key -ea 0
+  if ($p) {
+    $dateval = $p.AVDatDate
+  } else {  
+    $key="registry::HKLM\SOFTWARE\McAfee\AVSolution\DS\DS"
+    $p=get-itemproperty $key -ea 0
+    if ($p) {
+      $dateval = $p.szContentCreationDate -replace "-","/"
+    } else {
+      $key="registry::HKLM\Software\Wow6432Node\McAfee\AVSolution\DS\DS"
+      $p=get-itemproperty $key -ea 0
+      if ($p) {
+        $dateval = $p.szContentCreationDate -replace "-","/"
+      }
+    }
+  }
+}
+
+if ($dateval -ne "") {
+  write-host "<<<mcafee_av_client>>>"
+  write-host $dateval
+}


### PR DESCRIPTION
mcafee_av_client.ps1 checks both Virusscan and ENS DAT dates in registry.

Added comment in mcafee_av_client.bat informing users that it is restricted to Virusscan only