### PR TITLE
[Sophos XG-FIREWALL] adds sophos_swap, streamlines cpu/memory/disk/swap adds  absolute values to disk/memory

### DIFF
--- a/checkman/sophos_swap
+++ b/checkman/sophos_swap
@@ -1,0 +1,11 @@
+title: Sophos Device: Swap memory Usage
+agents: snmp
+catalog: hw/network/sophos
+license: GPL
+distribution: check_mk
+description:
+ This Check monitors the current swap memory usage for Sophos devices.
+ Per default the levels for warning and critical if selected are 80 and 90 percentage respectively.
+
+inventory:
+ One service is created.

--- a/checks/sophos_cpu
+++ b/checks/sophos_cpu
@@ -20,7 +20,7 @@ check_info['sophos_cpu'] = {
     "parse_function": parse_sophos_cpu,
     "inventory_function": lambda parsed: [(None, {})] if parsed is not None else None,
     "check_function": check_sophos_cpu,
-    "service_description": "CPU usage",
+    "service_description": "CPU",
     "group": "sophos_cpu",
     "snmp_info": (".1.3.6.1.4.1.21067.2.1.2.2", [1]),
     "snmp_scan_function": lambda oid: '.1.3.6.1.4.1.21067.2' in oid(".1.3.6.1.2.1.1.2.0"),

--- a/checks/sophos_disk
+++ b/checks/sophos_disk
@@ -7,27 +7,37 @@
 
 def parse_sophos_disk(info):
     try:
-        return int(info[0][0])
+        disk_capacity, disk_percent_usage = info[0]
+        disk_capacity = int(disk_capacity) >> 10
+        disk_percent_usage = int(disk_percent_usage)
+        disk_usage = disk_capacity / 100 * disk_percent_usage
+        return (disk_capacity, disk_usage, disk_percent_usage)
     except (ValueError, IndexError):
         return None
 
 
 def check_sophos_disk(item, params, parsed):
-    return check_levels(parsed,
-                        "disk percentage usage",
+    disk_capacity, disk_usage, disk_percent_usage = parsed
+
+    yield check_levels(disk_percent_usage,
+                        "disk_percentage_usage",
                         params.get("disk_levels", (None, None)),
                         unit="%",
-                        infoname="Disk percentage usage",
+                        infoname="Usage",
                         human_readable_func=lambda x: "%d" % x)
 
+    yield 0, "(%d GB of %d GB)" % (disk_usage, disk_capacity)
 
 check_info['sophos_disk'] = {
     "parse_function": parse_sophos_disk,
     "inventory_function": lambda parsed: [(None, {})] if parsed is not None else None,
     "check_function": check_sophos_disk,
-    "service_description": "Disk usage",
+    "service_description": "Disk",
     "group": "sophos_disk",
-    "snmp_info": (".1.3.6.1.4.1.21067.2.1.2.3", [2]),
+    "snmp_info": (".1.3.6.1.4.1.21067.2.1.2.3", [
+        1,  # XG-FIREWALL-MIB::diskCapacity
+        2,  # XG-FIREWALL-MIB::diskPercentUsage
+        ]),
     "snmp_scan_function": lambda oid: '.1.3.6.1.4.1.21067.2' in oid(".1.3.6.1.2.1.1.2.0"),
     "includes": ["diskstat.include"],
 }

--- a/checks/sophos_memory
+++ b/checks/sophos_memory
@@ -7,20 +7,27 @@
 
 def parse_sophos_memory(info):
     try:
-        return int(info[0][0])
+        memory_capacity, memory_percent_usage = info[0]
+        memory_capacity = int(memory_capacity) >> 10
+        memory_percent_usage = int(memory_percent_usage)
+        memory_usage = memory_capacity / 100 * memory_percent_usage
+        return (memory_capacity, memory_usage, memory_percent_usage)
     except (ValueError, IndexError):
         return None
 
 
 def check_sophos_memory(_item, params, parsed):
-    return check_levels(
-        parsed,
+    memory_capacity, memory_usage, memory_percent_usage = parsed
+
+    yield check_levels(
+        memory_percent_usage,
         "memory_util",
         params.get("memory_levels", (None, None)),
         infoname="Usage",
         human_readable_func=get_percent_human_readable,
     )
 
+    yield 0, "(%d GB of %d GB)" % (memory_usage, memory_capacity)
 
 check_info['sophos_memory'] = {
     "parse_function": parse_sophos_memory,
@@ -28,6 +35,9 @@ check_info['sophos_memory'] = {
     "check_function": check_sophos_memory,
     "service_description": "Memory",
     "group": "sophos_memory",
-    "snmp_info": (".1.3.6.1.4.1.21067.2.1.2.4", [2]),
+    "snmp_info": (".1.3.6.1.4.1.21067.2.1.2.4", [
+        1,  # XG-FIREWALL-MIB::memoryCapacity
+        2,  # XG-FIREWALL-MIB::memoryPercentUsage
+        ]),
     "snmp_scan_function": lambda oid: '.1.3.6.1.4.1.21067.2' in oid(".1.3.6.1.2.1.1.2.0"),
 }

--- a/checks/sophos_swap
+++ b/checks/sophos_swap
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 tribe29 GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+
+
+def parse_sophos_swap(info):
+    try:
+        swap_capacity, swap_percent_usage = info[0]
+        swap_capacity = int(swap_capacity) >> 10
+        swap_percent_usage = int(swap_percent_usage)
+        swap_usage = swap_capacity / 100 * swap_percent_usage
+        return (swap_capacity, swap_usage, swap_percent_usage)
+    except (ValueError, IndexError):
+        return None
+
+
+def check_sophos_swap(_item, params, parsed):
+    swap_capacity, swap_usage, swap_percent_usage = parsed
+
+    yield check_levels(
+        swap_percent_usage,
+        "swap_util",
+        params.get("swap_levels", (None, None)),
+        infoname="Usage",
+        human_readable_func=get_percent_human_readable,
+    )
+
+    yield 0, "(%d GB of %d GB)" % (swap_usage, swap_capacity)
+
+check_info['sophos_swap'] = {
+    "parse_function": parse_sophos_swap,
+    "inventory_function": lambda parsed: [(None, {})] if parsed is not None else None,
+    "check_function": check_sophos_swap,
+    "service_description": "Swap",
+    "group": "sophos_swap",
+    "snmp_info": (".1.3.6.1.4.1.21067.2.1.2.4", [
+        3,  # XG-FIREWALL-MIB::swapCapacity
+        4,  # XG-FIREWALL-MIB::swapPercentUsage
+        ]),
+    "snmp_scan_function": lambda oid: '.1.3.6.1.4.1.21067.2' in oid(".1.3.6.1.2.1.1.2.0"),
+}

--- a/cmk/gui/plugins/metrics/sophos_disk.py
+++ b/cmk/gui/plugins/metrics/sophos_disk.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 tribe29 GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+
+from cmk.gui.plugins.metrics import (perfometer_info)
+
+perfometer_info.append({
+    "type": "linear",
+    "segments": ["disk_percentage_usage",],
+    "total": 100.0,
+})

--- a/cmk/gui/plugins/metrics/sophos_swap.py
+++ b/cmk/gui/plugins/metrics/sophos_swap.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 tribe29 GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+
+from cmk.gui.plugins.metrics import (perfometer_info)
+
+perfometer_info.append({
+    "type": "linear",
+    "segments": ["swap_util",],
+    "total": 100.0,
+})

--- a/cmk/gui/plugins/wato/check_parameters/sophos_swap.py
+++ b/cmk/gui/plugins/wato/check_parameters/sophos_swap.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 tribe29 GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+
+from cmk.gui.i18n import _
+from cmk.gui.valuespec import (
+    Dictionary,
+    Percentage,
+    Tuple,
+)
+
+from cmk.gui.plugins.wato import (
+    CheckParameterRulespecWithoutItem,
+    rulespec_registry,
+    RulespecGroupCheckParametersOperatingSystem,
+)
+
+
+def _parameter_valuespec_sophos_swap():
+    return Dictionary(elements=[
+        ("swap_levels",
+         Tuple(
+             title=_("Swap memory percentage usage"),
+             elements=[
+                 Percentage(title=_("Warning at"), default_value=80),
+                 Percentage(title=_("Critical at"), default_value=90)
+             ],
+         )),
+    ])
+
+
+rulespec_registry.register(
+    CheckParameterRulespecWithoutItem(
+        check_group_name="sophos_swap",
+        group=RulespecGroupCheckParametersOperatingSystem,
+        match_type="dict",
+        parameter_valuespec=_parameter_valuespec_sophos_swap,
+        title=lambda: _("Sophos Swap memory utilization"),
+    ))


### PR DESCRIPTION
This PR

- adds the check _sophos_swap_
- adds the absolute values to the output of _sophos_disk_, _sophos_memory_ and _sophos_swap_ to give the percentage value some context
- adds perfometer to _sophos_disk_
- streamlines the output of _sophos_disk_, _sophos_memory_, and _sophos_swap_
- streamlines _sophos_cpu_, _sophos_disk_ to match _sophos_memory_ and _sophos_swap_ by removing "usage" form the service name

additional streamlining could be done by changing the output of _sophos_cpu_