### PR TITLE
Fix calculation of issued rds_licenses

### DIFF
--- a/checks/rds_licenses
+++ b/checks/rds_licenses
@@ -57,9 +57,9 @@ def check_rds_licenses(item, params, parsed):
     used = 0
     for pack in license_pack:
         pack_total = int(pack.get("TotalLicenses"))
-        pack_avail = int(pack.get("AvailableLicenses"))
+        pack_issued = int(pack.get("IssuedLicenses"))
         total += pack_total
-        used += pack_total - pack_avail
+        used += pack_issued
 
     return license_check_levels(total, used, params)
 


### PR DESCRIPTION
RDS license servers are able to issue more licenses than added to their database.
The calculation 'pack_total - pack_avail' doesn't reflect, if more licenses are consumed, than available.
For the instance, this would work with the current check:
- 600 licenses in total
- 450 consumed
- 150 available
Using the existing calculation, it would result in 600-150=450 used licenses. 

But here comes the tricky part:
- 800 licenses in total
- 801 consumed
- 0 available
Using the existing calculation, it would result in 800-0=800 used licenses.

With the proposed solution, it would properly reflect the issued licenses, which are handed over via agent plugin anyhow and end up in a critical state.