### PR TITLE
change title of metric unit "rpm" to "Revolutions per minute"

### DIFF
--- a/cmk/gui/plugins/metrics/unit.py
+++ b/cmk/gui/plugins/metrics/unit.py
@@ -245,7 +245,7 @@ unit_info["l/s"] = {
 }
 
 unit_info["rpm"] = {
-    "title": _("Rotations per minute"),
+    "title": _("Revolutions per minute"),
     "symbol": _("rpm"),
     "render": lambda v: cmk.utils.render.physical_precision(v, 4, _("rpm")),
 }

--- a/locale/de/LC_MESSAGES/multisite.po
+++ b/locale/de/LC_MESSAGES/multisite.po
@@ -34963,8 +34963,8 @@ msgstr "rotiert"
 msgid "Rotated Log"
 msgstr "rotiertes Log"
 
-msgid "Rotations per minute"
-msgstr "Umdrehung pro Minute"
+msgid "Revolutions per minute"
+msgstr "Umdrehungen pro Minute"
 
 msgid "Round"
 msgstr "Rund"


### PR DESCRIPTION
The "r" in "rpm" neither means "rotations" nor "rounds" but "revolutions".