### PR TITLE
mk_oracle: Support for mk_oracle.d

### DIFF
--- a/agents/plugins/mk_oracle
+++ b/agents/plugins/mk_oracle
@@ -280,6 +280,13 @@ if [ -e "$MK_CONFDIR/mk_oracle.cfg" ]; then
     . "$MK_CONFDIR/mk_oracle.cfg"
 fi
 
+if [ -d "$MK_CONFDIR/mk_oracle.d" ]; then
+    for cfg in "$MK_CONFDIR"/mk_oracle.d/*.cfg
+    do
+        # shellcheck source=/dev/null
+        . "$cfg"
+    done
+fi
 
 #.
 #   .--logging-------------------------------------------------------------.


### PR DESCRIPTION
An addional configuration directory for mk_oracle has been added.
mk_oracle reads the mk_oracle.cfg and then all files with *.cfg from
$MK_CONFDIR/mk_oracle.d
This feauture is needed for setups with bakery and local changes on the
database server. It is possible to configure bakery with custom SQL in
mk_oracle.
All variables in files from mk_oracle.d will oerwrite possible entries from
mk_oracle.cfg.