### PR TITLE
Fix livestatus: decode http status code as well

### DIFF
--- a/livestatus/api/python/livestatus.py
+++ b/livestatus/api/python/livestatus.py
@@ -498,7 +498,7 @@ class SingleSiteConnection(Helpers):
         try:
             # Headers are always ASCII encoded
             resp = self.receive_data(16)
-            code = resp[0:3]
+            code = resp[0:3].decode("ascii")
             try:
                 length = int(resp[4:15].lstrip())
             except:


### PR DESCRIPTION
Related to https://github.com/tribe29/checkmk/commit/a5f352e02b535dda4fb7781f7f52c445c32f7383#diff-c6a4af85dc3d527988c1d1a5d0623d27:
not only the received data needs to be decoded, but also the http status code.

Without that fix, I get
```
  File "/mnt/sda8/files/development/owm/build/sources/djangohal/hal/livestatus.py", line 555, in recv_response
    raise MKLivestatusSocketError("Unhandled exception: %s" % e)
hal.livestatus.MKLivestatusSocketError: Unhandled exception: b'200': [[8]]
```
when running
```
results = ls.query("GET hosts\nStats: hard_state = 0")
```
against CheckMK Version 1.5.0p15.cee. `livestatus.py` is git HEAD.