### PR TITLE
mk_oracle: simplify configuration for ASYNC/SYNC section for each SID

### DIFF
--- a/agents/plugins/mk_oracle
+++ b/agents/plugins/mk_oracle
@@ -2529,14 +2529,29 @@ do_checks () {
         local do_async_sections=${ASYNC_ASM_SECTIONS}
         local do_sync_sections=${SYNC_ASM_SECTIONS}
     else
-        local dummy="SYNC_SECTIONS_${ORACLE_SID}"
-        local SYNC_SECTIONS_SID=${!dummy}
-        local do_sync_sections=${SYNC_SECTIONS_SID:-${SYNC_SECTIONS}}
-        unset dummy
+        # declare -p => check for SYNC_STIONS_<SID> is existing
+        # we need this for possible configuration: SYNC_SECTIONS_<SID>=""
+        # shellcheck disable=SC2153
+        if ! declare -p "SYNC_SECTIONS_${ORACLE_SID}" > /dev/null 2>&1
+        then
+            local do_sync_sections="${SYNC_SECTIONS}"
+        else
+            local dummy="SYNC_SECTIONS_${ORACLE_SID}"
+            local do_sync_sections=${!dummy}
+            unset dummy
+        fi
 
-        local dummy="ASYNC_SECTIONS_${ORACLE_SID}"
-        local ASYNC_SECTIONS_SID=${!dummy}
-        local do_async_sections=${ASYNC_SECTIONS_SID:-${ASYNC_SECTIONS}}
+        # declare -p => check for ASYNC_STIONS_<SID> is existing
+        # we need this for possible configuration: ASYNC_SECTIONS_<SID>=""
+        # shellcheck disable=SC2153
+        if ! declare -p "ASYNC_SECTIONS_${ORACLE_SID}" > /dev/null 2>&1
+        then
+            local do_async_sections="${ASYNC_SECTIONS}"
+        else
+            local dummy="ASYNC_SECTIONS_${ORACLE_SID}"
+            local do_async_sections=${!dummy}
+            unset dummy
+        fi
     fi
 
     if [ -n "${MK_ORA_SECTIONS[*]}" ]; then


### PR DESCRIPTION
The SYNC and ASYNC sections could be configured for each
ORACLE_SID in mk_oracle.cfg.
SYNC_SECTIONS_testdb1='instance'
ASYNC_SECTIONS_testdb1='tablespaces'

An empty string in SYNC_SECTIONS_testdb1 or ASYNC_SECTIONS_testdb1
is possible now.
Example:
ASYNC_SECTIONS_testdb1=""

Previous configurations need a " " as value. There is no requirement
to move to the new configuration. The following configuration is valid as well:

Example:
ASYNC_SECTIONS_testdb1=" "

> This PullRequest is related to CMKOC-97