### PR TITLE
Only count K8S running pods

### DIFF
--- a/cmk/special_agents/agent_kubernetes.py
+++ b/cmk/special_agents/agent_kubernetes.py
@@ -443,6 +443,7 @@ class Pod(Metadata):
                                         if status.container_statuses else [])
             self._conditions = status.conditions if status.conditions else []
         else:
+            self.phase = None
             self.host_ip = None
             self.pod_ip = None
             self.qos_class = None
@@ -950,13 +951,13 @@ class PodList(K8sList[Pod]):
         return {
             node: {
                 'requests': {
-                    'pods': len(list(filter(lambda pod: pod.phase == "Running", pods)))
+                    'pods': len([pod for pod in pods if pod.phase not in ["Succeeded", "Failed"]])
                 }
             } for node, pods in by_node if node is not None
         }
 
     def pods_in_cluster(self):
-        return {'requests': {'pods': len(self)}}
+        return {'requests': {'pods': len([pod for pod in self if pod.phase not in ["Succeeded", "Failed"]])}}
 
     def info(self):
         return {pod.name: pod.info for pod in self}

--- a/cmk/special_agents/agent_kubernetes.py
+++ b/cmk/special_agents/agent_kubernetes.py
@@ -435,6 +435,7 @@ class Pod(Metadata):
 
         status = pod.status
         if status:
+            self.phase = status.phase
             self.host_ip = status.host_ip
             self.pod_ip = status.pod_ip
             self.qos_class = status.qos_class
@@ -949,7 +950,7 @@ class PodList(K8sList[Pod]):
         return {
             node: {
                 'requests': {
-                    'pods': len(list(pods))
+                    'pods': len(list(filter(lambda pod: pod.phase == "Running", pods)))
                 }
             } for node, pods in by_node if node is not None
         }


### PR DESCRIPTION
Please, find my first MR to Check_MK and my first bytes in Python :) I hope it not too bad.

**Description :**

With many Job/CronJob, we have many terminated pods. They are excluded in the default 110 pods per node limit. Luckily :)

I noticed that the pod count returned by check_mk-k8s_resources.pods includes terminated pods. So some of my nodes reports and warns about too much pods. Bad.

This MR add Pod.phase status in the Pod class and excludes them from the list count used by pod count (and seems only used there).

It would be nice to see that merged in 1.6.0 branch too.

