### PR TITLE
Update config.py

### DIFF
--- a/cmk_base/config.py
+++ b/cmk_base/config.py
@@ -828,7 +828,7 @@ _old_service_descriptions = {
     "mssql_tablespaces": "%s Sizes",
     "mssql_transactionlogs": "Transactionlog %s",
     "mssql_versions": "%s Version",
-    "mssql_blocked_sessions": lambda item: (False, "MSSQL Blocked Sessions"),
+    "mssql_blocked_sessions": "MSSQL %s Blocked Sessions",
 }
 
 


### PR DESCRIPTION
Necessary to get the updated service_description that includes the Instance Name for mssql Blocked Sessions.