### PR TITLE
replacing cisco_asa_xxxsessions with cisco_asa_vpnsessions

### DIFF
--- a/checkman/cisco_asa_vpnsessions
+++ b/checkman/cisco_asa_vpnsessions
@@ -1,0 +1,21 @@
+title: Monitor Cisco ASA/FirePower VPN sessions (Remota Access and Lan2Lan)
+agents: snmp
+catalog: hw/network/cisco
+license: GPL
+distribution: https://thl-cmk.hopto.org
+description:
+ This check monitors the number of VPN sessions of a Cisco ASA/FirePower appliance.
+ The check creates the service  VPN Sessions with the session type as item. Each
+ service shows the active/peak/system max. and cumulative numer of VPN sessions.
+ It goes critical/warning if the number of active sessions is equal or above the
+ configured leveles.
+
+perfdata:
+ Number of current active sessions and number of peak sessions since restart of the device.
+
+inventory:
+ The inventory checks for a Cisco ASA/FirePower Appliance in sysDesc. If found
+ it will create the service VPN Sessions.
+
+item:
+ the VPN session type. One of: AnyConnect, Clientless, IPSec RA, IPSec L2L or Summary.

--- a/checks/cisco_asa_vpnsessions
+++ b/checks/cisco_asa_vpnsessions
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# License: GNU General Public License v2
+#
+# Author: thl-cmk[at]outlook[dot]com
+# URL   : https://thl-cmk.hopto.org
+# Date  : 2020-04-27
+# monitor Cisco ASA VPN Session counters
+#
+# this check replaces the original cisco_svcsesions and my cisco_asa_cras package
+# if you use this check please remove the cisco_asa_cras package (if installed)
+# and disable the cisco_asa_svcsessions check
+#
+# sample snmpwalk
+#
+# .1.3.6.1.4.1.9.9.392.1.1.1.0 = INTEGER: 150
+# .1.3.6.1.4.1.9.9.392.1.3.26.0 = Gauge32: 0
+# .1.3.6.1.4.1.9.9.392.1.3.27.0 = Counter32: 0
+# .1.3.6.1.4.1.9.9.392.1.3.28.0 = Gauge32: 0
+# .1.3.6.1.4.1.9.9.392.1.3.29.0 = Gauge32: 13
+# .1.3.6.1.4.1.9.9.392.1.3.30.0 = Counter32: 73624
+# .1.3.6.1.4.1.9.9.392.1.3.31.0 = Gauge32: 13
+# .1.3.6.1.4.1.9.9.392.1.3.32.0 = Gauge32: 0
+# .1.3.6.1.4.1.9.9.392.1.3.33.0 = Counter32: 0
+# .1.3.6.1.4.1.9.9.392.1.3.34.0 = Gauge32: 0
+# .1.3.6.1.4.1.9.9.392.1.3.35.0 = Gauge32: 28
+# .1.3.6.1.4.1.9.9.392.1.3.36.0 = Counter32: 1590
+# .1.3.6.1.4.1.9.9.392.1.3.37.0 = Gauge32: 37
+# .1.3.6.1.4.1.9.9.392.1.3.38.0 = Gauge32: 0
+# .1.3.6.1.4.1.9.9.392.1.3.39.0 = Counter32: 0
+# .1.3.6.1.4.1.9.9.392.1.3.40.0 = Gauge32: 0
+#
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasMaxSessionsSupportable.0 = INTEGER: 150 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasIPSecNumSessions.0 = Gauge32: 0 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasIPSecCumulateSessions.0 = Counter32: 0 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasIPSecPeakConcurrentSessions.0 = Gauge32: 0 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasL2LNumSessions.0 = Gauge32: 13 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasL2LCumulateSessions.0 = Counter32: 73624 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasL2LPeakConcurrentSessions.0 = Gauge32: 13 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasLBNumSessions.0 = Gauge32: 0 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasLBCumulateSessions.0 = Counter32: 0 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasLBPeakConcurrentSessions.0 = Gauge32: 0 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasSVCNumSessions.0 = Gauge32: 28 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasSVCCumulateSessions.0 = Counter32: 1590 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasSVCPeakConcurrentSessions.0 = Gauge32: 37 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasWebvpnNumSessions.0 = Gauge32: 0 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasWebvpnCumulateSessions.0 = Counter32: 0 Sessions
+# CISCO-REMOTE-ACCESS-MONITOR-MIB::crasWebvpnPeakConcurrentSessions.0 = Gauge32: 0 Sessions
+#
+# sample info
+# [[u'0', u'0', u'0', u'13', u'73624', u'13', u'28', u'1590', u'37', u'0', u'0', u'0', u'150']]
+#
+
+factory_settings['cisco_asa_vpnsessions_defaults'] = {
+    'WarnCrit': (10, 100),
+}
+
+
+def parse_cisco_asa_vpnsessions(info):
+
+    IPSecNumSessions, IPSecCumulateSessions, IPSecPeakSessions, L2LNumSessions, L2LCumulateSessions, \
+    L2LPeakSessions, SVCNumSessions, SVCCumulateSessions, SVCPeakSessions, WebvpnNumSessions, \
+    WebvpnCumulateSessions, WebvpnPeakSessions, MaxSessionsSupportable = info[0]
+
+    IPSecNumSessions = int(IPSecNumSessions)
+    IPSecCumulateSessions = int(IPSecCumulateSessions)
+    IPSecPeakSessions = int(IPSecPeakSessions)
+    L2LNumSessions = int(L2LNumSessions)
+    L2LCumulateSessions = int(L2LCumulateSessions)
+    L2LPeakSessions = int(L2LPeakSessions)
+    SVCNumSessions = int(SVCNumSessions)
+    SVCCumulateSessions = int(SVCCumulateSessions)
+    SVCPeakSessions = int(SVCPeakSessions)
+    WebvpnNumSessions = int(WebvpnNumSessions)
+    WebvpnCumulateSessions = int(WebvpnCumulateSessions)
+    WebvpnPeakSessions = int(WebvpnPeakSessions)
+    MaxSessionsSupportable = int(MaxSessionsSupportable)
+    SumNumSessions = IPSecNumSessions + L2LNumSessions + SVCNumSessions + WebvpnNumSessions
+    SumCumulateSessions = IPSecCumulateSessions + L2LCumulateSessions + SVCCumulateSessions + WebvpnCumulateSessions
+
+    parsed = {         # current,      peak,            cumulative,          system max
+        'AnyConnect': (SVCNumSessions, SVCPeakSessions, SVCCumulateSessions, MaxSessionsSupportable),
+        'Clientless': (WebvpnNumSessions, WebvpnPeakSessions, WebvpnCumulateSessions, MaxSessionsSupportable),
+        'IPSec RA': (IPSecNumSessions, IPSecPeakSessions, IPSecCumulateSessions, MaxSessionsSupportable),
+        'IPSec L2L': (L2LNumSessions, L2LPeakSessions, L2LCumulateSessions, MaxSessionsSupportable),
+        'Summary': (SumNumSessions, 0, SumCumulateSessions, MaxSessionsSupportable),
+    }
+
+    return parsed
+
+
+def inventory_cisco_asa_vpnsessions(parsed):
+    for key in parsed.keys():
+        yield key, {}
+
+
+def check_cisco_asa_vpnsessions(item, params, parsed):
+
+    warn, crit = params['WarnCrit']
+    current, peak, cumulative, sysmax = parsed[item]
+    VPNType = str(item).lower().replace(' ', '')
+
+    if not VPNType == 'summary':
+        infotext = '%d/%d/%d/%d (current/peak/system max./cumulative)' % (current, peak, sysmax, cumulative)
+        perfdata = [
+            ('%s_current' % VPNType, current, warn, crit, 0, sysmax),
+            ('%s_peak' % VPNType, peak, None, None, peak + 10),
+        ]
+    else:
+        infotext = '%d/%d/%d (current/system max./cumulative)' % (current, sysmax, cumulative)
+        perfdata = [
+            ('%s_current' % VPNType, current, warn, crit, 0, sysmax),
+        ]
+
+    if current >= crit:
+        yield 2, 'current >= %d' % crit
+    elif current >= warn:
+        yield 1, 'current >= %d' % warn
+
+    yield 0, infotext, perfdata
+
+
+check_info['cisco_asa_vpnsessions'] = {
+    'check_function'         : check_cisco_asa_vpnsessions,
+    'inventory_function'     : inventory_cisco_asa_vpnsessions,
+    'service_description'    : 'VPN Sessions %s',
+    'has_perfdata'           : True,
+    'default_levels_variable': 'cisco_asa_vpnsessions_defaults',
+    'parse_function'         : parse_cisco_asa_vpnsessions,
+    'group'                  : 'cisco_asa_vpnsessions',
+    'snmp_scan_function'     : lambda oid: oid('.1.3.6.1.2.1.1.1.0').lower().startswith('cisco adaptive security')\
+                                        or oid('.1.3.6.1.2.1.1.1.0').lower().startswith('cisco firepower threat defense'),
+    'snmp_info'              : ('.1.3.6.1.4.1.9.9.392.1', ['3.26',  # crasIPSecNumSessions
+                                                           '3.27',  # crasIPSecCumulateSessions
+                                                           '3.28',  # crasIPSecPeakConcurrentSessions
+                                                           '3.29',  # crasL2LNumSessions
+                                                           '3.30',  # crasL2LCumulateSessions
+                                                           '3.31',  # crasL2LPeakConcurrentSessions
+                                                           '3.35',  # crasSVCNumSessions
+                                                           '3.36',  # crasSVCCumulateSessions
+                                                           '3.37',  # crasSVCPeakConcurrentSessions
+                                                           '3.38',  # crasWebvpnNumSessions
+                                                           '3.39',  # crasWebvpnCumulateSessions
+                                                           '3.40',  # crasWebvpnPeakConcurrentSessions
+                                                           '1.1',   # crasMaxSessionsSupportable
+                                                       ]),
+}

--- a/cmk/gui/plugins/metrics/cisco_asa_vpnsessions.py
+++ b/cmk/gui/plugins/metrics/cisco_asa_vpnsessions.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# License: GNU General Public License v2
+#
+# Cisco ASA VPN Sessions metrics plugin
+#
+# Author: thl-cmk[at]outlook[dot]com
+# Date  : 2018-02-16
+#
+#
+
+################################################################################
+#
+# define metrics
+#
+################################################################################
+
+from cmk.gui.i18n import _
+
+from cmk.gui.plugins.metrics import (
+    metric_info,
+    graph_info,
+    check_metrics,
+)
+
+metric_info['cisco_asa_vpnsessions_ipsecl2l_current'] = {
+    'title': _('IPSec L2L sessions active'),
+    'help': _('number of current active IPSec L2L sessions'),
+    'unit': 'count',
+    'color': '26/a',
+}
+metric_info['cisco_asa_vpnsessions_ipsecl2l_peak'] = {
+    'title': _('IPSec L2L sessions peak'),
+    'help': _('number of peak IPSec L2L sessions'),
+    'unit': 'count',
+    'color': '21/a',
+}
+
+metric_info['cisco_asa_vpnsessions_anyconnect_current'] = {
+    'title': _('AnyConnect sessions active'),
+    'help': _('number of current active AnyConnect (SVC) sessions'),
+    'unit': 'count',
+    'color': '26/a',
+}
+metric_info['cisco_asa_vpnsessions_anyconnect_peak'] = {
+    'title': _('AnyConnect sessions peak'),
+    'help': _('number of peak active AnyConnect (SVC) sessions'),
+    'unit': 'count',
+    'color': '21/a',
+}
+
+metric_info['cisco_asa_vpnsessions_clientless_current'] = {
+    'title': _('Clientless VPN sessions active'),
+    'help': _('number of current active client less (WEB) VPN sessions'),
+    'unit': 'count',
+    'color': '26/a',
+}
+
+metric_info['cisco_asa_vpnsessions_clientless_peak'] = {
+    'title': _('Clientless VPN sessions peak'),
+    'help': _('number of peak active clientless (WEB) VPN sessions'),
+    'unit': 'count',
+    'color': '21/a',
+}
+
+metric_info['cisco_asa_vpnsessions_ipsecra_current'] = {
+    'title': _('IPSec RAS sessions active'),
+    'help': _('number of current active IPSec remote access sessions'),
+    'unit': 'count',
+    'color': '26/a',
+}
+metric_info['cisco_asa_vpnsessions_ipsecra_peak'] = {
+    'title': _('IPSec RAS sessions peak'),
+    'help': _('number of peak IPSec remote access sessions'),
+    'unit': 'count',
+    'color': '21/a',
+}
+
+metric_info['cisco_asa_vpnsessions_summary_current'] = {
+    'title': _('Active sessions summary'),
+    'help': _('number of current active summary'),
+    'unit': 'count',
+    'color': '26/a',
+}
+
+################################################################################
+#
+# map perfdata to metric
+#
+################################################################################
+
+check_metrics['check_mk-cisco_asa_vpnsessions'] = {
+    'ipsecl2l_current': {
+        'name': 'cisco_asa_vpnsessions_ipsecl2l_current',
+    },
+    'ipsecl2l_peak': {
+        'name': 'cisco_asa_vpnsessions_ipsecl2l_peak',
+    },
+    'anyconnect_current': {
+        'name': 'cisco_asa_vpnsessions_anyconnect_current',
+    },
+    'anyconnect_peak': {
+        'name': 'cisco_asa_vpnsessions_anyconnect_peak',
+    },
+    'ipsecra_current': {
+        'name': 'cisco_asa_vpnsessions_ipsecra_current',
+    },
+    'ipsecra_peak': {
+        'name': 'cisco_asa_vpnsessions_ipsecra_peak',
+    },
+    'clientless_current': {
+        'name': 'cisco_asa_vpnsessions_clientless_current',
+    },
+    'clientless_peak': {
+        'name': 'cisco_asa_vpnsessions_clientless_peak',
+    },
+    'summary_current': {
+        'name': 'cisco_asa_vpnsessions_summary_current'
+    },
+}
+
+################################################################################
+#
+# how to graph perdata
+#
+################################################################################
+
+graph_info.append({
+    'title': _('Lan2Lan VPN Sessions'),
+    'metrics': [
+        ('cisco_asa_vpnsessions_ipsecl2l_current', 'area'),
+        ('cisco_asa_vpnsessions_ipsecl2l_peak', 'line'),
+    ],
+    'range': (0, 'cisco_asa_vpnsessions_ipsecl2l_peak:max'),
+    'scalars': [
+        ('cisco_asa_vpnsessions_ipsecl2l_current:crit', _('crit level')),
+        ('cisco_asa_vpnsessions_ipsecl2l_current:warn', _('warn level')),
+    ],
+})
+graph_info.append({
+    'title': _('Anyconnect VPN Sessions'),
+    'metrics': [
+        ('cisco_asa_vpnsessions_anyconnect_current', 'area'),
+        ('cisco_asa_vpnsessions_anyconnect_peak', 'line'),
+    ],
+    'range': (0, 'cisco_asa_vpnsessions_anyconnect_peak:max'),
+    'scalars': [
+        ('cisco_asa_vpnsessions_anyconnect_current:crit', _('crit level')),
+        ('cisco_asa_vpnsessions_anyconnect_current:warn', _('warn level')),
+    ],
+})
+graph_info.append({
+    'title': _('IPSec RAS VPN Sessions'),
+    'metrics': [
+        ('cisco_asa_vpnsessions_ipsecra_current', 'area'),
+        ('cisco_asa_vpnsessions_ipsecra_peak', 'line'),
+    ],
+    'range': (0, 'cisco_asa_vpnsessions_ipsecra_peak:max'),
+    'scalars': [
+        ('cisco_asa_vpnsessions_ipsecra_current:crit', _('crit level')),
+        ('cisco_asa_vpnsessions_ipsecra_current:warn', _('warn level')),
+    ],
+})
+graph_info.append({
+    'title': _('Clientless (WEB) VPN Sessions'),
+    'metrics': [
+        ('cisco_asa_vpnsessions_clientless_current', 'area'),
+        ('cisco_asa_vpnsessions_clientless_peak', 'line'),
+    ],
+    'range': (0, 'cisco_asa_vpnsessions_clientless_peak:max'),
+    'scalars': [
+        ('cisco_asa_vpnsessions_clientless_current:crit', _('crit level')),
+        ('cisco_asa_vpnsessions_clientless_current:warn', _('warn level')),
+    ],
+})
+
+graph_info.append({
+    'title': _('VPN Sessions summary'),
+    'metrics': [('cisco_asa_vpnsessions_summary_current', 'area'),],
+    'range': (0, 'cisco_asa_vpnsessions_summary_current:max'),
+    'scalars': [
+        ('cisco_asa_vpnsessions_summary_current:crit', _('crit level')),
+        ('cisco_asa_vpnsessions_summary_current:warn', _('warn level')),
+    ],
+})
+
+################################################################################
+#
+# define perf-o-meter
+#
+################################################################################
+
+from cmk.gui.plugins.metrics import (
+    perfometer_info,)
+
+# ToDo: need a way to use vpnsessions_current:max as half value
+sysmax_vpn_half_value = 500
+
+perfometer_info.append({
+    'type': 'logarithmic',
+    'metric': 'cisco_asa_vpnsessions_ipsecl2l_current',
+    'half_value': sysmax_vpn_half_value,
+    'exponent': 2,
+})
+perfometer_info.append({
+    'type': 'logarithmic',
+    'metric': 'cisco_asa_vpnsessions_anyconnect_current',
+    'half_value': sysmax_vpn_half_value,
+    'exponent': 2,
+})
+perfometer_info.append({
+    'type': 'logarithmic',
+    'metric': 'cisco_asa_vpnsessions_clientless_current',
+    'half_value': sysmax_vpn_half_value,
+    'exponent': 2,
+})
+perfometer_info.append({
+    'type': 'logarithmic',
+    'metric': 'cisco_asa_vpnsessions_ipsecra_current',
+    'half_value': sysmax_vpn_half_value,
+    'exponent': 2,
+})
+
+perfometer_info.append({
+    'type': 'logarithmic',
+    'metric': 'cisco_asa_vpnsessions_summary_current',
+    'half_value': sysmax_vpn_half_value,
+    'exponent': 2,
+})

--- a/cmk/gui/plugins/wato/check_parameters/cisco_asa_vpnsessions.py
+++ b/cmk/gui/plugins/wato/check_parameters/cisco_asa_vpnsessions.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# License: GNU General Public License v2
+#
+# Author : thl-cmk[at]outlook[dot]com
+# Date   : 2020-04-27
+# Content: wato plugin for snmp check 'cisco_asa_vpnsessions'
+#          to configure waring/critical levels
+#
+
+from cmk.gui.i18n import _
+from cmk.gui.valuespec import (
+    Dictionary,
+    Integer,
+    TextAscii,
+    Tuple,
+)
+
+from cmk.gui.plugins.wato import (
+    CheckParameterRulespecWithItem,
+    rulespec_registry,
+    RulespecGroupCheckParametersNetworking,
+)
+
+
+def _parameter_valuespec_cisco_asa_vpnsessions():
+    return Dictionary(elements=[
+        ('WarnCrit',
+         Tuple(
+             title=_('Number of active sessions'),
+             help=_('This check monitors the number of active/peak sessions'),
+             elements=[
+                 Integer(title=_('Warning at'), unit=_('sessions'), default_value=10),
+                 Integer(title=_('Critical at'), unit=_('sessions'), default_value=100),
+             ],
+         )),
+    ],)
+
+
+def _item_spec_cisco_asa_vpnsessions():
+    return TextAscii(
+        title=_('VPN session type'),
+        help=_(
+            'VPN session type is one of AnyConnect, Clientless, IPSec L2L, IPSec RA or Summary. '),
+        allow_empty=False,
+    )
+
+
+rulespec_registry.register(
+    CheckParameterRulespecWithItem(
+        check_group_name='cisco_asa_vpnsessions',
+        group=RulespecGroupCheckParametersNetworking,
+        item_spec=_item_spec_cisco_asa_vpnsessions,
+        match_type='dict',
+        parameter_valuespec=_parameter_valuespec_cisco_asa_vpnsessions,
+        title=lambda: _('Cisco ASA VPN sessions'),
+    ))


### PR DESCRIPTION
Hi Joerg,

her is the pull request for the cisco_asa_vpnsessions check as replacement for cisco_asa_ipsecsessions, cisco_asa_svcsessions, cisco_asa_webvpnsessions and cisco_asa_sessions.include.

I had to recereate my fork after the problems with your repository from the weekend :-( 
The old request was #183.

Grettings,
Thomas