### PR TITLE
AIX Agent: Fix cache age for plugins to unixtime

### DIFF
--- a/agents/check_mk_agent.aix
+++ b/agents/check_mk_agent.aix
@@ -124,7 +124,9 @@ function run_cached {
         if (( $MTIME < $MAXAGE )) ; then
             USE_CACHEFILE=1
         fi
-        CACHE_INFO="cached($MTIME,$MAXAGE)"
+        # get file time for cache
+        FTIME=$(perl -le 'print((stat shift)[9])' $CACHEFILE)
+        CACHE_INFO="cached($FTIME,$MAXAGE)"
         if [[ $NAME == local_* ]]; then
             sed -e "s/^/$CACHE_INFO /" "$CACHEFILE"
         else


### PR DESCRIPTION
This patch fixed teh issue if plugins run cached and becomes stale.