### PR TITLE
added option container_id:nodename_name to mk_docker.py plugin

### DIFF
--- a/agents/cfg_examples/docker.cfg
+++ b/agents/cfg_examples/docker.cfg
@@ -64,8 +64,10 @@ skip_sections: docker_node_disk_usage,docker_node_images
 # container, as well as items for services created on the node for each
 # container.
 # By default, the identifier is assumed to be the first 12 characters
-# of the container UUID. You can choose to use the full ID or the containers
-# name instead. Allowed values are "short" (the default), "long" and "name".
+# of the container UUID. You can choose to use the full ID, the container
+# name or the nodename (hostname of host running the docker daemon) concatenated
+# with the container name. e.g. hostname1_containername1
+# Allowed values are "short" (the default), "long", "name" and "nodename_name".
 container_id: name
 
 # BASE URL

--- a/agents/plugins/mk_docker.py
+++ b/agents/plugins/mk_docker.py
@@ -184,6 +184,8 @@ class MKDockerClient(docker.DockerClient):
         all_containers = self.containers.list(all=True)
         if config['container_id'] == "name":
             self.all_containers = dict([(c.attrs["Name"].lstrip('/'), c) for c in all_containers])
+		elif config['container_id'] == "nodename_name":
+            self.all_containers = dict([("%s_%s" % (c.attrs["Config"]['Hostname'], c.attrs["Name"].lstrip('/')), c) for c in all_containers])
         elif config['container_id'] == "long":
             self.all_containers = dict([(c.attrs["Id"], c) for c in all_containers])
         else:

--- a/agents/plugins/mk_docker.py
+++ b/agents/plugins/mk_docker.py
@@ -184,7 +184,7 @@ class MKDockerClient(docker.DockerClient):
         all_containers = self.containers.list(all=True)
         if config['container_id'] == "name":
             self.all_containers = dict([(c.attrs["Name"].lstrip('/'), c) for c in all_containers])
-		elif config['container_id'] == "nodename_name":
+        elif config['container_id'] == "nodename_name":
             self.all_containers = dict([("%s_%s" % (c.attrs["Config"]['Hostname'], c.attrs["Name"].lstrip('/')), c) for c in all_containers])
         elif config['container_id'] == "long":
             self.all_containers = dict([(c.attrs["Id"], c) for c in all_containers])

--- a/tests/unit/agents/plugins/test_mk_docker.py
+++ b/tests/unit/agents/plugins/test_mk_docker.py
@@ -21,7 +21,7 @@ def test_docker_plugin_version(mk_docker):
     assert md5 == PLUGIN_CHECKSUMS.get(mk_docker.VERSION), """
     Plugin source code has changed.
     If your changes are compatible to previous versions,
-    put the new md5 sum of the plugin into PLUIGIN_CHECKSUMS.
+    put the new md5 sum of the plugin into PLUGIN_CHECKSUMS.
     If your change is incompatible, increase the mk_docker.VERSION
-    and put a new entry into PLUIGIN_CHECKSUMS.
+    and put a new entry into PLUGIN_CHECKSUMS.
     """

--- a/tests/unit/agents/plugins/test_mk_docker.py
+++ b/tests/unit/agents/plugins/test_mk_docker.py
@@ -11,7 +11,7 @@ def mk_docker():
 
 
 PLUGIN_CHECKSUMS = {
-    '0.1': '5a82452c9374dec3b6b3beca042b9765',
+    '0.1': '5b3d6f5ba3d3d9655397ad8075090b69',
 }
 
 


### PR DESCRIPTION
I have many docker nodes running containers with identical name and this change in mk_docker.py allows to name every piggybacked container as nodename_name , being "nodename" the hostname of the machine running the docker daemon (and also the check_mk agent) and "name" the name of the container

I tried to use the option in Access to agents ➳ General settings ➳ Hostname translation for piggybacked hosts but it seems that I cannot add the nodename in a generic way. I asked about it in the mailing list: https://lists.mathias-kettner.de/pipermail/checkmk-en/2019-October/028898.html

This change doesn't change the default behavior of the plugin