### PR TITLE
postgres: Bugfix in postgres_version and posgres_stat_database for in…

### DIFF
--- a/checks/postgres_stat_database
+++ b/checks/postgres_stat_database
@@ -69,7 +69,7 @@ def inventory_postgres_stat_database(parsed):
 
 def check_postgres_stat_database(item, params, parsed):
     if item not in parsed:
-        return (3, "Database not found")
+        raise MKCounterWrapped("Cluster not runnint or database data missing")
 
     stats = parsed[item]
     status = 0

--- a/checks/postgres_version
+++ b/checks/postgres_version
@@ -52,7 +52,6 @@ def parse_postgres_version(info):
     return parsed
 
 
-@get_parsed_item_data
 def check_postgres_version(_no_item, _no_params, data):
     if "could not connect" in data:
         raise MKCounterWrapped("Login into database failed")


### PR DESCRIPTION
…stance down

The check postgres_version creates a CRIT when a PostgreSQL Cluster is not
running. This issue is a regression of Werk 7140 which introduced this issue.

The check postgres_stat_database creates a CRIT when a PostgreSQL Cluster is not
running. This is useless for a check with statistical informations only.

Both checks goes PEND when agent output is missing.