### PR TITLE
Skip parsing second "Personalities" to make md check cluster aware

### DIFF
--- a/checks/md
+++ b/checks/md
@@ -146,7 +146,8 @@ def parse_md(info):
                         instance["%s_values" % e] = line[idx + 3]
                 continue
 
-            if line[-1].startswith("[") and line[-1].endswith("]"):
+            if line[-1].startswith("[") and line[-1].endswith("]") and \
+                    not line[0].startswith("Personalities"):
                 instance["working_disks"] = line[-1][1:-1]
 
             if len(line) >= 2 and line[-2].startswith("[") and line[-2].endswith("]"):


### PR DESCRIPTION
When using the checkmk cluster feature, the output of two <<<md>>> sections is
merged. The second line can falsely be parsed as output of the last raid block.
Hence, when looking for working disks, we need to skip lines starting with:
Personalities
Otherwise, the check would return CRIT for the last md block of the first
cluster member because it parses e.g. "raid1" as a working disk, which then
doesn't list the right number of working disks in line 192 where active disks
are compared to the number of "U" in working_disks