### PR TITLE
BUG: snapvault/snapmirror changed to destination-location

### DIFF
--- a/cmk/special_agents/agent_netapp.py
+++ b/cmk/special_agents/agent_netapp.py
@@ -1048,13 +1048,13 @@ def process_clustermode(args, server, netapp_mode, licenses):
         print(
             format_config(snapmirror_info,
                           "snapvault",
-                          "destination-volume",
+                          "destination-location",
                           config_report=[
-                              "destination-volume-node", "policy", "mirror-state", "source-vserver",
-                              "lag-time", "relationship-status"
+                              "destination-vserver", "policy", "mirror-state", "source-vserver",
+                              "lag-time", "relationship-status", "is-healthy"
                           ],
                           config_rename={
-                              "destination-volume-node": "destination-system",
+                              "destination-vserver": "destination-system",
                               "mirror-state": "state",
                               "source-vserver": "source-system",
                               "relationship-status": "status"


### PR DESCRIPTION
as unique key. The unique key used before "destination-volume" is only available if the snapvault/snapmirror is done from a volume and not a SVM.
"destination-volume-node" was replaced with "destination-vserver" for the same reason only available for volume and not SVM. 

-Incompatible change-
A rediscovery is needed as the service description changes.
