### PR TITLE
added option "container_id: nodename_name" for the mk_docker.py plugin

### DIFF
--- a/agents/cfg_examples/docker.cfg
+++ b/agents/cfg_examples/docker.cfg
@@ -40,8 +40,10 @@ skip_sections: docker_node_disk_usage,docker_node_images
 # container, as well as items for services created on the node for each
 # container.
 # By default, the identifier is assumed to be the first 12 characters
-# of the container UUID. You can choose to use the full ID or the containers
-# name instead. Allowed values are "short" (the default), "long" and "name".
+# of the container UUID. You can choose to use the full ID, the container
+# name or the nodename (hostname of host running the docker daemon) concatenated
+# with the container name. e.g. hostname1_containername1
+# Allowed values are "short" (the default), "long", "name" and "nodename_name".
 container_id: name
 
 # BASE URL

--- a/agents/plugins/mk_docker.py
+++ b/agents/plugins/mk_docker.py
@@ -184,6 +184,8 @@ class MKDockerClient(docker.DockerClient):
         all_containers = self.containers.list(all=True)
         if config['container_id'] == "name":
             self.all_containers = dict([(c.attrs["Name"].lstrip('/'), c) for c in all_containers])
+        elif config['container_id'] == "nodename_name":
+            self.all_containers = dict([("%s_%s" % (c.attrs["Config"]['Hostname'], c.attrs["Name"].lstrip('/')), c) for c in all_containers])
         elif config['container_id'] == "long":
             self.all_containers = dict([(c.attrs["Id"], c) for c in all_containers])
         else:


### PR DESCRIPTION
I have many docker nodes running containers with identical name and this change in `mk_docker.py` allows to name every piggybacked container as `nodename_name` , being "nodename" the hostname of the machine running the docker daemon (and also the check_mk agent) and "name" the name of the container

I tried to use the option in `Access to agents ➳ General settings ➳ Hostname translation for piggybacked hosts` but it seems that I cannot add the nodename in a generic way. I asked about it in the mailing list: https://lists.mathias-kettner.de/pipermail/checkmk-en/2019-October/028898.html

This change doesn't change the default behavior of the plugin