### PR TITLE
Show spooled local checks in case plug-ins are executed

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1454,9 +1454,6 @@ run_mrpe
 # Local checks
 run_local_checks
 
-# Plugins
-run_plugins
-
 # Agent output snippets created by cronjobs, etc.
 if [ -d "$SPOOLDIR" ] && [ -r "$SPOOLDIR" ]; then
     pushd "$SPOOLDIR" >/dev/null
@@ -1490,3 +1487,7 @@ if [ -d "$SPOOLDIR" ] && [ -r "$SPOOLDIR" ]; then
     done
     popd >/dev/null
 fi
+
+# Plugins
+run_plugins
+


### PR DESCRIPTION
If a plug-in create its own sections, a spooled local check will not be part of the local section anymore. By writing the output from spool first, it is ensured, that at least this doesn't happen anymore. 

Another solution would be to create another local section before outputting the spooled stuff.
