### PR TITLE
ssl connection to localhost do no verify ssl certificate

### DIFF
--- a/agents/plugins/nginx_status
+++ b/agents/plugins/nginx_status
@@ -41,6 +41,7 @@ import os
 import re
 import sys
 import urllib2
+import ssl
 
 # tell urllib2 not to honour "http(s)_proxy" env variables
 urllib2.getproxies = lambda: {}
@@ -129,13 +130,13 @@ for server in servers:
         # Try to fetch the status page for each server
         try:
             request = urllib2.Request(url, headers={"Accept": "text/plain"})
-            fd = urllib2.urlopen(request)
+            fd = urllib2.urlopen(request, context=ssl._create_unverified_context())
         except urllib2.URLError as e:
             if 'SSL23_GET_SERVER_HELLO:unknown protocol' in str(e):
                 # HACK: workaround misconfigurations where port 443 is used for
                 # serving non ssl secured http
                 url = 'http://%s:%s/%s' % (address, port, page)
-                fd = urllib2.urlopen(url)
+                fd = urllib2.urlopen(url, context=ssl._create_unverified_context())
             else:
                 raise
 


### PR DESCRIPTION
since urllib2 seems to verify server certificates by default https connection to localhost will not work anymore. This is my quick fix for Python 2.7