### PR TITLE
bugfix Werk 7966: allow rule hosttag operators or and nor, too.

### DIFF
--- a/cmk/gui/plugins/webapi/webapi.py
+++ b/cmk/gui/plugins/webapi/webapi.py
@@ -875,10 +875,16 @@ class APICallHosttags(APICallCollection):
                     if isinstance(tag_spec, dict):
                         if "$ne" in tag_spec:
                             used_tags.add((tag_group_id, tag_spec["$ne"]))
-                            continue
-                        raise NotImplementedError()
-
-                    used_tags.add((tag_group_id, tag_spec))
+                        else:
+                            for _oper in ('$or', '$nor'):
+                                if _oper in tag_spec:
+                                    for _tag in tag_spec[_oper]:
+                                        used_tags.add((tag_group_id, _tag))
+                                    break
+                            else:
+                                raise NotImplementedError()
+                    else:
+                        used_tags.add((tag_group_id, tag_spec))
 
         return used_tags
 


### PR DESCRIPTION
It was not possible to set_hosttags via WEBAPI call if rules with
hosttags and operator "one of" and/or "none of" are used. This
caused a NotImplementedError in webapi.py function
_get_used_tags_from_rules()