### PR TITLE
apache_status: New Feature free Naming of Instances

### DIFF
--- a/agents/cfg_examples/apache_status.cfg
+++ b/agents/cfg_examples/apache_status.cfg
@@ -6,22 +6,30 @@
 # Note: you need this file only if the autodetection fails
 # or you do not want to contact all servers it detects
 
+#ENABLE_OMD_SITE_DETECTION = True
+#
+#CUSTOM_ADDRESS_OVERWRITE = {
+#    '127.0.0.1:5000' : "instance name",
+
+#}
 # Note: Activate this only if the autodetection fails.
 #servers = [
 #{
 # 'protocol' : 'http',
 # 'address'  : 'localhost',
 # 'port'     : 80 ,
-#},
-#{
-# 'protocol' : 'http',
-# 'address'  : 'localhost',
-# 'port'     : 8080 ,
+# 'instance' : 'Your instance name', # optional
 #},
 #{
 # 'protocol' : 'https',
 # 'address'  : 'localhost',
 # 'port'     : 443 ,
 #},
+#{
+# 'protocol' : 'https',
+# 'address'  : 'external-host',
+# 'port'     : 443 ,
+# 'cafile'   : '/path/to/cafile', # optional
+#},
 #]
-
+#

--- a/agents/plugins/apache_status
+++ b/agents/plugins/apache_status
@@ -51,8 +51,21 @@ def get_config():
         "ssl_ports": [443],
     }
     if os.path.exists(config_file):
-        exec(open(config_file).read(), config)
+        exec (open(config_file).read(), config)
     return config
+
+
+def get_instance_name(host, port_nr, conf):
+    """
+    Get Instance name either from config
+    or from detected sites
+    """
+    search = "%s:%s" % (host, port_nr)
+    if search in conf['custom']:
+        return conf['custom'][search]
+    if 'omd_sites' in conf:
+        return conf['omd_sites'].get(search, host)
+    return ""
 
 
 def try_detect_servers(ssl_ports):
@@ -142,13 +155,27 @@ def get_response(proto, cafile, address, portspec, page):
         elif proto == "https" and is_local:
             return urllib2.urlopen(request, context=get_ssl_no_verify_context())
         return urllib2.urlopen(request)
-    except urllib2.URLError, exc:
+    except urllib2.URLError as exc:
         if 'unknown protocol' in str(exc):
             # HACK: workaround misconfigurations where port 443 is used for
             # serving non ssl secured http
             url = 'http://%s%s/server-status?auto' % (address, portspec)
             return urllib2.urlopen(url)
         raise
+
+
+def get_instance_name_map(cfg):
+    instance_name_map = {'custom': cfg.get("CUSTOM_ADDRESS_OVERWRITE", {})}
+    if cfg.get('ENABLE_OMD_SITE_DETECTION') and os.path.exists('/usr/bin/omd'):
+        for line in os.popen('omd sites').readlines():
+            sitename = line.split()[0]
+            path = "/opt/omd/sites/%s/etc/apache/listen-port.conf" % sitename
+            with open(path) as site_cfg_handle:  #pylint: disable=W0141
+                site_raw_conf = site_cfg_handle.readlines()
+                site_conf = site_raw_conf[-2].strip().split()[1]
+                instance_name_map.setdefault('omd_sites', {})
+                instance_name_map['omd_sites'][site_conf] = sitename
+    return instance_name_map
 
 
 def main():
@@ -175,12 +202,13 @@ def main():
                 if line.lstrip()[0] == '<':
                     # Seems to be html output. Skip this server.
                     break
-
+                if not name:
+                    name = get_instance_name(address, port, get_instance_name_map(config))
                 sys.stdout.write("%s|%s|%s|%s\n" % (address, port, name, line))
-        except urllib2.HTTPError, exc:
+        except urllib2.HTTPError as exc:
             sys.stderr.write('HTTP-Error (%s%s): %s %s\n' % (address, portspec, exc.code, exc))
 
-        except Exception, exc:  # pylint: disable=broad-except
+        except Exception as exc:  # pylint: disable=broad-except
             sys.stderr.write('Exception (%s%s): %s\n' % (address, portspec, exc))
 
     return 0


### PR DESCRIPTION
It's possible in three ways:

 - Autodetection by OMD Configuration
 - Overwrite of automatically detected instances
 - Setting an Instance Name for manual configured

If enabled in apache_status.cfg by setting ENABLE_OMD_SITE_DETECTION to True,
the Name for server instances are translated to OMD site names if the ip and port
match the omd config

To Overwrite instance names by preconfigured values, use CUSTOM_ADDRESS_OVERWRITE
in apache_status.cfg. Use Host/IP:Port as key, the new name as the value

CUSTOM_ADDRESS_OVERWRITE = {
    '127.0.0.1:5000' : "omd_site_mon",
}

In Custom server configurations use the key 'instance' to set a custom Name

servers = [
{
 'protocol' : 'http',
 'address'  : 'localhost',
 'port'     : 80 ,
 'instance' : "my-webserver"
},
]