### PR TITLE
Exclude BeeGFS from df check

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -200,7 +200,7 @@ section_df() {
     # The exclusion list is getting a bit of a problem.
     # -l should hide any remote FS but seems to be all but working.
     local excludefs
-    excludefs="-x smbfs -x cifs -x iso9660 -x udf -x nfsv4 -x nfs -x mvfs -x prl_fs -x squashfs -x devtmpfs -x autofs"
+    excludefs="-x smbfs -x cifs -x iso9660 -x udf -x nfsv4 -x nfs -x mvfs -x prl_fs -x squashfs -x devtmpfs -x autofs -x beegfs"
     if [ -z "$IS_LXC_CONTAINER" ]; then
         excludefs+=" -x zfs"
     fi


### PR DESCRIPTION
Exclude the BeeGFS parallel file system from the df check on linux as it may cause filesystem overload