### PR TITLE
enhance "mounts" check to have a configurable list of ignored options

### DIFF
--- a/checkman/mounts
+++ b/checkman/mounts
@@ -12,6 +12,10 @@ description:
  the monitoring. Also excluded is the option {localalloc=} for recent
  kernels and OCFS2 filesystems.
 
+ It is also possible to configure further mount options that are to
+ be ignored by this check so that it won't go to the warning state
+ if these options appear or disappear.
+
  This check goes critical if the mount option {ro} appears. This
  might indicate IO errors have occurred, causing the filesystem
  to switch to read-only mode.

--- a/checks/mounts
+++ b/checks/mounts
@@ -29,17 +29,32 @@ def discovery_mounts(info):
         if dev not in devices:
             devices.append(dev)
             opts = sorted(options.split(","))
-            yield mountpoint.replace("\\040(deleted)", ""), opts
+            yield mountpoint.replace("\\040(deleted)", ""), {'expected': opts}
 
 
-def _should_ignore_option(option):
-    for ignored_option in ["commit=", "localalloc=", "subvol=", "subvolid="]:
+def _should_ignore_option(option, ignorelist):
+    for ignored_option in ignorelist:
         if option.startswith(ignored_option):
             return True
     return False
 
 
-def check_mounts(item, targetopts, info):
+def check_mounts(item, params, info):
+
+    # The original plugin had a parameter "targetopts" which was just a list
+    # of strings (expected mount options as determined during the discovery).
+    # Our modified plugin uses a dictionary as parameter with two elements:
+    #     'expected': same as the old "targetopts"
+    #     'ignore': list of strings (mount options to ignore)
+    # Both parameters can be overwritten using a WATO rule.
+    default_ignorelist = ["commit=", "localalloc=", "subvol=", "subvolid="]
+    if isinstance(params, dict):
+        targetopts = params.get('expected', [])
+        ignorelist = params.get('ignore', default_ignorelist)
+    else:
+        targetopts = params
+        ignorelist = default_ignorelist
+
     # Ignore options that are allowed to change
     for _dev, mountpoint, _fstype, options, _dump, _fsck in info:
         if item == mountpoint.replace("\\040(deleted)", ""):
@@ -51,11 +66,11 @@ def check_mounts(item, targetopts, info):
             # Now compute the exact difference.
 
             exceeding = [
-                opt for opt in opts if opt not in targetopts and not _should_ignore_option(opt)
+                opt for opt in opts if opt not in targetopts and not _should_ignore_option(opt, ignorelist)
             ]
 
             missing = [
-                opt for opt in targetopts if opt not in opts and not _should_ignore_option(opt)
+                opt for opt in targetopts if opt not in opts and not _should_ignore_option(opt, ignorelist)
             ]
 
             if not missing and not exceeding:

--- a/cmk/gui/plugins/wato/check_parameters/fs_mount_options.py
+++ b/cmk/gui/plugins/wato/check_parameters/fs_mount_options.py
@@ -6,9 +6,11 @@
 
 from cmk.gui.i18n import _
 from cmk.gui.valuespec import (
+    Dictionary,
     ListOfStrings,
     TextAscii,
     TextUnicode,
+    Transform,
 )
 
 from cmk.gui.plugins.wato import (
@@ -19,13 +21,35 @@ from cmk.gui.plugins.wato import (
 
 
 def _parameter_valuespec_fs_mount_options():
-    return ListOfStrings(
+    expected = ListOfStrings(
         title=_("Expected mount options"),
         help=_("Specify all expected mount options here. If the list of "
                "actually found options differs from this list, the check will go "
                "warning or critical. Just the option <tt>commit</tt> is being "
                "ignored since it is modified by the power saving algorithms."),
         valuespec=TextUnicode(),
+    )
+    ignore = ListOfStrings(
+        title=_("Mount options to ignore"),
+        help=_("Specify all mount options that should be ignored when inspecting "
+               "the list of actually found options. The options <tt>commit</tt>, "
+               "<tt>localalloc</tt>, <tt>subvol</tt>, <tt>subvolid</tt> are "
+               "ignored by default."),
+        valuespec=TextUnicode(),
+        default_value = ["commit=", "localalloc=", "subvol=", "subvolid="],
+    )
+
+    # The old parameterset was just a list of strings. We moved that list into a
+    # dictionary with the key 'expected'.
+    return Transform(
+        Dictionary(
+            title=_("Mount options"),
+            elements=[
+                ('expected', expected),
+                ('ignore', ignore),
+            ],
+        ),
+        forth = lambda params: params if isinstance(params, dict) else {'expected': params},
     )
 
 


### PR DESCRIPTION
The check plugin "mounts" uses a hardcoded list of mount options that
are ignored when comparing the mount options determined at discovery time
(expected options) to the actual mount options during a check. This list
grew over time as new options turned out to be flipping from ON to OFF
for various reasons like energy saving algorithms, for instance.

This commit adds the possibility to configure that "ignore list" by means
of a rule. The old rule allowed to define a list of expected mount options
(overwriting the list that was dynamically determined at discovery time).

The new rule additionaly allows for the definition of an "ignore
list". Both lists are now combined in a dictionary so that the "params"
parameter to the check function has changed from [] to {} and was renamed
from "targetopts" to "params".

The check and the WATO plugin are both compatible with existing rules.

--------

This enhancement was inspired by a [post in the checkmk forum](https://forum.checkmk.com/t/mount-options-of-tmp-check/19011?u=dirk) form a user who has a filesystem `/tmp` that wobbles from `exec` to `noexec` thus rendering the existing check useless to them.