### PR TITLE
Fixed HPE Storeonce checks

### DIFF
--- a/checks/storeonce.include
+++ b/checks/storeonce.include
@@ -75,15 +75,17 @@ def check_storeonce_space(item, params, values):
     yield df_check_filesystem_list(item, params, [(item, total_bytes/factor, free_bytes/factor, 0)])
 
     if cloud_bytes and local_bytes:
-        yield 0, "Total cloud: %s, Total local: %s" % (
+        yield 0, ("Total cloud: %s, Total local: %s" % (
               get_bytes_human_readable(cloud_bytes),
-              get_bytes_human_readable(local_bytes))
+              get_bytes_human_readable(local_bytes))), []
 
     if free_cloud_bytes and free_local_bytes:
-        yield 0, "Free cloud: %s, Free local: %s" % (
+        yield 0, ("Free cloud: %s, Free local: %s" % (
               get_bytes_human_readable(free_cloud_bytes),
-              get_bytes_human_readable(free_local_bytes))
+              get_bytes_human_readable(free_local_bytes))), []
 
-    dedupl_ratio_str = values.get('Deduplication Ratio')
-    if dedupl_ratio_str is not None:
-        yield 0, "Dedup ratio: %.2f" % float(dedupl_ratio_str)
+    dedup_ratio = values.get('Deduplication Ratio')
+    if dedup_ratio is None:
+        values.get('Dedupe Ratio')
+    if dedup_ratio is not None:
+        yield 0, ("Dedup ratio: %.2f" % float(dedup_ratio)), []

--- a/cmk_base/checking.py
+++ b/cmk_base/checking.py
@@ -494,7 +494,16 @@ def _item_not_found(is_snmp):
 
 
 def _sanitize_tuple_check_result(result, allow_missing_infotext=False):
-    if len(result) >= 3:
+    import types
+    if isinstance(result, types.GeneratorType):
+        state = 0
+        infotext = ""
+        perfdata = []
+        for state_, infotext_, perfdata_ in result:
+            if state_ != state and state_ > state:
+                state = state_
+            infotext += infotext_
+    elif not isinstance(result, types.GeneratorType) and len(result) >= 3:
         state, infotext, perfdata = result[:3]
         _validate_perf_data_values(perfdata)
     else:


### PR DESCRIPTION
Fixed error TypeError (object of type generator has no len()) in checking.py
and HPE storeonce deduplication ratio for new and old mibs.

Tested against both versions and customer verified in his environment.
Fix needed in Check_MK Version 1.5.0pXX.

Signed-off-by: Sven Rueß <github@sritd.de>