### PR TITLE
Nagios config activation: Bugfix for dead lock at activation time

### DIFF
--- a/cmk_base/nagios_utils.py
+++ b/cmk_base/nagios_utils.py
@@ -39,11 +39,12 @@ def do_check_nagiosconfig():
     cmk_base.console.output("Validating Nagios configuration...")
 
     p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
-    exit_status = p.wait()
+    (stdout, stderr) = p.communicate()
+    exit_status = p.returncode
     if not exit_status:
         cmk_base.console.output(tty.ok + "\n")
         return True
 
     cmk_base.console.output("ERROR:\n")
-    cmk_base.console.output(p.stdout.read(), stream=sys.stderr)
+    cmk_base.console.output(stdout, stderr)
     return False


### PR DESCRIPTION
The usage of subprocess.Popen and then p.wait in combination with
PIPE for stdout can lead to an dead lock. The complete description
for this problem can be found here https://bugs.python.org/issue1606.
Also inside the documenation https://docs.python.org/2/library/subprocess.html#popen-objects
The fix is using the communicate() instead of wait().