### PR TITLE
bug fix: Update auf 1.6.0p11 erzeugt Traceback AttributeError

### DIFF
--- a/cmk/gui/plugins/views/utils.py
+++ b/cmk/gui/plugins/views/utils.py
@@ -2026,12 +2026,18 @@ class Cell(object):
     # TODO: We really should have some intermediate "data" layer that would make it possible to
     # extract the data for the export in a cleaner way.
     def render_for_export(self, row):
+        txt = ''
         # type: (Row) -> CellContent
         rendered_txt = self.render_content(row)[1]
         if rendered_txt is None:
             return ""
+        elif isinstance(rendered_txt, (str, unicode)):
+            txt = rendered_txt.strip()  # type: Text
+        elif isinstance(rendered_txt, dict) and 'title' in rendered_txt:
+            txt = rendered_txt['title'] # type: Dictionary
 
-        txt = rendered_txt.strip()  # type: Text
+        if not txt:
+            txt = rendered_txt
 
         # Similar to the PDF rendering hack above, but this time we extract the title from our icons
         # and add them to the CSV export instead of stripping the whole HTML tag.

--- a/cmk/gui/plugins/views/utils.py
+++ b/cmk/gui/plugins/views/utils.py
@@ -2034,7 +2034,7 @@ class Cell(object):
         elif isinstance(rendered_txt, (str, unicode)):
             txt = rendered_txt.strip()  # type: Text
         elif isinstance(rendered_txt, dict) and 'title' in rendered_txt:
-            txt = rendered_txt['title']  # type: Dictionary
+            txt = rendered_txt.get('title', '')  # type: Dictionary
 
         if not txt:
             txt = rendered_txt

--- a/cmk/gui/plugins/views/utils.py
+++ b/cmk/gui/plugins/views/utils.py
@@ -2034,7 +2034,7 @@ class Cell(object):
         elif isinstance(rendered_txt, (str, unicode)):
             txt = rendered_txt.strip()  # type: Text
         elif isinstance(rendered_txt, dict) and 'title' in rendered_txt:
-            txt = rendered_txt['title'] # type: Dictionary
+            txt = rendered_txt['title']  # type: Dictionary
 
         if not txt:
             txt = rendered_txt


### PR DESCRIPTION
Update auf 1.6.0p11 erzeugt Traceback "AttributeError: 'dict'
object has no attribute 'strip'" bei Aufruf von
.../check_mk/view.py?view_name=aggr_all&output_format=python

[bug_fix_utils.py_cmk1.6.0p11_web.log_extract.txt](https://github.com/tribe29/checkmk/files/4431321/bug_fix_utils.py_cmk1.6.0p11_web.log_extract.txt)

