### PR TITLE
parse_brocade_fcport: Fix parsing for Brocade G630

### DIFF
--- a/checks/brocade_fcport
+++ b/checks/brocade_fcport
@@ -131,7 +131,13 @@ def parse_brocade_fcport(info):
         # as the sequence number in the borcade MIB (pindex = item_index)
         if_table = [x + y if y[0] == "56" else ["", x[-2]] for x, y in zip(if_info, speed_info)]
     else:
-        if_table = [x + ["", x[-2]] for x in if_info]
+        # Try to filter all FC ports and compare the length of the lists again.
+        # Sometimes there are other interfaces after the FC ports in speed_info, which are not in if_info.
+        speed_info = [x for x in speed_info if x[0] == "56"]
+        if len(if_info) == len(speed_info):
+            if_table = [x + y for x,y in zip(if_info, speed_info)]
+        else:
+            if_table = [x + ["", x[-2]] for x in if_info]
 
     parsed = []
     for index, phystate, opstate, admstate, txwords, rxwords, txframes, \


### PR DESCRIPTION
On Brocade G630 switches the current interface parsing doesn't work and thus the interfaces won't get discoverd.

The problem is, that if_info and speed_info don't have the same length, because after the FC interfaces there is another interface. The current code only strips non-FC-interface before the first FC interface.

The speed_info looks like:
[
  [u'805306369', u'24', u'0'],
  [u'805306370', u'6', u'1000'],
  [u'805306371', u'1', u'0'],
  [u'805306372', u'1', u'0'],
  [u'805306373', u'131', u'0'],
  [u'805306374', u'1', u'0'],
  [u'805306375', u'1', u'0'],
  [u'805306376', u'1', u'0'],
  [u'805306377', u'1', u'0'],
  [u'1073741824', u'56', u'16000'],
  [u'1073741825', u'56', u'16000'],
  [u'1073741826', u'56', u'16000'],
  [u'1073741827', u'56', u'16000'],
  ...
  [u'1073741951', u'56', u'32000'],
  [u'1207959584', u'1', u'0']
],

The current fallback for non existent speed info would also fail, because the switch doesn't report a value for swFCPortSpeed.
In this Case, the variable brocade_speed is "" and thus ifspeed will also be "". Later the function _try_int(ifspeed) will result in a ValueError and the interface is skipped.