### PR TITLE
Use nvidia-smi to get GPUCoreTemp

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -796,9 +796,14 @@ if inpath chronyc; then
     run_cached -s chrony 30 "waitmax 5 chronyc -n tracking | cat || true"
 fi
 
+if inpath nvidia-smi; then
+    echo '<<<nvidia-smi>>>'
+    waitmax 2 nvidia-smi --query-gpu=temperature.gpu --format=csv,nounits,noheader | sed "s/^/GPUCoreTemp: /"
+fi
+
 if inpath nvidia-settings && [ -S /tmp/.X11-unix/X0 ]; then
-    echo '<<<nvidia>>>'
-    for var in GPUErrors GPUCoreTemp; do
+    echo '<<<nvidia-settings>>>'
+    for var in GPUErrors; do
         DISPLAY=:0 waitmax 2 nvidia-settings -t -q $var | sed "s/^/$var: /"
     done
 fi

--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -528,11 +528,14 @@ if type chronyc > /dev/null 2>&1 ; then
     run_cached -s chrony 30 "waitmax 5 chronyc tracking || true"
 fi
 
-if type nvidia-settings >/dev/null && [ -S /tmp/.X11-unix/X0 ]
-then
-    echo '<<<nvidia>>>'
-    for var in GPUErrors GPUCoreTemp
-    do
+if inpath nvidia-smi; then
+    echo '<<<nvidia-smi>>>'
+    waitmax 2 nvidia-smi --query-gpu=temperature.gpu --format=csv,nounits,noheader | sed "s/^/GPUCoreTemp: /"
+fi
+
+if inpath nvidia-settings && [ -S /tmp/.X11-unix/X0 ]; then
+    echo '<<<nvidia-settings>>>'
+    for var in GPUErrors; do
         DISPLAY=:0 waitmax 2 nvidia-settings -t -q $var | sed "s/^/$var: /"
     done
 fi

--- a/checkman/nvidia.temp
+++ b/checkman/nvidia.temp
@@ -6,15 +6,12 @@ distribution: check_mk
 description:
  This checks monitors the temperatures of the
  ambient temperatur of an NVIDIA graphics card using the
- command line tool {nvidia-settings}. The check only works
- if that tool is installed and a X server is running on
- display {:0}.
+ command line tool {nvidia-smi}. The check only works
+ if that tool is installed.
 
 item:
- The name of the sensor as reported by {nvidia-settings -q all}
+ GPUCoreTemp
 
 inventory:
  All available temperature sensors are automatically inventorized except
  for the core which is handled in nvidia.temp_core
-
-

--- a/checkman/nvidia.temp_core
+++ b/checkman/nvidia.temp_core
@@ -6,15 +6,12 @@ distribution: check_mk
 description:
  This checks monitors the temperatures of the
  GPU core temperatur of an NVIDIA graphics card using the
- command line tool {nvidia-settings}. The check only works
- if that tool is installed and a X server is running on
- display {:0}.
+ command line tool {nvidia-smi}. The check only works
+ if that tool is installed.
 
 item:
- The name of the sensor as reported by {nvidia-settings -q all}
+ GPUCoreTemp
 
 inventory:
  All available temperature sensors are automatically inventorized except
  for the core which is handled in nvidia.temp_core
-
-


### PR DESCRIPTION
nvidia-settings has the drawback that it requires an X display and it
depends on many GUI-related shared libraries such as gtk. Neither the
X display nor the shared libraries will normally be needed/used on GPU
compute clusters. nvidia-smi doesn't have such issues and is the best
choice for making script-based GPU status queries.

Note: There is no nvidia-smi equivalent to `nvidia-settings -t -q GPUErrors`, so I have left that one alone. I believe it is because this metric is related to errrors encountered by the user space driver instance associated with the X-server, so for compute clusters that do not use this, I think this metric is meaningless. This is speculation though.

nvidia-smi has several additional things that it can report that are useful. I think it would be useful to add collection of temperature.memory, memory.total, memory.free, memory.used, utilization.memory, utilization.gpu.