### PR TITLE
Bug Fix windows_remote_alert_handler.py

### DIFF
--- a/doc/treasures/alert_handler/windows/windows_remote_alert_handler.py
+++ b/doc/treasures/alert_handler/windows/windows_remote_alert_handler.py
@@ -4,6 +4,12 @@
 # This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
 # conditions defined in the file COPYING, which is part of this source code package.
 
+from cmk.gui.cee.plugins.wato.alert_handling import (
+    register_alert_handler_parameters,)
+from cmk.gui.plugins.wato.utils import (
+    PasswordFromStore,)
+
+
 register_alert_handler_parameters(
     "windows_remote",
     Dictionary(


### PR DESCRIPTION
The import statements needed in 1.6 are missing in the WATO extension.