### PR TITLE
Fixed detection of McAfee plugin on 64 and 32 bit systems

### DIFF
--- a/agents/windows/plugins/mcafee_av_client.bat
+++ b/agents/windows/plugins/mcafee_av_client.bat
@@ -8,10 +8,14 @@ rem #  -------------------------------------------------------------------------
 setlocal enableDelayedExpansion
 set dateval=
 
-for /f "tokens=3" %%a in ('reg query "HKLM\SOFTWARE\McAfee\AvEngine" ^|find /I "AVDatDate" ^|find "REG_SZ"') do @set dateval=%%a
-if "%dateval%"=="" (
-    rem # on 64 bit systems the registry key is in the wow64/32 branch
-    for /f "tokens=3" %%a in ('reg query "HKLM\SOFTWARE\Wow6432Node\McAfee\AvEngine" ^|find /I "AVDatDate" ^|find "REG_SZ"') do @set dateval=%%a
+rem # on 64 bit systems
+if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
+  for /f "eol=S skip=2 tokens=3" %%a in ('reg query "HKLM\SOFTWARE\Wow6432Node\McAfee\AvEngine" /v AVDatDate /t REG_SZ 2^>nul') do @set dateval=%%a
+)
+
+rem # on 32 bit systems
+if "%PROCESSOR_ARCHITECTURE%" == "x86" (
+  for /f "eol=S skip=2 tokens=3" %%a in ('reg query "HKLM\SOFTWARE\McAfee\AvEngine" /v AVDatDate /t REG_SZ 2^>nul') do @set dateval=%%a
 )
 
 if not "%dateval%"=="" (


### PR DESCRIPTION
Fixed detection of McAfee plugin on 64 and 32 bit systems and avoid unnecessary error message in plugin output.

Signed-off-by: Sven Rueß <github@sritd.de>