### PR TITLE
Fix missing temperature info in brocade_optical

### DIFF
--- a/checks/brocade_optical
+++ b/checks/brocade_optical
@@ -214,7 +214,7 @@ def check_brocade_optical(item, params, parsed):
         else:
             yield 0, 'Operational %s' % oper_status_readable
 
-        if 'temp' in iface and iface['temp'][0[ is not None:
+        if 'temp' in iface and iface['temp'][0] is not None:
             yield check_temperature(iface['temp'][0],
                                     params,
                                     "brocade_optical_%s" % item,

--- a/checks/brocade_optical
+++ b/checks/brocade_optical
@@ -214,7 +214,7 @@ def check_brocade_optical(item, params, parsed):
         else:
             yield 0, 'Operational %s' % oper_status_readable
 
-        if 'temp' in iface:
+        if 'temp' in iface and iface['temp'][0[ is not None:
             yield check_temperature(iface['temp'][0],
                                     params,
                                     "brocade_optical_%s" % item,


### PR DESCRIPTION
There are devices without temperature information. 
This fix prevents them from crashing.

If merge, Please change Commit Message before the merge, working on GitHub only and cannot do that here. 