### PR TITLE
jolokia: Add version check in WATO

### DIFF
--- a/checks/jolokia.include
+++ b/checks/jolokia.include
@@ -197,3 +197,36 @@ def inventory_jolokia_metrics_apps(info, what):
                     inv.append(('%s %s' % (inst, app), levels))
                     continue
     return inv
+
+
+def jolokia_check_version(actual_version, params, label):
+    def tokenize(version):
+        return [int(n) for n in version.split('.')]
+
+    info = "%s %s" % (label, actual_version)
+    if actual_version is None:
+        return 3, info + " (no agent info)"
+    if "version" not in params:
+        return 0, info
+
+    comp_type, expected_version = params["version"]
+    try:
+        parts_actual = tokenize(actual_version)
+        parts_expected = tokenize(expected_version)
+    except ValueError:
+        error = ("Can not compare %s and %s. "
+                 "Only characters 0-9 and . are allowed for a version." %
+                 (actual_version, expected_version))
+        return 3, error
+
+    parts_actual_len = len(parts_actual)
+    parts_expected_len = len(parts_expected)
+    m = max(parts_actual_len, parts_expected_len)
+    parts_actual.extend(0 for _ in range(m - parts_actual_len))
+    parts_expected.extend(0 for _ in range(m - parts_expected_len))
+
+    if comp_type == "at_least" and parts_actual < parts_expected:
+        return 2, info + " (should be at least %s)" % expected_version
+    if comp_type == "specific" and parts_actual != parts_expected:
+        return 2, info + " (should be %s)" % expected_version
+    return 0, info

--- a/checks/jolokia_info
+++ b/checks/jolokia_info
@@ -13,7 +13,7 @@ def parse_jolokia_info(info):
 
 
 @get_parsed_item_data
-def check_jolokia_info(item, _no_params, data):
+def check_jolokia_info(item, params, data):
 
     line = data[0]
     # Inform user of non-working agent plugin, eg. missing json library
@@ -26,7 +26,8 @@ def check_jolokia_info(item, _no_params, data):
     product = line[0]
     jolokia_version = line[-1]
     version = " ".join(line[1:-1])
-    return 0, "%s %s (Jolokia version %s)" % (product.title(), version, jolokia_version)
+    return [(0, "%s %s" % (product.title(), version)),
+            jolokia_check_version(jolokia_version, params, "Jolokia")]
 
 
 check_info["jolokia_info"] = {
@@ -34,4 +35,6 @@ check_info["jolokia_info"] = {
     "service_description": "JVM %s",
     "check_function": check_jolokia_info,
     "inventory_function": discover(),
+    "includes": ["jolokia.include"],
+    "group": "jvm_jolokia_info",
 }

--- a/cmk/gui/plugins/wato/check_parameters/jvm_jolokia_version.py
+++ b/cmk/gui/plugins/wato/check_parameters/jvm_jolokia_version.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 tribe29 GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+
+from cmk.gui.i18n import _
+from cmk.gui.valuespec import (
+    CascadingDropdown,
+    Dictionary,
+    TextAscii,
+)
+
+from cmk.gui.plugins.wato import (
+    CheckParameterRulespecWithoutItem,
+    rulespec_registry,
+    RulespecGroupCheckParametersApplications,
+)
+
+
+def _parameter_valuespec_jolokia_version():
+    return Dictionary(elements=[
+        ("version",
+         CascadingDropdown(
+             title=_("Check for correct Jolokia version"),
+             help=_("You can make sure that the plugin is running"
+                    " with a specific or a minimal version."),
+             choices=[
+                 ("at_least", _("At least"), TextAscii(title=_("At least"), allow_empty=False)),
+                 ("specific", _("Specific version"),
+                  TextAscii(title=_("Specific version"), allow_empty=False)),
+             ],
+         )),
+    ],)
+
+
+rulespec_registry.register(
+    CheckParameterRulespecWithoutItem(
+        check_group_name="jvm_jolokia_info",
+        group=RulespecGroupCheckParametersApplications,
+        match_type="dict",
+        parameter_valuespec=_parameter_valuespec_jolokia_version,
+        title=lambda: _("JVM Jolokia version"),
+    ))

--- a/tests/unit/checks/generictests/datasets/jolokia_info_regression.py
+++ b/tests/unit/checks/generictests/datasets/jolokia_info_regression.py
@@ -23,5 +23,5 @@ checks = {
         3,
         'mk_jolokia requires either the json or simplejson library. Please either use a Python version that contains the json library or install the simplejson library on the monitored system.',
         [])]), ('INSTANCE1', {}, [(2, 'ERROR HTTP404 No response from server or whatever', [])]),
-         ('INSTANCE2', {}, [(0, 'Tomcat 3.141592 (Jolokia version 42.23)', [])])]
+         ('INSTANCE2', {}, [(0, 'Tomcat 3.141592', []), (0, 'Jolokia 42.23', [])])]
 }

--- a/tests/unit/checks/test_jolokia_include.py
+++ b/tests/unit/checks/test_jolokia_include.py
@@ -4,6 +4,8 @@
 # This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
 # conditions defined in the file COPYING, which is part of this source code package.
 
+# type: ignore
+
 import os
 import pytest  # type: ignore[import]
 
@@ -37,3 +39,66 @@ def test_jolokia_basic_split_fail_value(line, length):
 def test_jolokia_basic_split_fail_notimplemented(line, length):
     with pytest.raises(NotImplementedError):
         jolokia_basic_split(line, length)  # type: ignore[name-defined] # pylint: disable=undefined-variable
+
+
+def test_version_specific():
+    params = {'version': ('specific', '1.6.0')}
+
+    actual = jolokia_check_version("1.6.0", params, "Jolokia")  # type: ignore[name-defined] # pylint: disable=undefined-variable
+    expected = (0, 'Jolokia 1.6.0')
+    assert expected == actual
+
+    actual = jolokia_check_version("1.3.7", params, "Jolokia")  # type: ignore[name-defined] # pylint: disable=undefined-variable
+    expected = (2, 'Jolokia 1.3.7 (should be 1.6.0)')
+    assert expected == actual
+
+
+def test_version_at_least():
+    params = {'version': ('at_least', '1.5')}
+
+    actual = jolokia_check_version("1.5", params, "Jolokia")  # type: ignore[name-defined] # pylint: disable=undefined-variable
+    expected = (0, 'Jolokia 1.5')
+    assert expected == actual
+
+    actual = jolokia_check_version("1.5.0", params, "Jolokia")  # type: ignore[name-defined] # pylint: disable=undefined-variable
+    expected = (0, 'Jolokia 1.5.0')
+    assert expected == actual
+
+    actual = jolokia_check_version("1.5.1", params, "Jolokia")  # type: ignore[name-defined] # pylint: disable=undefined-variable
+    expected = (0, 'Jolokia 1.5.1')
+    assert expected == actual
+
+    actual = jolokia_check_version("1.6.3", params, "Jolokia")  # type: ignore[name-defined] # pylint: disable=undefined-variable
+    expected = (0, 'Jolokia 1.6.3')
+    assert expected == actual
+
+    actual = jolokia_check_version("1.3.7", params, "Jolokia")  # type: ignore[name-defined] # pylint: disable=undefined-variable
+    expected = (2, 'Jolokia 1.3.7 (should be at least 1.5)')
+    assert expected == actual
+
+    actual = jolokia_check_version("1.4", params, "Jolokia")  # type: ignore[name-defined] # pylint: disable=undefined-variable
+    expected = (2, 'Jolokia 1.4 (should be at least 1.5)')
+    assert expected == actual
+
+
+def test_version_unparseable():
+    const_error = "Only characters 0-9 and . are allowed for a version."
+    params = {'version': ('at_least', '1.5')}
+
+    actual = jolokia_check_version("1.5a", params, "Jolokia")  # type: ignore[name-defined] # pylint: disable=undefined-variable
+    expected = (3, 'Can not compare 1.5a and 1.5. ' + const_error)
+    assert expected == actual
+
+
+def test_version_unparseable_without_wato_rule():
+    params = {}
+    actual = jolokia_check_version('2.x', params, "Jolokia")  # type: ignore[name-defined] # pylint: disable=undefined-variable
+    expected = (0, "Jolokia 2.x")
+    assert expected == actual
+
+
+def test_version_not_present():
+    params = {}
+    actual = jolokia_check_version(None, params, "Jolokia")  # type: ignore[name-defined] # pylint: disable=undefined-variable
+    expected = (3, "Jolokia None (no agent info)")
+    assert expected == actual


### PR DESCRIPTION
With this new WATO rule it is possible to ensure a certain version level
of Jolokia for example to find out dated or vulnerable versions.