### PR TITLE
correct CPU count fix for armv6

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -151,7 +151,7 @@ section_mem() {
 }
 
 section_cpu() {
-    if [ "$(uname -m)" = "armv7l" ]; then
+    if [ "$(uname -m)" = "armv7l" ] || [ "$(uname -m)" = "armv6l" ]; then
         CPU_REGEX='^processor'
     else
         CPU_REGEX='^CPU|^processor'


### PR DESCRIPTION
On a armv6(RaspberryPi zero, for example), the wrong number of CPU's is show. 
This fix will show the correct output for the CPU count on armv6 processors.