### PR TITLE
Meinberg LANTIME fan status

### DIFF
--- a/checks/mbg_lantime_ng_fan
+++ b/checks/mbg_lantime_ng_fan
@@ -32,8 +32,9 @@ def inventory_mbg_lantime_ng_fan(info):
 
 def check_mbg_lantime_ng_fan(item, _no_params, info):
     fan_states = {
-        "1": (0, "on"),
-        "2": (2, "off"),
+        "0": (0, "not available"),
+        "1": (0, "off"),
+        "2": (2, "on"),
     }
     fan_errors = {
         "0": (0, "not available"),


### PR DESCRIPTION
Fan Status has changed, it can have 3 status just like other Meinberg checks.
Tested with M1000 Firmware 7.00.06.
Confirmed by MIB information from Meinberg.
MBG-LANTIME-NG-MIB.mib
mbgLtNgSysFanStatus OBJECT-TYPE
    SYNTAX INTEGER {
        notAvailable(0),
        off(1),
        on(2)
      }
    MAX-ACCESS read-only
    STATUS current
    DESCRIPTION
        "Status of fan"
    DEFVAL { 0 }
    ::= { mbgLtNgSysFanTableEntry 2 }
