### PR TITLE
Bugfix: mk_oracle: Regression from Werk 10359 Removed testing change

### DIFF
--- a/agents/plugins/mk_oracle
+++ b/agents/plugins/mk_oracle
@@ -597,7 +597,7 @@ sql_performance () {
 sql_tablespaces () {
 
     echo "PROMPT <<<oracle_tablespaces:sep(124)>>>"
-    if [ "$NUMERIC_ORACLE_VERSION" -ge 141 ]; then
+    if [ "$NUMERIC_ORACLE_VERSION" -ge 121 ]; then
 
         echo "SET SERVEROUTPUT ON feedback off
               DECLARE


### PR DESCRIPTION
The Werk 10359 introduced new SQLs for oracle_tablespaces. There was a wrong
version specifier for testing the  SQL.

This has been fixed.