### PR TITLE
[mk_inventory.linux] adds IPv6 routing information

### DIFF
--- a/agents/plugins/mk_inventory.linux
+++ b/agents/plugins/mk_inventory.linux
@@ -92,6 +92,7 @@ then
     if type ip > /dev/null ; then
         echo "<<<lnx_ip_r:persist($UNTIL)>>>"
         ip r
+        ip -6 r
     fi
 
 fi


### PR DESCRIPTION
"ip r" only shows IPv4 routes