### PR TITLE
Fix VictorOps webhook

### DIFF
--- a/cmk/notification_plugins/victorops.py
+++ b/cmk/notification_plugins/victorops.py
@@ -18,7 +18,7 @@ from cmk.notification_plugins.utils import host_url_from_context, service_url_fr
 
 def translate_states(state):
     if state in ['OK', 'UP']:
-        return 'OK'
+        return 'RECOVERY'
     if state in ['CRITICAL', 'DOWN']:
         return 'CRITICAL'
     if state in ['UNKNOWN', 'UNREACHABLE']:
@@ -28,7 +28,7 @@ def translate_states(state):
 
 def victorops_msg(context):
     # type: (Dict) -> Dict
-    """Build the message for slack"""
+    """Build the message for VictorOps"""
 
     if context.get('WHAT', None) == "SERVICE":
         state = translate_states(context["SERVICESTATE"])

--- a/tests-py3/unit/cmk/notifications/test_victorops.py
+++ b/tests-py3/unit/cmk/notifications/test_victorops.py
@@ -48,7 +48,7 @@ from cmk.notification_plugins.victorops import victorops_msg
         'entity_display_name': 'win7vm is UP',
         'entity_id': 'win7vm:10.3.1.239',
         'host_name': 'win7vm',
-        'message_type': 'OK',
+        'message_type': 'RECOVERY',
         'monitoring_tool': 'Check_MK notification',
         'state_message': 'Packet received via smart PING\n\nhttp://localhost/heute/check_mk/index.py?start_url=view.py%3Fview_name%3Dhoststatus%26host%3Dwin7vm%26site%3Dheute'
     })


### PR DESCRIPTION
VictorOps seems to have tightened their webhook handling: `OK` is no longer accepted as a `message_type`, according to [their webhook docs](https://help.victorops.com/knowledge-base/rest-endpoint-integration-guide/#recommended-rest-endpoint-integration-fields) it has to be `RECOVERY` instead.

As a result, VictorOps incidents no longer get resolved by checkmk. This PR fixes that.  
(It needs to be ported to the older branches, though.)