### PR TITLE
[Veeam Agent Plugin] Ignore Get-VBRJob warning

### DIFF
--- a/agents/windows/plugins/veeam_backup_status.ps1
+++ b/agents/windows/plugins/veeam_backup_status.ps1
@@ -38,7 +38,7 @@ foreach ($tapeJob in $tapeJobs)
 $myJobsText = "<<<veeam_jobs:sep(9)>>>`n"
 $myTaskText = ""
 
-$myBackupJobs = Get-VBRJob | where {$_.IsScheduleEnabled -eq $true }
+$myBackupJobs = Get-VBRJob -WarningAction SilentlyContinue | where {$_.IsScheduleEnabled -eq $true }
 
 foreach ($myJob in $myBackupJobs)
     {


### PR DESCRIPTION
Since Veeam 10 Get-VBRJob returns a warning which ends up in the agent output and confuses the veeam_tapejobs check. This change silently discards this warning and makes the check compatible with Veeam 10.

```
PS C:\WINDOWS\system32> $myBackupJobs = Get-VBRJob  | where {$_.IsScheduleEnabled -eq $true }
WARNING: This cmdlet is obsolete and no longer supported. To get computer backup job use "Get-VBRComputerBackupJob" instead.

PS C:\WINDOWS\system32> $myBackupJobs = Get-VBRJob  -WarningAction SilentlyContinue | where {$_.IsScheduleEnabled -eq $true }

PS C:\WINDOWS\system32> 
```