### PR TITLE
Linux Agent: Clean up handling of GNU 'stat' 5.3 issue (cont'd)

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -78,11 +78,39 @@ else
     unset IS_LXC_CONTAINER
 fi
 
+# Function to list CIFS mounts for use by section_nfs
+get_cifs_mounts() {
+    if [ -r /proc/mounts ]; then
+        sed -n '/ cifs\? /s/[^ ]* \([^ ]*\) .*/\1/p' < /proc/mounts | sed 's/\\040/ /g'
+    else
+        mount | awk '/ cifs/{print $3;}'
+    fi
+}
+
+# Function to list NFS mounts for use by section_nfs
+get_nfs_mounts() {
+    if [ -r /proc/mounts ]; then
+        sed -n '/ nfs4\? /s/[^ ]* \([^ ]*\) .*/\1/p' < /proc/mounts | sed 's/\\040/ /g'
+    else
+        mount | awk '/ nfs/{print $3;}'
+    fi
+}
+
 # Function to replace "if type [somecmd]" idiom
 # 'command -v' tends to be more robust vs 'which' and 'type' based tests
 inpath() {
     command -v "${1:?No command to test}" >/dev/null 2>&1
 }
+
+# 'coreutils' 5.3.0 broke how 'stat' handled its output.  This was reverted
+# in 5.9.4 STABLE.  Just in case we happen across this particular version
+# we catch it and build a workaround to correct its behaviour globally
+# See: https://lists.gnu.org/archive/html/bug-coreutils/2005-12/msg00157.html
+if stat --version 2>&1 | head -n 1 | grep "5.3.0" >/dev/null 2>&1; then
+    stat() {
+        printf -- '%s\n' "$(command stat "${@}")"
+    }
+fi
 
 # Prefer (relatively) new /usr/bin/timeout from coreutils against
 # our shipped waitmax. waitmax is statically linked and crashes on
@@ -105,14 +133,8 @@ if [ -f "$MK_CONFDIR/exclude_sections.cfg" ]; then
 fi
 
 if [ "$ENCRYPTED" == "yes" ]; then
-    OPENSSL_VERSION=$(openssl version | awk '{print $2}' | awk -F . '{print (($1 * 100) + $2) * 100+ $3}')
-    if [ $OPENSSL_VERSION -ge 10000 ]; then
-        echo -n "02"
-        exec > >(openssl enc -aes-256-cbc -md sha256 -k "$PASSPHRASE" -nosalt)
-    else
-        echo -n "00"
-        exec > >(openssl enc -aes-256-cbc -md md5 -k "$PASSPHRASE" -nosalt)
-    fi
+    echo -n "00" # protocol version
+    exec > >(openssl enc -aes-256-cbc -md md5 -k "$PASSPHRASE" -nosalt)
 fi
 
 RTC_PLUGINS=""
@@ -144,10 +166,37 @@ section_mem() {
     else
         echo '<<<docker_container_mem>>>'
         cat /sys/fs/cgroup/memory/memory.stat
-        echo "usage_in_bytes $(cat /sys/fs/cgroup/memory/memory.usage_in_bytes)"
-        echo "limit_in_bytes $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)"
+        echo -n "usage_in_bytes "
+        cat /sys/fs/cgroup/memory/memory.usage_in_bytes
+        echo -n "limit_in_bytes "
+        cat /sys/fs/cgroup/memory/memory.limit_in_bytes
         grep -F 'MemTotal:' /proc/meminfo
     fi
+}
+
+section_nfs() {
+    # Check NFS mounts by accessing them with stat -f (System call statfs()). 
+    # If this lasts more then 2 seconds we consider it as hanging. We need waitmax.
+    if inpath waitmax; then
+        echo '<<<nfsmounts>>>'
+        get_nfs_mounts | while read -r mountPoint; do
+            waitmax -s 9 5 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
+            || echo "${mountPoint} hanging 0 0 0 0"
+        done
+
+        echo '<<<cifsmounts>>>'
+        get_cifs_mounts | while read -r mountPoint; do
+            if [ ! -r "${mountPoint}" ]; then
+                echo "${mountPoint} Permission denied"
+            else
+                waitmax -s 9 2 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
+                    || echo "${mountPoint} hanging 0 0 0 0"
+            fi
+        done
+    fi
+
+    # Clean up our function variables
+    unset mountPoint
 }
 
 section_cpu() {
@@ -165,7 +214,6 @@ section_cpu() {
             cat /proc/sys/kernel/threads-max
         fi
     else
-
         if [ -n "$IS_DOCKERIZED" ]; then
             echo '<<<docker_container_cpu>>>'
         else
@@ -219,13 +267,10 @@ section_df() {
     echo '[df_inodes_end]'
 }
 
-sections_systemd() {
+section_systemd() {
     if inpath systemctl; then
         echo '<<<systemd_units>>>'
-        echo "[list-unit-files]"
-        systemctl list-unit-files --no-pager
-        echo "[all]"
-        systemctl --all --no-pager | sed '/^$/q'
+        systemctl --all --no-pager
     fi
 }
 
@@ -1458,7 +1503,7 @@ run_local_checks
 run_plugins
 
 # Agent output snippets created by cronjobs, etc.
-if [ -d "$SPOOLDIR" ] && [ -r "$SPOOLDIR" ]; then
+if [ -d "$SPOOLDIR" ]; then
     pushd "$SPOOLDIR" >/dev/null
     now=$(date +%s)
 

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -133,8 +133,14 @@ if [ -f "$MK_CONFDIR/exclude_sections.cfg" ]; then
 fi
 
 if [ "$ENCRYPTED" == "yes" ]; then
-    echo -n "00" # protocol version
-    exec > >(openssl enc -aes-256-cbc -md md5 -k "$PASSPHRASE" -nosalt)
+    OPENSSL_VERSION=$(openssl version | awk '{print $2}' | awk -F . '{print (($1 * 100) + $2) * 100+ $3}')
+    if [ $OPENSSL_VERSION -ge 10000 ]; then
+        echo -n "02"
+        exec > >(openssl enc -aes-256-cbc -md sha256 -k "$PASSPHRASE" -nosalt)
+    else
+        echo -n "00"
+        exec > >(openssl enc -aes-256-cbc -md md5 -k "$PASSPHRASE" -nosalt)
+    fi
 fi
 
 RTC_PLUGINS=""
@@ -166,10 +172,8 @@ section_mem() {
     else
         echo '<<<docker_container_mem>>>'
         cat /sys/fs/cgroup/memory/memory.stat
-        echo -n "usage_in_bytes "
-        cat /sys/fs/cgroup/memory/memory.usage_in_bytes
-        echo -n "limit_in_bytes "
-        cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+        echo "usage_in_bytes $(cat /sys/fs/cgroup/memory/memory.usage_in_bytes)"
+        echo "limit_in_bytes $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)"
         grep -F 'MemTotal:' /proc/meminfo
     fi
 }
@@ -270,7 +274,10 @@ section_df() {
 section_systemd() {
     if inpath systemctl; then
         echo '<<<systemd_units>>>'
-        systemctl --all --no-pager
+        echo "[list-unit-files]"
+        systemctl list-unit-files --no-pager
+        echo "[all]"
+        systemctl --all --no-pager | sed '/^$/q'
     fi
 }
 
@@ -1503,7 +1510,7 @@ run_local_checks
 run_plugins
 
 # Agent output snippets created by cronjobs, etc.
-if [ -d "$SPOOLDIR" ]; then
+if [ -d "$SPOOLDIR" ] && [ -r "$SPOOLDIR" ]; then
     pushd "$SPOOLDIR" >/dev/null
     now=$(date +%s)
 

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -78,6 +78,12 @@ else
     unset IS_LXC_CONTAINER
 fi
 
+# Function to replace "if type [somecmd]" idiom
+# 'command -v' tends to be more robust vs 'which' and 'type' based tests
+inpath() {
+    command -v "${1:?No command to test}" >/dev/null 2>&1
+}
+
 # Function to list CIFS mounts for use by section_nfs
 get_cifs_mounts() {
     if [ -r /proc/mounts ]; then
@@ -103,7 +109,8 @@ semver_to_int() {
     _sem_ver="${1:?No version number supplied}"
 
     # Strip the variable of any non-numerics or dots
-    _sem_ver="$(echo "${_sem_ver}" | sed 's/[^0-9.]//g')"
+    # Portable version if needed: "$(echo "${_sem_ver}" | sed 's/[^0-9.]//g')"
+    _sem_ver="${_sem_ver/[^0-9.]//}"
 
     # Swap the dots for spaces and assign the outcome to the positional param array
     # We want word splitting here, so we disable shellcheck's complaints

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -78,39 +78,11 @@ else
     unset IS_LXC_CONTAINER
 fi
 
-# Function to list CIFS mounts for use by section_nfs
-get_cifs_mounts() {
-    if [ -r /proc/mounts ]; then
-        sed -n '/ cifs\? /s/[^ ]* \([^ ]*\) .*/\1/p' < /proc/mounts | sed 's/\\040/ /g'
-    else
-        mount | awk '/ cifs/{print $3;}'
-    fi
-}
-
-# Function to list NFS mounts for use by section_nfs
-get_nfs_mounts() {
-    if [ -r /proc/mounts ]; then
-        sed -n '/ nfs4\? /s/[^ ]* \([^ ]*\) .*/\1/p' < /proc/mounts | sed 's/\\040/ /g'
-    else
-        mount | awk '/ nfs/{print $3;}'
-    fi
-}
-
 # Function to replace "if type [somecmd]" idiom
 # 'command -v' tends to be more robust vs 'which' and 'type' based tests
 inpath() {
     command -v "${1:?No command to test}" >/dev/null 2>&1
 }
-
-# 'coreutils' 5.3.0 broke how 'stat' handled its output.  This was reverted
-# in 5.9.4 STABLE.  Just in case we happen across this particular version
-# we catch it and build a workaround to correct its behaviour globally
-# See: https://lists.gnu.org/archive/html/bug-coreutils/2005-12/msg00157.html
-if stat --version 2>&1 | head -n 1 | grep "5.3.0" >/dev/null 2>&1; then
-    stat() {
-        printf -- '%s\n' "$(command stat "${@}")"
-    }
-fi
 
 # Prefer (relatively) new /usr/bin/timeout from coreutils against
 # our shipped waitmax. waitmax is statically linked and crashes on
@@ -178,31 +150,6 @@ section_mem() {
     fi
 }
 
-section_nfs() {
-    # Check NFS mounts by accessing them with stat -f (System call statfs()). 
-    # If this lasts more then 2 seconds we consider it as hanging. We need waitmax.
-    if inpath waitmax; then
-        echo '<<<nfsmounts>>>'
-        get_nfs_mounts | while read -r mountPoint; do
-            waitmax -s 9 5 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
-            || echo "${mountPoint} hanging 0 0 0 0"
-        done
-
-        echo '<<<cifsmounts>>>'
-        get_cifs_mounts | while read -r mountPoint; do
-            if [ ! -r "${mountPoint}" ]; then
-                echo "${mountPoint} Permission denied"
-            else
-                waitmax -s 9 2 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
-                    || echo "${mountPoint} hanging 0 0 0 0"
-            fi
-        done
-    fi
-
-    # Clean up our function variables
-    unset mountPoint
-}
-
 section_cpu() {
     if [ "$(uname -m)" = "armv7l" ]; then
         CPU_REGEX='^processor'
@@ -218,6 +165,7 @@ section_cpu() {
             cat /proc/sys/kernel/threads-max
         fi
     else
+
         if [ -n "$IS_DOCKERIZED" ]; then
             echo '<<<docker_container_cpu>>>'
         else
@@ -271,7 +219,7 @@ section_df() {
     echo '[df_inodes_end]'
 }
 
-section_systemd() {
+sections_systemd() {
     if inpath systemctl; then
         echo '<<<systemd_units>>>'
         echo "[list-unit-files]"

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -296,24 +296,24 @@ section_nfs_mounts() {
     # If this lasts more then 2 seconds we consider it as hanging. We need waitmax.
     if inpath waitmax; then
         echo '<<<nfsmounts>>>'
-        get_nfs_mounts | while read -r mountPoint; do
-            waitmax -s 9 5 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
-            || echo "${mountPoint} hanging 0 0 0 0"
+        get_nfs_mounts | while read -r _mount_point; do
+            waitmax -s 9 5 stat -f -c "${_mount_point} ok %b %f %a %s" "${_mount_point}" ||
+                echo "${_mount_point} hanging 0 0 0 0"
         done
 
         echo '<<<cifsmounts>>>'
-        get_cifs_mounts | while read -r mountPoint; do
-            if [ ! -r "${mountPoint}" ]; then
-                echo "${mountPoint} Permission denied"
+        get_cifs_mounts | while read -r _mount_point; do
+            if [ ! -r "${_mount_point}" ]; then
+                echo "${_mount_point} Permission denied"
             else
-                waitmax -s 9 2 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
-                    || echo "${mountPoint} hanging 0 0 0 0"
+                waitmax -s 9 2 stat -f -c "${_mount_point} ok %b %f %a %s" "${_mount_point}" ||
+                    echo "${_mount_point} hanging 0 0 0 0"
             fi
         done
     fi
 
     # Clean up our function variables
-    unset mountPoint
+    unset -v _mount_point
 }
 
 section_mounts() {

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -106,10 +106,29 @@ inpath() {
 # in 5.9.4 STABLE.  Just in case we happen across this particular version
 # we catch it and build a workaround to correct its behaviour globally
 # See: https://lists.gnu.org/archive/html/bug-coreutils/2005-12/msg00157.html
-if stat --version 2>&1 | head -n 1 | grep "5.3.0" >/dev/null 2>&1; then
-    stat() {
-        printf -- '%s\n' "$(command stat "${@}")"
-    }
+
+# In the future, we should control this behaviour with 'MK_STAT_BUG'
+# This should be coupled with an `is_true()` function i.e. `if is_true "${MK_STAT_BUG}"; then`
+# For now, this will just pass straight through
+if [ -z "${MK_STAT_BUG+x}" ]||[ "${MK_STAT_BUG}" = "true" ]; then
+    if stat --version 2>&1 | grep -q GNU; then
+        # The following sequence of transformations converts a semantic version to an integer
+        # Where the Major number is untouched, and the Minor and Patch numbers are zero padded
+        # e.g. 'stat (GNU coreutils) 8.28' --> '82800'
+        # This technique allows us to do simple integer based version comparisons
+        stat_version=$(stat --version | head -n 1)
+        stat_version="${stat_version//[!0-9.]/}"
+        # We want word splitting here so that 'set' assigns each 'word' appropriately
+        # shellcheck disable=SC2086
+        set -- ${stat_version//./ }
+        stat_version="${1}$(printf -- '%02d' "${2}" "${3:-0}")"
+
+        if [ "${stat_version}" -ge 50300 ] && [ "${stat_version}" -lt 50904 ]; then
+            stat() {
+                printf -- '%s\n' "$(command stat "${@}")"
+            }
+        fi
+    fi
 fi
 
 # Prefer (relatively) new /usr/bin/timeout from coreutils against

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -109,13 +109,13 @@ semver_to_int() {
     _sem_ver="${1:?No version number supplied}"
 
     # Strip the variable of any non-numerics or dots
-    # Portable version if needed: "$(echo "${_sem_ver}" | sed 's/[^0-9.]//g')"
-    _sem_ver="${_sem_ver/[^0-9.]//}"
+    # Portable version: _sem_ver="$(echo "${_sem_ver}" | sed 's/[^0-9.]//g')"
+    _sem_ver="${_sem_ver//[!0-9.]/}"
 
     # Swap the dots for spaces and assign the outcome to the positional param array
     # We want word splitting here, so we disable shellcheck's complaints
-    # shellcheck disable=SC2046
-    set -- $(echo "${_sem_ver}" | tr '.' ' ')
+    # shellcheck disable=SC2086
+    set -- ${_sem_ver//./ }
 
     # Assemble and print our integer
     printf -- '%d%02d%02d' "${1}" "${2:-0}" "${3:-0}"

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -292,38 +292,28 @@ section_zfs() {
 }
 
 section_nfs_mounts() {
+    # Check NFS mounts by accessing them with stat -f (System call statfs()). 
+    # If this lasts more then 2 seconds we consider it as hanging. We need waitmax.
     if inpath waitmax; then
-        STAT_VERSION=$(stat --version | head -1 | cut -d" " -f4)
-        STAT_BROKE="5.3.0"
-
         echo '<<<nfsmounts>>>'
-        sed -n '/ nfs4\? /s/[^ ]* \([^ ]*\) .*/\1/p' </proc/mounts |
-            sed 's/\\040/ /g' |
-            while read -r MP; do
-                if [ "$STAT_VERSION" != "$STAT_BROKE" ]; then
-                    waitmax -s 9 5 stat -f -c "$MP ok %b %f %a %s" "$MP" ||
-                        echo "$MP hanging 0 0 0 0"
-                else
-                    waitmax -s 9 5 stat -f -c "$MP ok %b %f %a %s" "$MP" &&
-                        printf '\n' || echo "$MP hanging 0 0 0 0"
-                fi
-            done
+        get_nfs_mounts | while read -r mountPoint; do
+            waitmax -s 9 5 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
+            || echo "${mountPoint} hanging 0 0 0 0"
+        done
 
         echo '<<<cifsmounts>>>'
-        sed -n '/ cifs\? /s/[^ ]* \([^ ]*\) .*/\1/p' </proc/mounts |
-            sed 's/\\040/ /g' |
-            while read -r MP; do
-                if [ ! -r "$MP" ]; then
-                    echo "$MP Permission denied"
-                elif [ "$STAT_VERSION" != "$STAT_BROKE" ]; then
-                    waitmax -s 9 2 stat -f -c "$MP ok %b %f %a %s" "$MP" ||
-                        echo "$MP hanging 0 0 0 0"
-                else
-                    waitmax -s 9 2 stat -f -c "$MP ok %b %f %a %s" "$MP" &&
-                        printf '\n' || echo "$MP hanging 0 0 0 0"
-                fi
-            done
+        get_cifs_mounts | while read -r mountPoint; do
+            if [ ! -r "${mountPoint}" ]; then
+                echo "${mountPoint} Permission denied"
+            else
+                waitmax -s 9 2 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
+                    || echo "${mountPoint} hanging 0 0 0 0"
+            fi
+        done
     fi
+
+    # Clean up our function variables
+    unset mountPoint
 }
 
 section_mounts() {

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -96,39 +96,51 @@ get_nfs_mounts() {
     fi
 }
 
-# Function to replace "if type [somecmd]" idiom
-# 'command -v' tends to be more robust vs 'which' and 'type' based tests
-inpath() {
-    command -v "${1:?No command to test}" >/dev/null 2>&1
+# Convert a three number style semantic version number to an integer for version comparisons
+# This zero pads, to double digits, the second and third numbers and removes any non-numerical chars
+# e.g. 'openssl 1.0.2k-fips' -> '10002'
+semver_to_int() {
+    _sem_ver="${1:?No version number supplied}"
+
+    # Strip the variable of any non-numerics or dots
+    _sem_ver="$(echo "${_sem_ver}" | sed 's/[^0-9.]//g')"
+
+    # Swap the dots for spaces and assign the outcome to the positional param array
+    # We want word splitting here, so we disable shellcheck's complaints
+    # shellcheck disable=SC2046
+    set -- $(echo "${_sem_ver}" | tr '.' ' ')
+
+    # Assemble and print our integer
+    printf -- '%d%02d%02d' "${1}" "${2:-0}" "${3:-0}"
+
+    unset -v _sem_ver
 }
 
-# 'coreutils' 5.3.0 broke how 'stat' handled its output.  This was reverted
-# in 5.9.4 STABLE.  Just in case we happen across this particular version
-# we catch it and build a workaround to correct its behaviour globally
+# GNU 'coreutils' 5.3.0 broke how 'stat' handled line endings in its output.
+# This was corrected somewhere around 5.92 - 5.94 STABLE.
+# If we detect a version of GNU stat 5.x, we investigate and set MK_STAT_BUG
 # See: https://lists.gnu.org/archive/html/bug-coreutils/2005-12/msg00157.html
-
-# In the future, we should control this behaviour with 'MK_STAT_BUG'
-# This should be coupled with an `is_true()` function i.e. `if is_true "${MK_STAT_BUG}"; then`
-# For now, this will just pass straight through
-if [ -z "${MK_STAT_BUG+x}" ]||[ "${MK_STAT_BUG}" = "true" ]; then
-    if stat --version 2>&1 | grep -q GNU; then
-        # The following sequence of transformations converts a semantic version to an integer
-        # Where the Major number is untouched, and the Minor and Patch numbers are zero padded
-        # e.g. 'stat (GNU coreutils) 8.28' --> '82800'
-        # This technique allows us to do simple integer based version comparisons
-        stat_version=$(stat --version | head -n 1)
-        stat_version="${stat_version//[!0-9.]/}"
-        # We want word splitting here so that 'set' assigns each 'word' appropriately
-        # shellcheck disable=SC2086
-        set -- ${stat_version//./ }
-        stat_version="${1}$(printf -- '%02d' "${2}" "${3:-0}")"
-
-        if [ "${stat_version}" -ge 50300 ] && [ "${stat_version}" -lt 50904 ]; then
-            stat() {
-                printf -- '%s\n' "$(command stat "${@}")"
-            }
+if [ -z "${MK_STAT_BUG+x}" ]; then
+    # We only care about versions in the range [ 5.3.0 .. 5.94 ] (yes different numbering schemes)
+    if stat --version 2>&1 | grep -q "GNU.*5.[3-9]"; then
+        # Convert the version information from semantic versioning to an integer
+        stat_version=$(semver_to_int "$(stat --version 2>&1 | head -n 1)")
+        if [ "${stat_version}" -ge 50300 ] && [ "${stat_version}" -lt 59400 ]; then
+            MK_STAT_BUG="true"
+        else
+            MK_STAT_BUG="false"
         fi
+        readonly MK_STAT_BUG
+        export MK_STAT_BUG
     fi
+
+fi
+
+# If MK_STAT_BUG is true, we correct 'stat's behaviour globally
+if [ "${MK_STAT_BUG}" = "true" ]; then
+    stat() {
+        printf -- '%s\n' "$(command stat "${@}")"
+    }
 fi
 
 # Prefer (relatively) new /usr/bin/timeout from coreutils against


### PR DESCRIPTION
Hi,
continuing on from #22, which I'll close off to simplify my workflow.

The existing section for NFS and CIFS mounts individually deals with a bug in GNU `stat`, resulting in duplicated code.

This commit splits out the detection of the faulty version of `stat` and corrects it for the entire agent, giving consistent `stat` behaviour globally, which allows us to de-duplicate the NFS/CIFS code in the process. This de-duplicated code is tucked away in a new function; `section_nfs_mounts()`

This commit also adds two functions: `get_cifs_mounts()` and `get_nfs_mounts()` which are used by `section_nfs_mounts()` and available for use elsewhere. These provide methods for when `/proc/mounts` exists and when it doesn't.

In other words: the handling for NFS and CIFS from the AIX agent is basically 99% merged in, meaning a step towards merging the various agent scripts.

Further notes/discussion/etc is available for review at #22 