### PR TITLE
Use legacy output on drbd9

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -553,6 +553,7 @@ section_drbd() {
     if [ -z "$IS_DOCKERIZED" ] && [ -z "$IS_LXC_CONTAINER" ] && [ -e /proc/drbd ]; then
         echo '<<<drbd>>>'
         cat /proc/drbd
+	cat /sys/kernel/debug/drbd/resources/*/connections/*/0/proc_drbd 2>/dev/null
     fi
 }
 

--- a/checks/drbd
+++ b/checks/drbd
@@ -146,6 +146,7 @@ drbd_cs_map = {
     'WFConnection': 2,
     'WFReportParams': 1,
     'Connected': 0,
+    'Established': 0,
     'StartingSyncS': 1,
     'StartingSyncT': 1,
     'WFBitMapS': 1,


### PR DESCRIPTION
Hello,

on legacy drbd9 Systems (Upgraded drbd8 with 2 Nodes) /proc/drbd has only basic informations.
Other Informations per Node and Resource are in /sys/kernel/debug/drbd/resources/\*/connections/\*/0/proc_drbd
Connected state ist "Established" in drbd9 context.

It would be nice to see it in next 1.6.0p14 release ;)

Best Regards,
Juri Grabowski