### PR TITLE
ibm_mq: Add timestamp in agent output.

### DIFF
--- a/agents/plugins/ibm_mq
+++ b/agents/plugins/ibm_mq
@@ -72,16 +72,17 @@ check_tool runmqsc
 
 dspmq -n | while read -r dspmqline
 do
+    now=$(date +'%Y-%m-%dT%H:%M:%S%z')
     QM=$(echo "$dspmqline" | sed 's,QMNAME(\([^)]*\).*,\1,')
     if is_qm_monitored "$QM"; then
         echo '<<<ibm_mq_channels:sep(10)>>>'
-        echo "$dspmqline"
+        echo "$dspmqline NOW($now)"
         runmqsc -e "$QM" <<EOF
 display channel(*) xmitq
 display chstatus(*)
 EOF
         echo '<<<ibm_mq_queues:sep(10)>>>'
-        echo "$dspmqline"
+        echo "$dspmqline NOW($now)"
         runmqsc -e "$QM" <<EOF
 display qlocal(*) maxdepth maxmsgl
 display qstatus(*) all

--- a/checks/ibm_mq.include
+++ b/checks/ibm_mq.include
@@ -6,7 +6,7 @@
 
 
 def parse_runmqsc_display_output(info, group_by_object):
-    re_qminfo_from_dspmq = regex(r"^QMNAME\((.*)\)[\s]*STATUS\((.*)\)")
+    re_intro = regex(r"^QMNAME\((.*)\)[\s]*STATUS\((.*?)\)[\s]*NOW\((.*)\)")
     re_group = regex(r"^AMQ\d+\w?: [^.]*.")
     re_key = regex(r"[\s]*[A-Z0-9]+\(")
     re_second_column = regex(r" [A-Z0-9]+\(")
@@ -18,31 +18,45 @@ def parse_runmqsc_display_output(info, group_by_object):
         value = pair.group(2).strip()
         attributes[key] = value
 
-    def record_group(attributes, parsed):
-        if not attributes:
-            return
+    def record_group(qmname, attributes, parsed):
         obj = attributes.get(group_by_object)
         if obj is not None and not obj.startswith(("SYSTEM", "AMQ.MQEXPLORER")):
             obj = "%s:%s" % (qmname, obj)
             parsed.setdefault(obj, {})
             parsed[obj].update(attributes)
-        attributes.clear()
 
-    attributes = {}
+    def lookahead(iterable):
+        """
+        Pass through all values from the given iterable, augmented by the
+        information if there are more values to come after the current one
+        (True), or if it is the last value (False).
+        """
+        it = iter(iterable)
+        last = next(it)
+        for val in it:
+            yield last, True
+            last = val
+        yield last, False
+
     parsed = {}
-    qmname = None
-    qmstatus = None
-    for line in info:
-        line = line[0]
-        intro_line = re_qminfo_from_dspmq.match(line)
+    attributes = {}
+    for (line,), has_more in lookahead(info):
+        intro_line = re_intro.match(line)
         if intro_line:
-            record_group(attributes, parsed)
+            if attributes:
+                record_group(qmname, attributes, parsed)
+                attributes.clear()
             qmname = intro_line.group(1)
             qmstatus = intro_line.group(2)
-            parsed.setdefault(qmname, {'STATUS': qmstatus})
-        elif re_group.match(line):
-            record_group(attributes, parsed)
-        elif re_key.match(line):
+            now = intro_line.group(3)
+            parsed[qmname] = {'STATUS': qmstatus, 'NOW': now}
+            continue
+        if re_group.match(line) or not has_more:
+            if attributes:
+                record_group(qmname, attributes, parsed)
+                attributes.clear()
+            continue
+        if re_key.match(line):
             if re_second_column.match(line[39:]):
                 first_half = line[:40]
                 second_half = line[40:]
@@ -50,7 +64,6 @@ def parse_runmqsc_display_output(info, group_by_object):
                 record_attribute(second_half, attributes, parsed)
             else:
                 record_attribute(line, attributes, parsed)
-    record_group(attributes, parsed)
     return parsed
 
 

--- a/checks/ibm_mq_queues
+++ b/checks/ibm_mq_queues
@@ -33,6 +33,8 @@
 # No commands have a syntax error.
 # All valid MQSC commands were processed.
 
+import dateutil
+
 factory_settings["ibm_mq_queues_default_levels"] = {}
 
 
@@ -65,12 +67,14 @@ def check_ibm_mq_queues(item, params, parsed):
     if "LGETDATE" in data:
         mq_date = data.get("LGETDATE")
         mq_time = data.get("LGETTIME")
-        yield ibm_mq_last_age(mq_date, mq_time, 'Last get', 'lgetage', params)
+        agent_timestamp = ibm_mq_agent_timestamp(item, parsed)
+        yield ibm_mq_last_age(mq_date, mq_time, agent_timestamp, 'Last get', 'lgetage', params)
 
     if "LPUTDATE" in data:
         mq_date = data.get("LPUTDATE")
         mq_time = data.get("LPUTTIME")
-        yield ibm_mq_last_age(mq_date, mq_time, 'Last put', 'lputage', params)
+        agent_timestamp = ibm_mq_agent_timestamp(item, parsed)
+        yield ibm_mq_last_age(mq_date, mq_time, agent_timestamp, 'Last put', 'lputage', params)
 
     if "IPPROCS" in data:
         cnt = data["IPPROCS"]
@@ -132,17 +136,18 @@ def ibm_mq_msg_age(msg_age, params):
                         infoname=label)
 
 
-def ibm_mq_last_age(mq_date, mq_time, label, key, params):
+def ibm_mq_agent_timestamp(item, parsed):
+    qmgr_name = item.split(':', 1)[0]
+    now = dateutil.parser.isoparse(parsed[qmgr_name]['NOW'])
+    return now
+
+
+def ibm_mq_last_age(mq_date, mq_time, agent_timestamp, label, key, params):
     if not (mq_date and mq_time):
         return (0, label + ": n/a", [])
-    mq_datetime = "%s %s" % (mq_date, mq_time)
-    struct = time.strptime(mq_datetime, "%Y-%m-%d %H.%M.%S")
-
-    # FIXME: The use of the local time will fail if the IBM MQ server
-    # and the Checkmk server are in different time zones.
-    input_time = time.mktime(struct)
-    reference_time = time.time()
-    age = int(reference_time - input_time)
+    mq_datetime = "%s %s" % (mq_date, mq_time.replace('.', ':'))
+    input_time = dateutil.parser.parse(mq_datetime, default=agent_timestamp)
+    age = (agent_timestamp - input_time).total_seconds()
     return check_levels(age,
                         None,
                         params.get(key),

--- a/tests-py3/unit/checks/test_ibm_mq_channels.py
+++ b/tests-py3/unit/checks/test_ibm_mq_channels.py
@@ -29,7 +29,7 @@ factory_settings["ibm_mq_channels_default_levels"] = {
 
 def test_parse(check_manager):
     lines = """\
-QMNAME(MY.TEST)                                           STATUS(RUNNING)
+QMNAME(MY.TEST)                                           STATUS(RUNNING) NOW(2020-04-03T17:27:02+0200)
 5724-H72 (C) Copyright IBM Corp. 1994, 2015.
 Starting MQSC for queue manager MY.TEST.
 
@@ -65,6 +65,7 @@ All valid MQSC commands were processed.
 
     attrs = parsed['MY.TEST']
     assert attrs['STATUS'] == 'RUNNING'
+    assert attrs['NOW'] is not None
 
     attrs = parsed['MY.TEST:HERE.TO.THERE.TWO']
     assert attrs['CHLTYPE'] == 'SDR'
@@ -79,7 +80,7 @@ All valid MQSC commands were processed.
 
 def test_parse_svrconn_with_multiple_instances(check_manager):
     lines = """\
-QMNAME(MY.TEST)                                           STATUS(RUNNING)
+QMNAME(MY.TEST)                                           STATUS(RUNNING) NOW(2020-04-03T17:27:02+0200)
 5724-H72 (C) Copyright IBM Corp. 1994, 2015.
 Starting MQSC for queue manager MY.TEST.
 

--- a/tests-py3/unit/checks/test_ibm_mq_include.py
+++ b/tests-py3/unit/checks/test_ibm_mq_include.py
@@ -28,7 +28,7 @@ def parse_info(lines, separator=None):
 class TestRunmqscParser:
     def test_normal(self):
         lines = """\
-QMNAME(FOO.BAR)                                           STATUS(ENDED UNEXPECTEDLY)
+QMNAME(FOO.BAR)                                           STATUS(ENDED UNEXPECTEDLY) NOW(2020-04-03T17:27:02+0200)
 5724-H72 (C) Copyright IBM Corp. 1994, 2015.
 Starting MQSC for queue manager FOO.BAR.
 
@@ -38,7 +38,7 @@ AMQ8146: WebSphere MQ queue manager not available.
 No MQSC commands read.
 No commands have a syntax error.
 All valid MQSC commands were processed.
-QMNAME(MY.TEST)                                           STATUS(RUNNING)
+QMNAME(MY.TEST)                                           STATUS(RUNNING) NOW(2019-04-03T17:27:02+0200)
 5724-H72 (C) Copyright IBM Corp. 1994, 2015.
 Starting MQSC for queue manager MY.TEST.
 
@@ -83,6 +83,8 @@ All valid MQSC commands were processed.
 
         assert parsed['FOO.BAR']['STATUS'] == 'ENDED UNEXPECTEDLY'
         assert parsed['MY.TEST']['STATUS'] == 'RUNNING'
+        assert parsed['FOO.BAR']['NOW'] == '2020-04-03T17:27:02+0200'
+        assert parsed['MY.TEST']['NOW'] == '2019-04-03T17:27:02+0200'
 
         attrs = parsed['MY.TEST:OTHER.LARGE.INPUT.TEST.FOR.CHECKMK']
         assert attrs['CURDEPTH'] == '1400'
@@ -94,7 +96,7 @@ All valid MQSC commands were processed.
 
     def test_multiple_queue_managers(self):
         lines = """\
-QMNAME(QM.ONE)                                            STATUS(RUNNING)
+QMNAME(QM.ONE)                                            STATUS(RUNNING) NOW(2020-04-03T17:27:02+0200)
 5724-H72 (C) Copyright IBM Corp. 1994, 2011.  ALL RIGHTS RESERVED.
 Starting MQSC for queue manager QM.ONE.
 
@@ -115,7 +117,7 @@ AMQ8450: Display queue status details.
 2 MQSC commands read.
 No commands have a syntax error.
 All valid MQSC commands were processed.
-QMNAME(QM.TWO)                                            STATUS(RUNNING)
+QMNAME(QM.TWO)                                            STATUS(RUNNING) NOW(2020-04-03T17:27:02+0200)
 5724-H72 (C) Copyright IBM Corp. 1994, 2011.  ALL RIGHTS RESERVED.
 Starting MQSC for queue manager QM.TWO.
 
@@ -146,7 +148,7 @@ All valid MQSC commands were processed.
 
     def test_empty_value_for_msgage(self):
         lines = """\
-QMNAME(MY.TEST)                                           STATUS(RUNNING)
+QMNAME(MY.TEST)                                           STATUS(RUNNING) NOW(2020-04-03T17:27:02+0200)
 5724-H72 (C) Copyright IBM Corp. 1994, 2015.
 Starting MQSC for queue manager MY.TEST.
 
@@ -174,7 +176,7 @@ All valid MQSC commands were processed.
 
     def test_no_channel_status_of_inactive_channels(self):
         lines = """\
-QMNAME(MY.TEST)                                           STATUS(RUNNING)
+QMNAME(MY.TEST)                                           STATUS(RUNNING) NOW(2020-04-03T17:27:02+0200)
 5724-H72 (C) Copyright IBM Corp. 1994, 2015.
 Starting MQSC for queue manager MY.TEST.
 
@@ -193,7 +195,7 @@ One valid MQSC command could not be processed.
 
     def test_mq9_includes_severity_in_message_code(self):
         lines = """\
-QMNAME(MY.TEST)                                           STATUS(RUNNING)
+QMNAME(MY.TEST)                                           STATUS(RUNNING) NOW(2020-04-03T17:27:02+0200)
 5724-H72 (C) Copyright IBM Corp. 1994, 2018.
 Starting MQSC for queue manager MY.TEST.
 

--- a/tests/unit/agents/plugins/test_ibm_mq.sh
+++ b/tests/unit/agents/plugins/test_ibm_mq.sh
@@ -75,17 +75,17 @@ test_is_qm_monitored_full_config() {
 test_monitored_qm() {
     ONLY_QM="BAR TEE"
     mock_dspmq="QMNAME(TEE)                                           STATUS(RUNNING)"
-    actual=$(. "$IBM_PLUGIN_PATH")
+    actual=$(. "$IBM_PLUGIN_PATH" | sed 's/NOW([^)]*)/NOW(timestamp)/')
     expected="\
 <<<ibm_mq_plugin:sep(58)>>>
 version: 1.6.0
 dspmq: OK
 runmqsc: OK
 <<<ibm_mq_channels:sep(10)>>>
-QMNAME(TEE)                                           STATUS(RUNNING)
+QMNAME(TEE)                                           STATUS(RUNNING) NOW(timestamp)
 
 <<<ibm_mq_queues:sep(10)>>>
-QMNAME(TEE)                                           STATUS(RUNNING)
+QMNAME(TEE)                                           STATUS(RUNNING) NOW(timestamp)
 
 <<<ibm_mq_managers:sep(10)>>>
 QMNAME(TEE)                                           STATUS(RUNNING)"


### PR DESCRIPTION
IBM MQ outputs the last get/put timestamp for a queue in the local timezone of the queue manager, see [Inquire Queue Status (Response)](https://www.ibm.com/support/knowledgecenter/SSFKSJ_9.1.0/com.ibm.mq.ref.adm.doc/q087890_.htm). Now the age calculation is correct even if the agent and checkmk server are not running in the same timezone.

Removes a FIXME that Tom Bärwinkel added in the code.