### PR TITLE
modified windows-tasks check that it can handle all exitcodes documen…

### DIFF
--- a/checkman/windows_tasks
+++ b/checkman/windows_tasks
@@ -6,8 +6,9 @@ distribution: check_mk
 description:
  The Windows Task Scheduler Checks controlls the last return state of windows task scripts.
  The check goes to {WARNING} state, if the task is disabled. If the Script from the Task returns
- another return code as "0", "1", "267009", "267014", "267045", "-2147216609", "-2147750687"
- the Check goes {CRITICAL}.
+ another return code than documented in https://docs.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-error-and-success-constants
+ the Check goes {CRITICAL}. Some of the return codes are defined as {WARNING}, and some as {CRITICAL}. You can
+ configure the results in WATO.
  In order to run, its needed to copy the windows_tasks.ps1 script to the plugin folder of the agent.
 
 item:

--- a/checks/hitachi_hus.include
+++ b/checks/hitachi_hus.include
@@ -56,7 +56,7 @@ def check_hitachi_hus(item, _no_params, info):
     # We need to take care that the right map type is checked
     if len(info[0]) == 5:
         component = [
-            "Processor",
+            "Power Supply",
             "Fan",
             "Environment",
             "Drive",

--- a/checks/hitachi_hus.include
+++ b/checks/hitachi_hus.include
@@ -56,7 +56,7 @@ def check_hitachi_hus(item, _no_params, info):
     # We need to take care that the right map type is checked
     if len(info[0]) == 5:
         component = [
-            "Power Supply",
+            "Processor",
             "Fan",
             "Environment",
             "Drive",

--- a/checks/windows_tasks
+++ b/checks/windows_tasks
@@ -1,8 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2019 tribe29 GmbH - License: GNU General Public License v2
-# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
-# conditions defined in the file COPYING, which is part of this source code package.
+#
+# check_mk is free software;  you can redistribute it and/or modify it
+# under the  terms of the  GNU General Public License  as published by
+# the Free Software Foundation in version 2.  check_mk is  distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;  with-
+# out even the implied warranty of  MERCHANTABILITY  or  FITNESS FOR A
+# PARTICULAR PURPOSE. See the  GNU General Public License for more de-
+# tails. You should have  received  a copy of the  GNU  General Public
+# License along with GNU Make; see the file  COPYING.  If  not,  write
+# to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
+# Boston, MA 02110-1301 USA.
+
+# Author:
+# Antoine Scheffold
+# antoinescheffold@gmail.com
+
+# and checkmk team
 
 # Example output from agent:
 # <<<windows_tasks:sep(58)>>>
@@ -34,7 +48,6 @@
 #- '-2147216609': instance of this task already running -> being taken care of by the separate monitor
 #- '-2147750687': task already running -> being taken care of by the separate monitor
 
-
 def parse_windows_tasks(info):
     data = {}
     last_task = False
@@ -51,23 +64,72 @@ def parse_windows_tasks(info):
 
 
 def inventory_windows_tasks(parsed):
-    return [(n, None) for n, v in parsed.items() if v.get('Scheduled Task State') == "Enabled"]
+    return [(n, None) for n, v in parsed.items() if v.get('Scheduled Task State') != "Disabled"]
 
 
-def check_windows_tasks(item, _no_params, parsed):
+def check_windows_tasks(item, params, parsed):
     if item not in parsed:
-        yield 3, "Task not found on server"
+        yield (3, "Task not found on server")
         return
 
     map_codes = {
-        "0": "operation completed successfully",
-        "1": "task containing a popup action",
-        "267009": "currently running",
-        "267014": "terminated by user",
-        "267045": "queued",
-        "-2147216609": "an instance of the task already running",
-        "-2147750687": "task already running",
+        '0x00000000': (0, 'The task exited successfully'),
+        # '0x00000001': 'The task contained a popup action',
+        '0x00041300': (0, 'The task is ready to run at its next scheduled time.'),
+        '0x00041301': (0, 'The task is currently running.'),
+        '0x00041302': (0, 'The task will not run at the scheduled times because it has been disabled.'),
+        '0x00041303': (0, 'The task has not yet run.'),
+        '0x00041304': (0, 'There are no more runs scheduled for this task.'),
+        '0x00041305': (1, 'One or more of the properties that are needed to run this task on a schedule have not been set.'),
+        '0x00041306': (0, 'The last run of the task was terminated by the user.'),
+        '0x00041307': (1, 'Either the task has no triggers or the existing triggers are disabled or not set.'),
+        '0x00041308': (1, 'Event triggers do not have set run times.'),
+        '0x80041309': (1, 'A task\'s trigger is not found.'),
+        '0x8004130a': (1, 'One or more of the properties required to run this task have not been set.'),
+        '0x8004130b': (0, 'There is no running instance of the task.'),
+        '0x8004130c': (2, 'The Task Scheduler service is not installed on this computer.'),
+        '0x8004130d': (1, 'The task object could not be opened.'),
+        '0x8004130e': (1, 'The object is either an invalid task object or is not a task object.'),
+        '0x8004130f': (1, 'No account information could be found in the Task Scheduler security database for the task indicated.'),
+        '0x80041310': (1, 'Unable to establish existence of the account specified.'),
+        '0x80041311': (2, 'Corruption was detected in the Task Scheduler security database; the database has been reset.'),
+        '0x80041312': (1, 'Task Scheduler security services are available only on Windows NT.'),
+        '0x80041313': (1, 'The task object version is either unsupported or invalid.'),
+        '0x80041314': (1, 'The task has been configured with an unsupported combination of account settings and run time options.'),
+        '0x80041315': (1, 'The Task Scheduler Service is not running.'),
+        '0x80041316': (1, 'The task XML contains an unexpected node.'),
+        '0x80041317': (1, 'The task XML contains an element or attribute from an unexpected namespace.'),
+        '0x80041318': (1, 'The task XML contains a value which is incorrectly formatted or out of range.'),
+        '0x80041319': (1, 'The task XML is missing a required element or attribute.'),
+        '0x8004131a': (1, 'The task XML is malformed.'),
+        '0x0004131b': (1, 'The task is registered, but not all specified triggers will start the task.'),
+        '0x0004131c': (1, 'The task is registered, but may fail to start. Batch logon privilege needs to be enabled for the task principal.'),
+        '0x8004131d': (1, 'The task XML contains too many nodes of the same type.'),
+        '0x8004131e': (1, 'The task cannot be started after the trigger end boundary.'),
+        '0x8004131f': (0, 'An instance of this task is already running.'),
+        '0x80041320': (1, 'The task will not run because the user is not logged on.'),
+        '0x80041321': (1, 'The task image is corrupt or has been tampered with.'),
+        '0x80041322': (1, 'The Task Scheduler service is not available.'),
+        '0x80041323': (1, 'The Task Scheduler service is too busy to handle your request. Please try again later.'),
+        '0x80041324': (1, 'The Task Scheduler service attempted to run the task, but the task did not run due to one of the constraints in the task definition.'),
+        '0x00041325': (0, 'The Task Scheduler service has asked the task to run.'),
+        '0x80041326': (0, 'The task is disabled.'),
+        '0x80041327': (1, 'The task has properties that are not compatible with earlier versions of Windows.'),
+        '0x80041328': (1, 'The task settings do not allow the task to start on demand.'),
     }
+    sched_task_state = 1
+    if params:
+        list_state_of_exitcode, sched_task_state = params
+        if list_state_of_exitcode:
+            for state_of_exitcode in list_state_of_exitcode:
+                code, status, comment = state_of_exitcode
+                # if the exitcodes already exists, but only the MonitoringState
+                # gets changed, then take the original comment (if None) and Update
+                # the code
+                if code in map_codes:
+                    if not comment:
+                        _, comment = map_codes[code]
+                map_codes.update({code.lower(): (status, comment)})
 
     data = parsed[item]
     last_result = data['Last Result']
@@ -76,27 +138,24 @@ def check_windows_tasks(item, _no_params, parsed):
     # To make it easier for the user to lookup the error code (e.g. on
     # MSDN) we convert the negative numbers to the hexadecimal
     # representation.
-    last_result_hex = hex(int(last_result) & 0xffffffff)
-    if last_result in map_codes:
-        infotext = "Service Status: %s (%s)" % (map_codes[last_result], last_result_hex)
-    else:
-        infotext = "Service status: Got exit code %s" % last_result_hex
+    last_result_hex = str(hex(int(last_result) & 0xffffffff))
+    # padding with 0
+    if len(last_result_hex) < 10:
+        for i in range(0, 10 - len(last_result_hex)):
+            begin, end = last_result_hex[:2], last_result_hex[2:]
+            last_result_hex = last_result_hex = "%s0%s" % (begin, end)
 
     state = 0
-    if last_result not in [
-            "0",
-            "1",
-            "267009",
-            "267014",
-            "267045",
-            "-2147216609",
-            "-2147750687",
-    ]:
+    if last_result_hex in map_codes:
+        infotext = "Task Status: %s (%s)" % (map_codes[last_result_hex][1], last_result_hex)
+
+    else:
+        infotext = "Task status: Got exit code %s." % last_result_hex
         state = 2
-    yield state, infotext
+    yield (state, infotext)
 
     if data['Scheduled Task State'] != 'Enabled':
-        yield 2, "Task not enabled"
+        yield sched_task_state, "Task not enabled"
 
     additional_infos = []
     for key, title in [
@@ -115,4 +174,5 @@ check_info["windows_tasks"] = {
     "check_function": check_windows_tasks,
     "inventory_function": inventory_windows_tasks,
     "service_description": "Task %s",
+    "group":"windows_tasks_group"
 }

--- a/checks/windows_tasks
+++ b/checks/windows_tasks
@@ -69,7 +69,7 @@ def inventory_windows_tasks(parsed):
 
 def check_windows_tasks(item, params, parsed):
     if item not in parsed:
-        yield (3, "Task not found on server")
+        yield 3, "Task not found on server"
         return
 
     map_codes = {
@@ -152,7 +152,7 @@ def check_windows_tasks(item, params, parsed):
     else:
         infotext = "Task status: Got exit code %s." % last_result_hex
         state = 2
-    yield (state, infotext)
+    yield state, infotext
 
     if data['Scheduled Task State'] != 'Enabled':
         yield sched_task_state, "Task not enabled"

--- a/cmk/gui/plugins/wato/check_parameters/windows_tasks.py
+++ b/cmk/gui/plugins/wato/check_parameters/windows_tasks.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+
+# Author
+# Antoine Scheffold
+# antoinescheffold@gmail.com
+
+from cmk.gui.i18n import _
+from cmk.gui.valuespec import (
+    ListOf,
+    MonitoringState,
+    TextAscii,
+    Tuple,
+)
+
+from cmk.gui.plugins.wato import (
+    CheckParameterRulespecWithoutItem,
+    rulespec_registry,
+    RulespecGroupCheckParametersApplications,
+)
+
+
+def _parameter_valuespec_windows_tasks():
+    return Tuple(
+        title=_("Value Spec"),
+        elements=[
+         ListOf(
+             Tuple(
+                 title=_("Windows task exitcode definition"),
+                 elements=[
+                  TextAscii(
+                            title=_("Exitcode: "),
+                            help = _("Enter the exitcode as hex value, e.g. 0x00000000."),
+                            ),
+                  MonitoringState(
+                            title = _("State for the exitcode: "),
+                            default_value = 0,
+                        ),
+                  TextAscii(
+                            title=_("Infotext: "),
+                            help = _("This infotext will be shown in CheckMK. If there is already a text, you can leave this empty"),
+                        ),
+             ])
+         ),
+         MonitoringState(title = _("State if task not enabled: "),),
+    ])
+
+
+
+rulespec_registry.register(
+    CheckParameterRulespecWithoutItem(
+        check_group_name="windows_tasks_group",
+        group=RulespecGroupCheckParametersApplications,
+        match_type="first",
+        parameter_valuespec=_parameter_valuespec_windows_tasks,
+        title=lambda: _("Windows Tasks"),
+    ))
+
+

--- a/cmk/gui/plugins/wato/check_parameters/windows_tasks.py
+++ b/cmk/gui/plugins/wato/check_parameters/windows_tasks.py
@@ -54,5 +54,3 @@ rulespec_registry.register(
         parameter_valuespec=_parameter_valuespec_windows_tasks,
         title=lambda: _("Windows Tasks"),
     ))
-
-

--- a/cmk/gui/plugins/wato/check_parameters/windows_tasks.py
+++ b/cmk/gui/plugins/wato/check_parameters/windows_tasks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Author
 # Antoine Scheffold
@@ -11,7 +11,6 @@ from cmk.gui.valuespec import (
     TextAscii,
     Tuple,
 )
-
 from cmk.gui.plugins.wato import (
     CheckParameterRulespecWithoutItem,
     rulespec_registry,
@@ -43,7 +42,6 @@ def _parameter_valuespec_windows_tasks():
          ),
          MonitoringState(title = _("State if task not enabled: "),),
     ])
-
 
 
 rulespec_registry.register(


### PR DESCRIPTION
Modified the windows-tasks plugin that it contains all exitcodes documented by microsoft in https://docs.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-error-and-success-constants, addad a WATO rule that the user can add or modify exitcodes of the windows-tasks check, modified checkman slightly.