### PR TITLE
mk_oracle: Option to parallize Database queries. 

### DIFF
--- a/agents/cfg_examples/mk_oracle.cfg
+++ b/agents/cfg_examples/mk_oracle.cfg
@@ -56,3 +56,7 @@
 #REMOTE_INSTANCE_this='check_mk:mypassword::myRemoteHost:1521::MYINST1:11.2'
 #REMOTE_ORACLE_HOME='/usr/lib/oracle/11.2/client64'
 
+
+### Speed tuning. Handle n tasks parallel. The
+### Example is the default
+# MAX_TASKS=1

--- a/agents/plugins/mk_oracle
+++ b/agents/plugins/mk_oracle
@@ -32,6 +32,7 @@ load_default_config () {
     ASYNC_ASM_SECTIONS="asm_diskgroup"
     CACHE_MAXAGE=600
     OLRLOC=/etc/oracle/olr.loc
+    MAX_TASKS=1
 }
 
 #.
@@ -119,6 +120,9 @@ CONFIGURATION:
                         can use SKIP_SIDS="+ASM1 ..." instead.
                         This variable has priority 3.
                         Default is empty.
+
+  MAX_TASKS=<Number>    Specify how many SIDs to check in parallel
+                        Default is "$MAX_TASKS"
 
 CONFIGURATION REMOTE INSTANCES:
   REMOTE_INSTANCE_<id>="<user>:<password>:<role>:<host>:<port>:<piggybackhost>:<sid>:<version>:<tnsalias>"
@@ -483,7 +487,7 @@ mk_ora_mtime () {
 
 logging () {
     if $MK_ORA_LOGGING; then
-        local log_file="$MK_VARDIR/log/mk_oracle.log"
+        local log_file=${MK_VARDIR}/log/mk_oracle_task_${TASK_NR:-0}.log
         local criticality=
         local args=
         local header=
@@ -1669,9 +1673,9 @@ sql_ts_quotas () {
 sql_version () {
     echo 'PROMPT <<<oracle_version>>>'
     echo "select upper(i.INSTANCE_NAME)
-	  || ' ' || banner
-	  from v\$version, v\$instance i
-	  where banner like 'Oracle%';"
+      || ' ' || banner
+      from v\$version, v\$instance i
+      where banner like 'Oracle%';"
 }
 
 sql_systemparameter () {
@@ -1679,11 +1683,11 @@ sql_systemparameter () {
 # implement a "persist:$UNTIL" to reduce amount of data transmission
     echo "PROMPT <<<oracle_systemparameter:sep(124)>>>"
     echo "select upper(i.instance_name)
-	  || '|' || NAME
-	  || '|' || DISPLAY_VALUE
-	  || '|' || ISDEFAULT
-	  from v\$system_parameter, v\$instance i
-	  where name not like '!_%' ESCAPE '!';"
+      || '|' || NAME
+      || '|' || DISPLAY_VALUE
+      || '|' || ISDEFAULT
+      from v\$system_parameter, v\$instance i
+      where name not like '!_%' ESCAPE '!';"
 }
 
 
@@ -2112,7 +2116,7 @@ do_custom_sqls () {
         # If SID is not part of sids we can skip the rest
         if ! echo "$sids" | "${GREP}" -q "$MK_SID"; then
             logging -w "[${MK_SID}] [${section}] [custom_sql]"\
-                    "SID '${MK_SID}' is not part of stated SIDs '$sids'"
+                       "SID '${MK_SID}' is not part of stated SIDs '$sids'"
             unset_custom_sqls_vars
             continue
         fi
@@ -2130,14 +2134,14 @@ do_custom_sqls () {
 
         if [ ! -d "$sql_dir" ] || [ ! -r "$sql_dir" ] ; then
             logging -w "[${MK_SID}] [${section}] [custom_sql]"\
-                    "SQL folder '${sql_dir}' not found or not readable"
+                       "SQL folder '${sql_dir}' not found or not readable"
             unset_custom_sqls_vars
             continue
         fi
 
         if [ ! -f "${sql_dir}/$sql" ] || [ ! -r "${sql_dir}/$sql" ]; then
             logging -w "[${MK_SID}] [${section}] [custom_sql]"\
-                    "SQL file '${sql_dir}/$sql' not found or not readable"
+                       "SQL file '${sql_dir}/$sql' not found or not readable"
             unset_custom_sqls_vars
             continue
         fi
@@ -2172,7 +2176,7 @@ do_custom_sqls () {
                 local SQLS_ITEM_SID="$MK_SID"
             fi
             logging "[${MK_SID}] [${section}] [custom_sql] "\
-                    "SQLS_ITEM_SID: $SQLS_ITEM_SID"
+                    "SQLS_ITEM_SID  : $SQLS_ITEM_SID"
 
             if [ -n "$SQLS_ITEM_NAME" ]; then
                 local item="${SQLS_ITEM_SID}|${SQLS_ITEM_NAME}"
@@ -2883,7 +2887,9 @@ export -f do_async_custom_sqls
 export -f handle_custom_sql_errors
 
 if $MK_ORA_LOGGING; then
-    echo "Start logging to file: $MK_VARDIR/log/mk_oracle.log" >&2
+    # cleanup old leftovers
+    rm -f ${MK_VARDIR}/log/mk_oracle_task_*.log
+    echo "Logging to file: ${MK_VARDIR}/log/mk_oracle.log" >&2
 fi
 
 logging "--------------------------------------------------------------------"
@@ -2917,6 +2923,7 @@ logging "[preliminaries]" "SIDs: ${SIDS//\\n/ }"\
         "ASYNC_ASM_SECTIONS: ${ASYNC_ASM_SECTIONS}" "CACHE_MAXAGE: ${CACHE_MAXAGE}"\
         "ONLY_SIDS: ${ONLY_SIDS}" "SKIP_SIDS: ${SKIP_SIDS}"
 
+
 if [ "$PIGGYBACK_HOSTS" ]; then
     if [ ! -e "$MK_VARDIR/mk_oracle.found" ]; then
         touch "$MK_VARDIR/mk_oracle.found"
@@ -2944,13 +2951,8 @@ do_dummy_sections
 
 #   ---local----------------------------------------------------------------
 
-for sid in $SIDS; do
-    skip=$(skip_sid "$sid")
-    if [ "$skip" == "yes" ]; then
-        logging "[${sid}] [local]" "Skip"
-        continue
-    fi
 
+function sid_actions () {
     set_ora_env "$sid"
     if [ $? -eq 2 ] ; then
         # we have to skip this SID due to missing/unknown ORACLE_HOME
@@ -2970,7 +2972,30 @@ for sid in $SIDS; do
 
     # MK_DB_CONNECT could be changed by do_custom_sqls!
     do_custom_sqls
+
+}
+
+ORA_TMPDIR="${MK_VARDIR}/tmp/mk_oracle"
+mkdir -p ${ORA_TMPDIR}
+TASK_NR=0
+for sid in $SIDS; do
+    skip=$(skip_sid "$sid")
+    if [ "$skip" == "yes" ]; then
+        logging "[${sid}] [local]" "Skipping this SID"
+        continue
+    fi
+    ((TASK_NR++))
+    logging "[${sid}] [local] starting background task '${TASK_NR}'"
+    (sid_actions $sid > "$ORA_TMPDIR/$sid") &
+    if [[ $(jobs -r -p | wc -l) -ge ${MAX_TASKS} ]]; then
+        logging "[${sid}] [local] max parallel task running, waiting for new slot"
+        wait -n
+    fi
+
 done
+wait
+cat $ORA_TMPDIR/*
+rm -f $ORA_TMPDIR/*
 
 #   ---remote---------------------------------------------------------------
 
@@ -2992,3 +3017,8 @@ for remote_instance in $REMOTE_INSTANCES; do
     do_checks
     do_custom_sqls
 done
+
+if ${MK_ORA_LOGGING}; then
+    cat ${MK_VARDIR}/log/mk_oracle_task_*.log >> ${MK_VARDIR}/log/mk_oracle.log
+    rm -f ${MK_VARDIR}/log/mk_oracle_task_*.log
+fi

--- a/tests/agent-plugin-unit/test_mk_oracle.sh
+++ b/tests/agent-plugin-unit/test_mk_oracle.sh
@@ -87,6 +87,7 @@ test_mk_oracle_default_config () {
     assertEquals "asm_diskgroup" "$ASYNC_ASM_SECTIONS"
     assertEquals "600" "$CACHE_MAXAGE"
     assertEquals "/etc/oracle/olr.loc" "$OLRLOC"
+    assertEquals "1" $MAX_TASKS
 }
 
 
@@ -99,6 +100,7 @@ SYNC_ASM_SECTIONS=instance
 ASYNC_ASM_SECTIONS=asm_diskgroup
 CACHE_MAXAGE=300
 OLRLOC=/other/path
+MAX_TASKS=5
 EOF
 
     load_config
@@ -109,6 +111,7 @@ EOF
     assertEquals "asm_diskgroup" "$ASYNC_ASM_SECTIONS"
     assertEquals "300" "$CACHE_MAXAGE"
     assertEquals "/other/path" "$OLRLOC"
+    assertEquals "5" $MAX_TASKS
 }
 
 


### PR DESCRIPTION

New feature to specify the number of parallel SID query Tasks by
setting MAX_TASKS in config.

The Default is one but based on the performance of your system you
can run more jobs in parallel to run the mk_oralce plugin much faster.