### PR TITLE
Fix debian/ubuntu dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,13 +414,14 @@ setup:
 	    libsasl2-dev \
 	    libldap2-dev \
 	    libkrb5-dev \
-	    libmysqlclient-dev \
+	    libmariadb-dev-compat \
 	    pngcrush \
 	    valgrind \
 	    shellcheck \
 	    direnv \
 	    python-pip \
 	    python3.7-dev \
+	    python-setuptools \
 	    chrpath \
 	    enchant \
 	    ksh \


### PR DESCRIPTION
**mySQL** has been replaced by **MariaDB**.
**libmariadb-dev-compat** requires libmariadb-dev and provides the symlinks expected for a mySQL installation.

**python-setuptools** is required by several python dependencies including (virtualenv->pipenv->)**distlib**