### PR TITLE
[sophos_disk] fix: dsname should not contain spaces

### DIFF
--- a/checks/sophos_disk
+++ b/checks/sophos_disk
@@ -14,7 +14,7 @@ def parse_sophos_disk(info):
 
 def check_sophos_disk(item, params, parsed):
     return check_levels(parsed,
-                        "disk percentage usage",
+                        "disk_percentage_usage",
                         params.get("disk_levels", (None, None)),
                         unit="%",
                         infoname="Disk percentage usage",


### PR DESCRIPTION
minor change: this PR will replace the spaces in dsname with underscores
change from "disk percentage usage" ti "disk_percentage_usage"