### PR TITLE
[Veeam Agent Plugin] Add agent managed Windows backup job to veeam_jobs

### DIFF
--- a/agents/windows/plugins/veeam_backup_status.ps1
+++ b/agents/windows/plugins/veeam_backup_status.ps1
@@ -144,6 +144,28 @@ foreach ($myJob in $myBackupJobs)
 
     }
 
+$myBackupJobs = Get-VBREPJob | where {$_.IsEnabled -eq $true }
+
+foreach ($myJob in $myBackupJobs)
+    {
+	$myJobName = $myJob.Name -replace "\'","_" -replace " ","_"
+
+	$myJobType = $myjob.Description
+
+	$myJobLastState = $myJob.LastState
+
+	$myJobLastResult = $myJob.LastResult
+
+	$myJobLastSession = (Get-VBREPSession -Name $myJobName)[-1]
+
+	$myJobCreationTime = $myJobLastSession.CreationTime |  get-date -Format "dd.MM.yyyy HH\:mm\:ss"  -ErrorAction SilentlyContinue
+
+	$myJobEndTime = $myJobLastSession.EndTime |  get-date -Format "dd.MM.yyyy HH\:mm\:ss"  -ErrorAction SilentlyContinue
+
+	$myJobsText = "$myJobsText" + "$myJobName" + "`t" + "$myJobType" + "`t" + "$myJobLastState" + "`t" + "$myJobLastResult" + "`t" + "$myJobCreationTime" + "`t" + "$myJobEndTime" + "`n"
+    
+    }
+
 write-host $myJobsText
 write-host $myTaskText
 }


### PR DESCRIPTION
The Veeam Agent for Windows can backup to a Veeam Backup repository without job being managed by the Veeam server. This jobs can be monitored too by using the `Get-VBREPJob` command.