### PR TITLE
Support stock QLogic FC Switches

### DIFF
--- a/checks/qlogic_fcport
+++ b/checks/qlogic_fcport
@@ -201,12 +201,14 @@ check_info["qlogic_fcport"] = {
     # .1.3.6.1.4.1.3873.1.12 QLogic 8 Gb and 4/8 Gb Intelligent Pass-thru Module
     # .1.3.6.1.4.1.3873.1.9  QLogic SANBox 5802 FC Switch
     # .1.3.6.1.4.1.3873.1.11 HP StorageWorks 8/20q Fibre Channel Switch
+    # .1.3.6.1.4.1.1663.1.1  SANbox 5600 FC Switch
     'snmp_scan_function'    : lambda oid: \
            oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.3873.1.14") \
-        or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.3873.1.8") \
+        or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.3873.1.8")  \
         or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.3873.1.11") \
         or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.3873.1.12") \
-        or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.3873.1.9"),
+        or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.3873.1.9")  \
+        or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.1663.1.1"),
     'group':                   'qlogic_fcport',
     'default_levels_variable': 'qlogic_fcport_default_levels',
 }


### PR DESCRIPTION
Adds support for **QLogic SANbox 5600** 4Gbit/s SAN switches.
The check works fine for the standard FC ports.
These switches also got a 10gbit/s uplink port, I cannot test that one.

#### Note:

QLogic's SAN stuff has switched owners a few times it seems, so expect documentation to disappear over time.

(Also cleaned up a formatting thinggy)