### PR TITLE
[graph title] Time left instead of Hours left

### DIFF
--- a/cmk/gui/plugins/metrics/check_mk.py
+++ b/cmk/gui/plugins/metrics/check_mk.py
@@ -826,7 +826,7 @@ metric_info["mem_trend"] = {
 }
 
 metric_info["trend_hoursleft"] = {
-    "title": _("Hours left until full"),
+    "title": _("Time left until full"),
     "unit": "s",
     "color": "#94b65a",
 }

--- a/locale/de/LC_MESSAGES/multisite.po
+++ b/locale/de/LC_MESSAGES/multisite.po
@@ -32205,6 +32205,9 @@ msgstr "Netzteil"
 msgid "Power Supply name"
 msgstr "Name des Netzteils"
 
+msgid "Time left until full"
+msgstr "Verbleibende Zeit"
+
 msgid "Power Usage"
 msgstr "Energie Verbrauch"
 


### PR DESCRIPTION
It is a little bit confusing when the y axis is labeled with a small m for minutes, but the graph title says "Hours left until full".