### PR TITLE
fix web api site login for 1.6 (invalid secret)

### DIFF
--- a/cmk/gui/watolib/automations.py
+++ b/cmk/gui/watolib/automations.py
@@ -321,8 +321,7 @@ def do_site_login(site_id, name, password):
         '_login': '1',
         '_username': name,
         '_password': password,
-        '_origtarget': 'automation_login.py?_version=%s&_edition_short=%s' %
-                       (cmk.__version__, cmk.edition_short()),
+        '_origtarget': 'automation_login.py',
         '_plain_error': '1',
     }
     response = get_url(url, site.get('insecure', False), auth=(name, password),


### PR DESCRIPTION
1.6 expects a **value (string)** behind the key secret 

secret: Z>0B?KELTUWY@:XYXYXY;5AN6YL39<1W
            
If you use the web api to login a site
```bash
curl "http://myserver/mysite/check_mk/webapi.py?action=login_site&_username=automation&_secret=myautomationsecret" -d 'request={"site_id":"mySlave","username":"cmkadmin","password":"cmk"}'
```
the following dict will be written:
```python
"secret" : {
            "edition_short" : "cme",
            "login_secret" : "Z>0B?KELTUWY@:XYXYXY;5AN6YL39<1W",
            "version" : "1.6.0p6"
}
```
which results in a "Invalid Automation Secret" error in WATO distributed monitoring


