### PR TITLE
cmkoc 84: mk_oracle_crs: Support for Solaris + ShellCheck

### DIFF
--- a/agents/plugins/mk_oracle_crs
+++ b/agents/plugins/mk_oracle_crs
@@ -38,11 +38,11 @@ function set_osenv () {
 
 function set_has_env(){
     test -f ${ocrcfgfile} || exit 0
-    local_has_type=$(cat $ocrcfgfile | $GREP "^local_only=" | cut -d"=" -f2 | tr '[:lower:]' '[:upper:]')
+    local_has_type=$($GREP "^local_only=" "$ocrcfgfile" | cut -d"=" -f2 | tr '[:lower:]' '[:upper:]')
     local_has_type=${local_has_type:-"FALSE"}
 
     if [ -f ${olrcfgfile} ] ; then
-        has_ORACLE_HOME=$(cat $olrcfgfile | $GREP "^crs_home=" | cut -d"=" -f2)
+        has_ORACLE_HOME=$($GREP "^crs_home=" "$olrcfgfile" | cut -d"=" -f2)
     else
         # There is no olr.cfg in 10.2 and 11.1
         # we try to get the ORA_CRS_HOME from /etc/init.d/init.cssd
@@ -67,8 +67,8 @@ function printhasdata() {
     $CRSCTL query has releaseversion
 
     echo "<<<oracle_crs_res:sep(124)>>>"
-    OLS_NODENAME=`uname -n`
-    echo "nodename|"$OLS_NODENAME
+    OLS_NODENAME=$(uname -n)
+    echo "nodename|$OLS_NODENAME"
     $CRSCTL stat res -f | $GREP -E $resourcefilter | sed "s/^/csslocal\|/"
 }
 
@@ -77,7 +77,7 @@ function printcrsdata() {
 
     echo "<<<oracle_crs_version:sep(124)>>>"
     crs_version=$($CRSCTL query crs releaseversion)
-    echo $crs_version
+    echo "$crs_version"
 
     echo "<<<oracle_crs_voting>>>"
     $CRSCTL query css votedisk | $GREP "^ [0-9]"
@@ -86,11 +86,11 @@ function printcrsdata() {
     echo "<<<oracle_crs_res:sep(124)>>>"
     OLS_NODENAME=$($OLSNODES -l)
 
-    echo "nodename|"$OLS_NODENAME
+    echo "nodename|$OLS_NODENAME"
 
-    crs_version_short=$(echo $crs_version | cut -d"[" -f2- | cut -d"." -f-2 | sed 's/\.//')
-    if [ $(($crs_version_short)) -ge 112 ] ; then
-        $CRSCTL stat res -v -n $OLS_NODENAME -init | $GREP -E $resourcefilter | sed "s/^/csslocal\|/"
+    crs_version_short=$(echo "$crs_version" | cut -d"[" -f2- | cut -d"." -f-2 | sed 's/\.//')
+    if [ "$crs_version_short" -ge 112 ] ; then
+        $CRSCTL stat res -v -n "$OLS_NODENAME" -init | $GREP -E "$resourcefilter" | sed "s/^/csslocal\|/"
         for nodelist in $($OLSNODES)
         do
             $CRSCTL stat res -v -n "$nodelist" | $GREP -E "$resourcefilter" | sed "s/^/$nodelist\|/"

--- a/agents/plugins/mk_oracle_crs
+++ b/agents/plugins/mk_oracle_crs
@@ -7,8 +7,6 @@
 
 set -f
 
-ocrcfgfile=/etc/oracle/ocr.loc
-olrcfgfile=/etc/oracle/olr.loc
 resourcefilter="^NAME=|^TYPE=|^STATE=|^TARGET=|^ENABLED="
 
 #   .--Functions-----------------------------------------------------------.
@@ -22,13 +20,29 @@ resourcefilter="^NAME=|^TYPE=|^STATE=|^TARGET=|^ENABLED="
 #   |                                                                      |
 #   '----------------------------------------------------------------------'
 
+function set_osenv () {
+    ostype=$(uname -s)
+    if [ "$ostype" = 'Linux' ] ; then
+        ocrcfgfile=/etc/oracle/ocr.loc
+        olrcfgfile=/etc/oracle/olr.loc
+        GREP=$(which grep)
+    elif [ "$ostype" = 'SunOS' ] ; then
+        ocrcfgfile=/var/opt/oracle/ocr.loc
+        olrcfgfile=/var/opt/oracle/olr.loc
+        GREP=/usr/xpg4/bin/grep
+    else
+        ostype="unknown OS: ${ostype}"
+	    exit 1
+    fi
+}
+
 function set_has_env(){
     test -f ${ocrcfgfile} || exit 0
-    local_has_type=$(cat $ocrcfgfile | grep "^local_only=" | cut -d"=" -f2 | tr '[:lower:]' '[:upper:]')
+    local_has_type=$(cat $ocrcfgfile | $GREP "^local_only=" | cut -d"=" -f2 | tr '[:lower:]' '[:upper:]')
     local_has_type=${local_has_type:-"FALSE"}
 
     if [ -f ${olrcfgfile} ] ; then
-        has_ORACLE_HOME=$(cat $olrcfgfile | grep "^crs_home=" | cut -d"=" -f2)
+        has_ORACLE_HOME=$(cat $olrcfgfile | $GREP "^crs_home=" | cut -d"=" -f2)
     else
         # There is no olr.cfg in 10.2 and 11.1
         # we try to get the ORA_CRS_HOME from /etc/init.d/init.cssd
@@ -37,7 +51,7 @@ function set_has_env(){
         if [ ! -f ${INITCSSD} ] ; then
             exit 0
         else
-            has_ORACLE_HOME=$(grep "^ORA_CRS_HOME=" ${INITCSSD} | cut -d"=" -f2-)
+            has_ORACLE_HOME=$($GREP "^ORA_CRS_HOME=" ${INITCSSD} | cut -d"=" -f2-)
         fi
     fi
 
@@ -47,26 +61,28 @@ function set_has_env(){
 }
 
 function printhasdata() {
-    ps -e | grep cssd.bin > /dev/null || exit 0
+    ps -ef | $GREP -v grep | $GREP cssd.bin > /dev/null || exit 0
 
     echo "<<<oracle_crs_version:sep(124)>>>"
     $CRSCTL query has releaseversion
 
-    echo "<<<oracle_crs_res>>>"
-    $CRSCTL stat res -f | grep -E $resourcefilter
+    echo "<<<oracle_crs_res:sep(124)>>>"
+    OLS_NODENAME=`uname -n`
+    echo "nodename|"$OLS_NODENAME
+    $CRSCTL stat res -f | $GREP -E $resourcefilter | sed "s/^/csslocal\|/"
 }
 
 function printcrsdata() {
-    ps -e | grep -e ohasd.bin -e crsd.bin > /dev/null || exit 0
+    ps -ef | $GREP -v grep | $GREP -e ohasd.bin -e crsd.bin > /dev/null || exit 0
 
     echo "<<<oracle_crs_version:sep(124)>>>"
     crs_version=$($CRSCTL query crs releaseversion)
     echo $crs_version
 
     echo "<<<oracle_crs_voting>>>"
-    $CRSCTL query css votedisk | grep "^ [0-9]"
+    $CRSCTL query css votedisk | $GREP "^ [0-9]"
 
-    ps -e | grep crsd.bin > /dev/null || exit 0
+    ps -ef | $GREP -v grep | $GREP crsd.bin > /dev/null || exit 0
     echo "<<<oracle_crs_res:sep(124)>>>"
     OLS_NODENAME=$($OLSNODES -l)
 
@@ -74,13 +90,13 @@ function printcrsdata() {
 
     crs_version_short=$(echo $crs_version | cut -d"[" -f2- | cut -d"." -f-2 | sed 's/\.//')
     if [ $(($crs_version_short)) -ge 112 ] ; then
-        $CRSCTL stat res -v -n $OLS_NODENAME -init | grep -E $resourcefilter | sed "s/^/csslocal\|/"
+        $CRSCTL stat res -v -n $OLS_NODENAME -init | $GREP -E $resourcefilter | sed "s/^/csslocal\|/"
         for nodelist in $($OLSNODES)
         do
-            $CRSCTL stat res -v -n $nodelist | grep -E $resourcefilter | sed "s/^/$nodelist\|/"
+            $CRSCTL stat res -v -n "$nodelist" | $GREP -E "$resourcefilter" | sed "s/^/$nodelist\|/"
         done
     else
-        $CRS_STAT -f -c $OLS_NODENAME | grep -E $resourcefilter | sed "s/^/$OLS_NODENAME\|/"
+        $CRS_STAT -f -c "$OLS_NODENAME" | $GREP -E "$resourcefilter" | sed "s/^/$OLS_NODENAME\|/"
     fi
 }
 
@@ -96,6 +112,7 @@ function printcrsdata() {
 #   |                                                                      |
 #   '----------------------------------------------------------------------'
 
+set_osenv
 set_has_env
 echo "<<<oracle_crs_res>>>"
 echo "<<<oracle_crs_version>>>"
@@ -105,4 +122,3 @@ if [ $local_has_type = 'FALSE' ] ; then
 else
     printhasdata
 fi
-


### PR DESCRIPTION
This PR includes the extension for supporting the plugin mk_oracle_crs on Solaris

Some fixes for ShellCheck are done as well.