### PR TITLE
Add multi controller support for storcli checks

### DIFF
--- a/checkman/storcli_pdisks
+++ b/checkman/storcli_pdisks
@@ -10,7 +10,7 @@ description:
  entered in the script.
 
 item:
- The enclosure ID and the slot number followed by the device ID (seperated by a {{-}}).
+ The controller number, the enclosure ID, and the slot number followed by the device ID (seperated by a {{-}}).
 
 inventory:
- One service is created for each found disk.
+ One service is created for each found disk on each controller.

--- a/checkman/storcli_vdrives
+++ b/checkman/storcli_vdrives
@@ -10,7 +10,7 @@ description:
  entered in the script.
 
 item:
- The ID of the virtual drive.
+ The controller number and the ID of the virtual drive.
 
 inventory:
- One service is created for each found virtual drive.
+ One service is created for each found virtual drive on each controller.

--- a/checks/storcli_pdisks
+++ b/checks/storcli_pdisks
@@ -27,18 +27,21 @@ def parse_storcli_pdisks(info):
 
     parsed = {}
 
+    controller_num = 0
     separator_count = 0
     for line in info:
         if line[0].startswith("-----"):
             separator_count += 1
         elif separator_count == 2:
             eid_and_slot, device, state, _drivegroup, size, size_unit = line[:6]
-            parsed[eid_and_slot + "-" + device] = {
+            parsed["C%i.%s-%s" % (controller_num, eid_and_slot, device)] = {
                 "state": statenames.get(state, state),
                 "size": (float(size), size_unit)
             }
         if separator_count == 3:
-            break
+            # each controller has 3 separators, reset count and continue
+            separator_count = 0
+            controller_num += 1
 
     return parsed
 

--- a/checks/storcli_vdrives
+++ b/checks/storcli_vdrives
@@ -25,20 +25,23 @@ def parse_storcli_vdrives(info):
 
     parsed = {}
 
+    controller_num = 0
     separator_count = 0
     for line in info:
         if line[0].startswith("-----"):
             separator_count += 1
         elif separator_count == 2:
-            item, raid_type, rawstate, access, consistent = line[:5]
-            parsed[item] = {
+            dg_vd, raid_type, rawstate, access, consistent = line[:5]
+            parsed["C%i.%s" % (controller_num, dg_vd)] = {
                 "raid_type": raid_type,
                 "state": raid_statenames.get(rawstate.lower(), rawstate),
                 "access": access,
                 "consistent": consistent,
             }
         if separator_count == 3:
-            break
+            # each controller has 3 separators, reset count and continue
+            separator_count = 0
+            controller_num += 1
 
     return parsed
 


### PR DESCRIPTION
Since the check plugin already supports it, this commit adds support for multiple LSI MegaRaid controllers. To differentiate between the controllers the item name is prepended by "Cn." where n is the number of the controller.
E.g.:

- _RAID Virtual Drive 0/0_ would become 
    _RAID Virtual Drive C0.0/0_ for controller 0
- _RAID PDisk EID:Slot-Device 13:9-19_ would become
    _RAID PDisk EID:Slot-Device C1.13:9-19_ for controller 1

As this PR changes the item name, this is an incompatible change and will require re-inventorizing the services.