### PR TITLE
mk_oracle: Support for Custom SQL with Remote Monitoring

### DIFF
--- a/agents/plugins/mk_oracle
+++ b/agents/plugins/mk_oracle
@@ -1935,7 +1935,7 @@ do_custom_sqls () {
         fi
 
         # set custom credentials from section
-        db_connect=$(mk_ora_db_connect "$sid")
+        db_connect=$(mk_ora_db_connect "$MK_SID")
         export MK_DB_CONNECT=$db_connect
 
         unset_custom_sqls_vars
@@ -2693,9 +2693,9 @@ for sid in $SIDS; do
             "ORACLE_SID: ${ORACLE_SID}" "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"\
             "ORACLE_VERSION: ${ORACLE_VERSION} (${NUMERIC_ORACLE_VERSION})"
 
-
-    db_connect=$(mk_ora_db_connect "$sid")
+    # MK_SID is feauture replacement for sid
     export MK_SID=$sid
+    db_connect=$(mk_ora_db_connect "$MK_SID")
     export MK_DB_CONNECT=$db_connect
 
     do_checks

--- a/agents/plugins/mk_oracle
+++ b/agents/plugins/mk_oracle
@@ -1842,7 +1842,7 @@ sql_asm_diskgroup () {
 
 unset_custom_sqls_vars () {
     unset SQLS_SECTION_NAME SQLS_SECTION_SEP SQLS_SIDS SQLS_DIR SQLS_SQL SQLS_PARAMETERS SQLS_MAX_CACHE_AGE SQLS_ITEM_NAME MK_CUSTOM_SQLS_SECTION MK_CUSTOM_SQLS_SECTION_HEADER MK_CUSTOM_SQLS_ITEM MK_CUSTOM_SQLS_SECTION_QUERY
-    unset SQLS_DBUSER SQLS_DBPASSWORD SQLS_DBSYSCONNECT SQLS_TNSALIAS
+    unset SQLS_DBUSER SQLS_DBPASSWORD SQLS_DBSYSCONNECT SQLS_TNSALIAS SQLS_ITEM_SID
 }
 
 
@@ -1915,10 +1915,25 @@ do_custom_sqls () {
         fi
 
         if [ "$section_name" = "oracle_sql" ]; then
-            if [ -n "$SQLS_ITEM_NAME" ]; then
-                local item="${MK_SID}|${SQLS_ITEM_NAME}"
+            if [[ "$MK_SID" =~ ^REMOTE_INSTANCE_.* ]]; then
+                if [ -z "$SQLS_ITEM_SID" ]; then
+                    # we can not extract MK_SID from REMOTE_INSTANCE_ variable name
+                    # get MK_SID from mk_oracle.cfg when SQLS_ITEM_SID is not defined
+                    # => needed when tnsnames.ora is used without SID in CFGLINE...
+                    local SQLS_ITEM_SID
+                    SQLS_ITEM_SID=$(eval "echo \${$MK_SID}" | cut -d":" -f7)
+                fi
             else
-                local item="${MK_SID}|${sql}"
+                # local connection mode
+                local SQLS_ITEM_SID="$MK_SID"
+            fi
+            logging "[${MK_SID}] [${section}] [custom_sql] "\
+                    "SQLS_ITEM_SID: $SQLS_ITEM_SID"
+
+            if [ -n "$SQLS_ITEM_NAME" ]; then
+                local item="${SQLS_ITEM_SID}|${SQLS_ITEM_NAME}"
+            else
+                local item="${SQLS_ITEM_SID}|${sql}"
             fi
         else
             local item=
@@ -2722,4 +2737,5 @@ for remote_instance in $REMOTE_INSTANCES; do
     export MK_PIGGYBACK_HOST=$piggyback_host
 
     do_checks
+    do_custom_sqls
 done


### PR DESCRIPTION
The new feauture Custom SQL could be used with Remote Monitoring as well.
Be aware that the configuration of Custom SQL and Remote Monitoring is not
easy...

The SQLS_ITEM_SID is mandatory in this configuration. Otherwise the value
from SQLS_SIDS is used in the service name during Discovery.

The following example shows only the needed parameter for a configuration.
This is not complete for a whole mk_oracle.cfg!

Example mk_oracle.cfg:

REMOTE_INSTANCE_1_db1=c##cmk:cmkpass::dbhost:1524:piggybackhost:db191:19

SQLS_SECTIONS="invalid_objects"
SQLS_DIR=/etc/check_mk
SQLS_MAX_CACHE_AGE=10

invalid_objects () {
SQLS_SIDS=REMOTE_INSTANCE_1_db1
SQLS_ITEM_SID=db191
SQLS_SQL=invalid_objects.sql
}

Please note the Ticket CMKOC-138