### PR TITLE
[job] adds mapping of job exit codes to check states

### DIFF
--- a/checkman/job
+++ b/checkman/job
@@ -20,7 +20,8 @@ description:
  all these data to the Check_MK server.
 
  The check is {CRITICAL} if the exit code of the job is not {0}, or if
- warning or critical limits for the job age have been reached.
+ warning or critical limits for the job age have been reached. Other mappings
+ of exit code to check state can be defined in the check parameters.
 
  Limits can be configured with WATO.
 

--- a/checks/job
+++ b/checks/job
@@ -121,10 +121,16 @@ def _process_start_time(value, warn, crit):
     return 0, display_value
 
 
-def _process_job_stats(job, age_levels):
+def _process_job_stats(job, age_levels, exit_codes):
     txt = 'Exit-Code: %d' % job['exit_code']
     state = 0
-    if job['exit_code'] != 0:
+    state_set = False
+    for exit_code, mon_state in exit_codes:
+        if job['exit_code'] == exit_code:
+            state = mon_state
+            txt += state_markers[state]
+            state_set = True
+    if not state_set and job['exit_code'] != 0:
         state = 2
         txt += ' (!!)'
     output = [txt]
@@ -173,7 +179,7 @@ def check_job(_no_item, params, nodes):
             results.append((3, '%sGot incomplete information for this job' % prefix))
             continue
 
-        state, text, perfdata = _process_job_stats(job, (warn, crit))
+        state, text, perfdata = _process_job_stats(job, (warn, crit), params.get('exit_codes', []))
         if 'running_start_time' in job:
             running_start_time = min(job['running_start_time'])
             state, display_value = _process_start_time(running_start_time, warn, crit)

--- a/checks/job
+++ b/checks/job
@@ -121,15 +121,16 @@ def _process_start_time(value, warn, crit):
     return 0, display_value
 
 
-def _process_job_stats(job, age_levels, exit_codes):
+def _process_job_stats(job, age_levels, exit_code_to_state_map):
     txt = 'Exit-Code: %d' % job['exit_code']
     state = 0
     state_set = False
-    for exit_code, mon_state in exit_codes:
+    for exit_code, mon_state in exit_code_to_state_map:
         if job['exit_code'] == exit_code:
             state = mon_state
             txt += state_markers[state]
             state_set = True
+            break
     if not state_set and job['exit_code'] != 0:
         state = 2
         txt += ' (!!)'
@@ -179,7 +180,7 @@ def check_job(_no_item, params, nodes):
             results.append((3, '%sGot incomplete information for this job' % prefix))
             continue
 
-        state, text, perfdata = _process_job_stats(job, (warn, crit), params.get('exit_codes', []))
+        state, text, perfdata = _process_job_stats(job, (warn, crit), params.get('exit_code_to_state_map', []))
         if 'running_start_time' in job:
             running_start_time = min(job['running_start_time'])
             state, display_value = _process_start_time(running_start_time, warn, crit)

--- a/cmk/gui/plugins/wato/check_parameters/job.py
+++ b/cmk/gui/plugins/wato/check_parameters/job.py
@@ -59,7 +59,6 @@ def _parameter_valuespec_job():
                      MonitoringState(title=_("Resulting state"),),
                  ],
                  default_value=(0, 0)),
-             ),
              title = _("Map exit codes"),
          )),
         ("outcome_on_cluster",

--- a/cmk/gui/plugins/wato/check_parameters/job.py
+++ b/cmk/gui/plugins/wato/check_parameters/job.py
@@ -50,6 +50,18 @@ def _parameter_valuespec_job():
                  Age(title=_("Critical at"), default_value=0)
              ],
          )),
+        ("exit_codes",
+         ListOf(
+             Tuple(
+                 orientation="horizontal",
+                 elements=[
+                     Integer(title=_("Exit code")),
+                     MonitoringState(title=_("Resulting state"),),
+                 ],
+                 default_value=(0, 0)),
+             ),
+             title = _("Map exit codes"),
+         )),
         ("outcome_on_cluster",
          DropdownChoice(
              title=_("Clusters: Prefered check result of local checks"),

--- a/cmk/gui/plugins/wato/check_parameters/job.py
+++ b/cmk/gui/plugins/wato/check_parameters/job.py
@@ -50,7 +50,7 @@ def _parameter_valuespec_job():
                  Age(title=_("Critical at"), default_value=0)
              ],
          )),
-        ("exit_codes",
+        ("exit_code_to_state_map",
          ListOf(
              Tuple(
                  orientation="horizontal",
@@ -59,7 +59,12 @@ def _parameter_valuespec_job():
                      MonitoringState(title=_("Resulting state"),),
                  ],
                  default_value=(0, 0)),
-             title = _("Map exit codes"),
+             title=_("Explicit mapping of job exit codes to states"),
+             help=_("Here you can define a mapping between possible exit codes and service states. "
+                    "If no mapping is defined, the check becomes CRITICAL when the exit code is not 0. "
+                    "If an exit code occurs that is not defined in this mapping, the check becomes CRITICAL. "
+                    "If you happen to define the same exit code multiple times the first entry will be used."),
+             allow_empty=False,
          )),
         ("outcome_on_cluster",
          DropdownChoice(


### PR DESCRIPTION
In the check parameters a mapping list of exit codes to service check states can now be configured.
Not all exit codes need to result in a CRITICAL state.