### PR TITLE
mk_postgres: Bugfix for instance detection

### DIFF
--- a/agents/plugins/mk_postgres
+++ b/agents/plugins/mk_postgres
@@ -87,7 +87,7 @@ function postgres_instances() {
     #   pgrep -af bin/postgres 2>/dev/null || pgrep -lf bin/postgres
     # but SLES 11 returns the exit code 0 for a wrong command line.
     # Newer versions of postgres are started with postmaster instead of postgres
-    ps -eo pid,command | grep -E "bin/postgres|bin/postmaster" | grep -vE '^[ ]*[0-9]+ grep '
+    ps -eo pid,command | grep -E "bin/postgres|bin/postmaster|bin/edb-postgres" | grep -vE '^[ ]*[0-9]+ grep '
 }
 
 

--- a/agents/plugins/mk_postgres
+++ b/agents/plugins/mk_postgres
@@ -86,7 +86,8 @@ function postgres_instances() {
     # was to use:
     #   pgrep -af bin/postgres 2>/dev/null || pgrep -lf bin/postgres
     # but SLES 11 returns the exit code 0 for a wrong command line.
-    ps -eo pid,command | grep bin/postgres | grep -vE '^[ ]*[0-9]+ grep '
+    # Newer versions of postgres are started with postmaster instead of postgres
+    ps -eo pid,command | grep -E "bin/postgres|bin/postmaster" | grep -vE '^[ ]*[0-9]+ grep '
 }
 
 


### PR DESCRIPTION
The process to detect a running instance has been changed in newer versions
of PostgreSQL from postgres to postmaster.

Examples:
  /usr/pgsql-11/bin/postmaster
  /usr/bin/postgres

Please update the plugin mk_postgres