### PR TITLE
Fix broken parsing if speed contains decimals

### DIFF
--- a/checks/lnx_if
+++ b/checks/lnx_if
@@ -172,11 +172,11 @@ def parse_lnx_if(info):
             if speed_text == '65535Mb/s':  # unknown
                 ifSpeed = ''
             elif speed_text.endswith("Kb/s"):
-                ifSpeed = int(speed_text[:-4]) * 1000
+                ifSpeed = int(float(speed_text[:-4])) * 1000
             elif speed_text.endswith("Mb/s"):
-                ifSpeed = int(speed_text[:-4]) * 1000000
+                ifSpeed = int(float(speed_text[:-4])) * 1000000
             elif speed_text.endswith("Gb/s"):
-                ifSpeed = int(speed_text[:-4]) * 1000000000
+                ifSpeed = int(float(speed_text[:-4])) * 1000000000
             else:
                 ifSpeed = ''
 


### PR DESCRIPTION
This fixes a bug where, for example, 43.67Mb/s (wifi interface) would break parsing of output.

Wifi interfaces have speeds other than 10/100/1000. Also on OSX, 1Gpbs is returned as 1.00Gb/s which breaks this as is.

This is related to another PR that fixes the OSX agent to return **lnx_is** style data about interfaces. The existing agent uses **netctr** which does not come in CMK at all because it is deprecated.