### PR TITLE
Linux Agent: de-bash is_valid_plugin()

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -150,31 +150,6 @@ section_mem() {
     fi
 }
 
-section_nfs() {
-    # Check NFS mounts by accessing them with stat -f (System call statfs()). 
-    # If this lasts more then 2 seconds we consider it as hanging. We need waitmax.
-    if inpath waitmax; then
-        echo '<<<nfsmounts>>>'
-        get_nfs_mounts | while read -r mountPoint; do
-            waitmax -s 9 5 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
-            || echo "${mountPoint} hanging 0 0 0 0"
-        done
-
-        echo '<<<cifsmounts>>>'
-        get_cifs_mounts | while read -r mountPoint; do
-            if [ ! -r "${mountPoint}" ]; then
-                echo "${mountPoint} Permission denied"
-            else
-                waitmax -s 9 2 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
-                    || echo "${mountPoint} hanging 0 0 0 0"
-            fi
-        done
-    fi
-
-    # Clean up our function variables
-    unset mountPoint
-}
-
 section_cpu() {
     if [ "$(uname -m)" = "armv7l" ]; then
         CPU_REGEX='^processor'
@@ -243,7 +218,7 @@ section_df() {
     echo '[df_inodes_end]'
 }
 
-section_systemd() {
+sections_systemd() {
     if inpath systemctl; then
         echo '<<<systemd_units>>>'
         echo "[list-unit-files]"
@@ -1035,16 +1010,10 @@ run_runas_executor() {
 # does not have certain patterns within its name
 is_valid_plugin() {
     case "${1:?No plugin defined}" in
-        (*dpkg-new|*dpkg-old|*dpkg-temp)
-            return 1
-        ;;
-        (*)
-            if [ -x "${1}" ]; then
-                return 0
-            else
-                return 1
-            fi
-        ;;
+        (*dpkg-new)  return 1 ;;
+        (*dpkg-old)  return 1 ;;
+        (*dpkg-temp) return 1 ;;
+        (*)          [ -x "${1}" ] && return "${?}" ;;
     esac
 }
 

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -105,14 +105,8 @@ if [ -f "$MK_CONFDIR/exclude_sections.cfg" ]; then
 fi
 
 if [ "$ENCRYPTED" == "yes" ]; then
-    OPENSSL_VERSION=$(openssl version | awk '{print $2}' | awk -F . '{print (($1 * 100) + $2) * 100+ $3}')
-    if [ $OPENSSL_VERSION -ge 10000 ]; then
-        echo -n "02"
-        exec > >(openssl enc -aes-256-cbc -md sha256 -k "$PASSPHRASE" -nosalt)
-    else
-        echo -n "00"
-        exec > >(openssl enc -aes-256-cbc -md md5 -k "$PASSPHRASE" -nosalt)
-    fi
+    echo -n "00" # protocol version
+    exec > >(openssl enc -aes-256-cbc -md md5 -k "$PASSPHRASE" -nosalt)
 fi
 
 RTC_PLUGINS=""
@@ -144,10 +138,37 @@ section_mem() {
     else
         echo '<<<docker_container_mem>>>'
         cat /sys/fs/cgroup/memory/memory.stat
-        echo "usage_in_bytes $(cat /sys/fs/cgroup/memory/memory.usage_in_bytes)"
-        echo "limit_in_bytes $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)"
+        echo -n "usage_in_bytes "
+        cat /sys/fs/cgroup/memory/memory.usage_in_bytes
+        echo -n "limit_in_bytes "
+        cat /sys/fs/cgroup/memory/memory.limit_in_bytes
         grep -F 'MemTotal:' /proc/meminfo
     fi
+}
+
+section_nfs() {
+    # Check NFS mounts by accessing them with stat -f (System call statfs()). 
+    # If this lasts more then 2 seconds we consider it as hanging. We need waitmax.
+    if inpath waitmax; then
+        echo '<<<nfsmounts>>>'
+        get_nfs_mounts | while read -r mountPoint; do
+            waitmax -s 9 5 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
+            || echo "${mountPoint} hanging 0 0 0 0"
+        done
+
+        echo '<<<cifsmounts>>>'
+        get_cifs_mounts | while read -r mountPoint; do
+            if [ ! -r "${mountPoint}" ]; then
+                echo "${mountPoint} Permission denied"
+            else
+                waitmax -s 9 2 stat -f -c "${mountPoint} ok %b %f %a %s" "${mountPoint}" \
+                    || echo "${mountPoint} hanging 0 0 0 0"
+            fi
+        done
+    fi
+
+    # Clean up our function variables
+    unset mountPoint
 }
 
 section_cpu() {
@@ -165,7 +186,6 @@ section_cpu() {
             cat /proc/sys/kernel/threads-max
         fi
     else
-
         if [ -n "$IS_DOCKERIZED" ]; then
             echo '<<<docker_container_cpu>>>'
         else
@@ -219,13 +239,10 @@ section_df() {
     echo '[df_inodes_end]'
 }
 
-sections_systemd() {
+section_systemd() {
     if inpath systemctl; then
         echo '<<<systemd_units>>>'
-        echo "[list-unit-files]"
-        systemctl list-unit-files --no-pager
-        echo "[all]"
-        systemctl --all --no-pager | sed '/^$/q'
+        systemctl --all --no-pager
     fi
 }
 
@@ -1458,7 +1475,7 @@ run_local_checks
 run_plugins
 
 # Agent output snippets created by cronjobs, etc.
-if [ -d "$SPOOLDIR" ] && [ -r "$SPOOLDIR" ]; then
+if [ -d "$SPOOLDIR" ]; then
     pushd "$SPOOLDIR" >/dev/null
     now=$(date +%s)
 

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1031,13 +1031,21 @@ run_runas_executor() {
     fi
 }
 
+# This function ensures that a file is executable and 
+# does not have certain patterns within its name
 is_valid_plugin() {
-    # NOTE: Due to an escaping-related bug in some old bash versions
-    # (3.2.x), we have to use an intermediate variable for the pattern.
-    pattern='\.dpkg-(new|old|temp)$'
-    #TODO Maybe we should change this mechanism
-    # shellcheck disable=SC2015
-    [[ -f "$1" && -x "$1" && ! "$1" =~ $pattern ]] && true || false
+    case "${1:?No plugin defined}" in
+        (*dpkg-new|*dpkg-old|*dpkg-temp)
+            return 1
+        ;;
+        (*)
+            if [ -x "${1}" ]; then
+                return 0
+            else
+                return 1
+            fi
+        ;;
+    esac
 }
 
 run_local_checks() {

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -105,8 +105,14 @@ if [ -f "$MK_CONFDIR/exclude_sections.cfg" ]; then
 fi
 
 if [ "$ENCRYPTED" == "yes" ]; then
-    echo -n "00" # protocol version
-    exec > >(openssl enc -aes-256-cbc -md md5 -k "$PASSPHRASE" -nosalt)
+    OPENSSL_VERSION=$(openssl version | awk '{print $2}' | awk -F . '{print (($1 * 100) + $2) * 100+ $3}')
+    if [ $OPENSSL_VERSION -ge 10000 ]; then
+        echo -n "02"
+        exec > >(openssl enc -aes-256-cbc -md sha256 -k "$PASSPHRASE" -nosalt)
+    else
+        echo -n "00"
+        exec > >(openssl enc -aes-256-cbc -md md5 -k "$PASSPHRASE" -nosalt)
+    fi
 fi
 
 RTC_PLUGINS=""
@@ -138,10 +144,8 @@ section_mem() {
     else
         echo '<<<docker_container_mem>>>'
         cat /sys/fs/cgroup/memory/memory.stat
-        echo -n "usage_in_bytes "
-        cat /sys/fs/cgroup/memory/memory.usage_in_bytes
-        echo -n "limit_in_bytes "
-        cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+        echo "usage_in_bytes $(cat /sys/fs/cgroup/memory/memory.usage_in_bytes)"
+        echo "limit_in_bytes $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)"
         grep -F 'MemTotal:' /proc/meminfo
     fi
 }
@@ -242,7 +246,10 @@ section_df() {
 section_systemd() {
     if inpath systemctl; then
         echo '<<<systemd_units>>>'
-        systemctl --all --no-pager
+        echo "[list-unit-files]"
+        systemctl list-unit-files --no-pager
+        echo "[all]"
+        systemctl --all --no-pager | sed '/^$/q'
     fi
 }
 
@@ -1475,7 +1482,7 @@ run_local_checks
 run_plugins
 
 # Agent output snippets created by cronjobs, etc.
-if [ -d "$SPOOLDIR" ]; then
+if [ -d "$SPOOLDIR" ] && [ -r "$SPOOLDIR" ]; then
     pushd "$SPOOLDIR" >/dev/null
     now=$(date +%s)
 


### PR DESCRIPTION
`is_valid_plugin()` tries to be too clever, and in doing so it breaks portability.

This PR replaces it with a far simpler, more obvious and portable approach.