### PR TITLE
mk_docker.py: check if docker is installed

### DIFF
--- a/agents/plugins/mk_docker.py
+++ b/agents/plugins/mk_docker.py
@@ -51,6 +51,14 @@ import functools
 import multiprocessing
 import logging
 
+def which(prg):
+    for path in os.environ["PATH"].split(os.pathsep):
+        if os.path.isfile(os.path.join(path,prg)) and os.access(os.path.join(path,prg), os.X_OK):
+            return os.path.join(path,prg)
+    return None
+if not os.path.isfile('/var/lib/docker') and not os.path.isfile('/var/run/docker') and not which('docker'):
+    sys.exit(1)
+
 try:
     import ConfigParser as configparser
 except ImportError:  # Python3


### PR DESCRIPTION
Check if docker is installed; exit silently if no executable is found in path and no /var/run and /var/lib folders are found for docker.