### PR TITLE
[Azure Agent] Make subscription optinal

### DIFF
--- a/cmk/gui/plugins/wato/datasource_programs.py
+++ b/cmk/gui/plugins/wato/datasource_programs.py
@@ -1874,7 +1874,7 @@ def _valuespec_special_agents_azure():
                  ],
              )),
         ],
-        optional_keys=["piggyback_vms", "sequential"],
+        optional_keys=["subscription", "piggyback_vms", "sequential"],
     )
 
 


### PR DESCRIPTION
This change enabled the Azure Agent config in wato to not specify a subscription. The special agent as well as the `checks/agent_azure` are already able to function without a subscription id. We use this to Monitor the AD Sync of a tenant without a subscription. (Teams Only)