### PR TITLE
Use just one instance of xinetd for check_mk to prevent high load

### DIFF
--- a/agents/cfg_examples/xinetd.conf
+++ b/agents/cfg_examples/xinetd.conf
@@ -11,6 +11,7 @@ service check_mk
 	wait           = no
 	user           = root
 	server         = /usr/bin/check_mk_agent
+	instances      = 1
 
         # listen on IPv4 AND IPv6 when available on this host
         #flags          = IPv6

--- a/agents/cfg_examples/xinetd.conf
+++ b/agents/cfg_examples/xinetd.conf
@@ -11,7 +11,7 @@ service check_mk
 	wait           = no
 	user           = root
 	server         = /usr/bin/check_mk_agent
-	instances      = 1
+	per_source      = 3
 
         # listen on IPv4 AND IPv6 when available on this host
         #flags          = IPv6


### PR DESCRIPTION
Use just one instance of xinetd for check_mk to prevent high load
Maybe it's a better default example for most cases.