### PR TITLE
Fix hp_fan and hp_psu: They already support 5412rzl2

### DIFF
--- a/checks/hp_fan
+++ b/checks/hp_fan
@@ -61,6 +61,6 @@ check_info['hp_fan'] = {
             "2",  # hpicfFanTray: Tray number in which the fan is docked.
             "4",  # hpicfFanState
         ]),
-    'snmp_scan_function': lambda oid: "hp" in oid(".1.3.6.1.2.1.1.1.0").lower() and "5406rzl2" in
-                          oid(".1.3.6.1.2.1.1.1.0").lower(),
+    'snmp_scan_function': lambda oid: "hp" in oid(".1.3.6.1.2.1.1.1.0").lower() and
+                          bool(re.search(r"54(06|12)rzl2", oid(".1.3.6.1.2.1.1.1.0").lower())),
 }

--- a/checks/hp_psu
+++ b/checks/hp_psu
@@ -110,6 +110,6 @@ check_info['hp_psu'] = {
             "2",  # hpicfPsState
             "4",  # hpicfPsTemp
         ]),
-    'snmp_scan_function': lambda oid: "hp" in oid(".1.3.6.1.2.1.1.1.0").lower() and "5406rzl2" in
-                          oid(".1.3.6.1.2.1.1.1.0").lower(),
+    'snmp_scan_function': lambda oid: "hp" in oid(".1.3.6.1.2.1.1.1.0").lower() and
+                          bool(re.search(r"54(06|12)rzl2", oid(".1.3.6.1.2.1.1.1.0").lower())),
 }


### PR DESCRIPTION
Dear developers,

This patch has been successfully tested on 1.6.0p2.