### PR TITLE
md-raid: add detection for check-state

### DIFF
--- a/checks/md
+++ b/checks/md
@@ -208,9 +208,9 @@ def check_md(item, _no_params, parsed):
     if "speed" in data:
         infotexts.append("Speed: %s" % data["speed"])
 
-    if "check_state" in data:
+    if "check_values" in data:
         header = "[Check]"
-        infotexts.append("Status: %s" % data["check_state"])
+        infotexts.append("Status: %s" % data["check_values"])
         yield 0, "%s %s" % (header, ", ".join(infotexts))
 
     elif infotexts:

--- a/checks/md
+++ b/checks/md
@@ -193,7 +193,7 @@ def check_md(item, _no_params, parsed):
     if "resync_state" in data:
         header = "[Resync]"
         infotexts.append("Status: %s" % data["resync_state"])
-        
+
     if "resync_values" in data:
         header = "[Resync]"
         infotexts.append(data["resync_values"])
@@ -201,21 +201,21 @@ def check_md(item, _no_params, parsed):
     if "recovery_values" in data:
         header = "[Recovery]"
         infotexts.append(data["recovery_values"])
-        
+
     if "finish" in data:
         infotexts.append("Finish: %s" % data["finish"])
 
     if "speed" in data:
         infotexts.append("Speed: %s" % data["speed"])
-        
+
     if "check_state" in data:
         header = "[Check]"
         infotexts.append("Status: %s" % data["check_state"])
         yield 0, "%s %s" % (header, ", ".join(infotexts))
-    
+
     elif infotexts:
         yield 1, "%s %s" % (header, ", ".join(infotexts))
-        
+
 
 check_info["md"] = {
     'parse_function': parse_md,

--- a/checks/md
+++ b/checks/md
@@ -72,6 +72,21 @@
 # unused devices: <none>
 # ----------------------------------------------------------
 
+# Example of RAID5 being checked
+#Personalities : [raid1] [raid6] [raid5] [raid4]
+#md125 : active raid1 sdb2[0] sdd2[1]
+#      182751552 blocks super 1.2 [2/2] [UU]
+#      bitmap: 1/2 pages [4KB], 65536KB chunk
+#
+#md126 : active raid5 sdf1[5] sde1[2] sdc1[1] sdg1[3] sda1[0]
+#      31255568384 blocks super 1.2 level 5, 512k chunk, algorithm 2 [5/5] [UUUUU]
+#      [===============>.....]  check = 76.0% (5938607824/7813892096) finish=255.8min speed=122145K/sec
+#      bitmap: 0/59 pages [0KB], 65536KB chunk
+#
+#md127 : active raid1 sdd1[1] sdb1[0]
+#      67107840 blocks super 1.2 [2/2] [UU]
+#      bitmap: 1/1 pages [4KB], 65536KB chunk
+
 # And now for something completely different:
 # ---------------------------------------------------------
 # Personalities : [raid1] [raid10]
@@ -122,7 +137,7 @@ def parse_md(info):
                     if e.startswith("finish=") or e.startswith("speed="):
                         k, v = e.split("=")
                         instance[k] = v
-                    elif e in ["recovery", "resync"]:
+                    elif e in ["recovery", "resync", "check"]:
                         instance["%s_values" % e] = line[idx + 3]
                 continue
 
@@ -178,7 +193,7 @@ def check_md(item, _no_params, parsed):
     if "resync_state" in data:
         header = "[Resync]"
         infotexts.append("Status: %s" % data["resync_state"])
-
+        
     if "resync_values" in data:
         header = "[Resync]"
         infotexts.append(data["resync_values"])
@@ -186,16 +201,21 @@ def check_md(item, _no_params, parsed):
     if "recovery_values" in data:
         header = "[Recovery]"
         infotexts.append(data["recovery_values"])
-
+        
     if "finish" in data:
         infotexts.append("Finish: %s" % data["finish"])
 
     if "speed" in data:
         infotexts.append("Speed: %s" % data["speed"])
-
-    if infotexts:
+        
+    if "check_state" in data:
+        header = "[Check]"
+        infotexts.append("Status: %s" % data["check_state"])
+        yield 0, "%s %s" % (header, ", ".join(infotexts))
+    
+    elif infotexts:
         yield 1, "%s %s" % (header, ", ".join(infotexts))
-
+        
 
 check_info["md"] = {
     'parse_function': parse_md,


### PR DESCRIPTION
atm checks turn md-service into warning state, bc. they come with "finish" and "speed" values. Checks are "By default, run at 00:57 on every Sunday, but do nothing unless the day of the month is less than or equal to 7 [...]". 
A check is no resync or recovery, it's just a periodic check and shouldn't degrade the state of the raid.