### PR TITLE
[cisco_asa_failover] adds cisco FirePower devices to scan function

### DIFF
--- a/checks/cisco_asa_failover
+++ b/checks/cisco_asa_failover
@@ -98,7 +98,8 @@ check_info["cisco_asa_failover"]  = {
     "check_function"            : check_cisco_asa_failover,
     "service_description"       : "Cluster Status",
     "snmp_scan_function"        : lambda oid: oid(".1.3.6.1.2.1.1.1.0").lower().startswith("cisco adaptive security") \
-                                       or "cisco pix security" in oid(".1.3.6.1.2.1.1.1.0").lower(),
+                                           or oid('.1.3.6.1.2.1.1.1.0').lower().startswith('cisco firepower threat defense')\
+                                           or "cisco pix security" in oid(".1.3.6.1.2.1.1.1.0").lower(),
     "snmp_info"                 : (".1.3.6.1.4.1.9.9.147.1.2.1.1.1", [
                                              "2", # CISCO-FIREWALL-MIB::cfwHardwareInformation
                                              "3", # CISCO-FIREWALL-MIB::cfwHardwareStatusValue


### PR DESCRIPTION
simple patch to add support for Cisco Firepower devices
```
--- cisco_asa_failover	2020-05-20 06:58:04.000000000 +0000
+++ /git/checkmk/checks/cisco_asa_failover	2020-05-30 11:55:26.543044165 +0000
@@ -98,7 +98,8 @@
     "check_function"            : check_cisco_asa_failover,
     "service_description"       : "Cluster Status",
     "snmp_scan_function"        : lambda oid: oid(".1.3.6.1.2.1.1.1.0").lower().startswith("cisco adaptive security") \
-                                       or "cisco pix security" in oid(".1.3.6.1.2.1.1.1.0").lower(),
+                                           or oid('.1.3.6.1.2.1.1.1.0').lower().startswith('cisco firepower threat defense')\
+                                           or "cisco pix security" in oid(".1.3.6.1.2.1.1.1.0").lower(),
     "snmp_info"                 : (".1.3.6.1.4.1.9.9.147.1.2.1.1.1", [
                                              "2", # CISCO-FIREWALL-MIB::cfwHardwareInformation
                                              "3", # CISCO-FIREWALL-MIB::cfwHardwareStatusValue
```