### PR TITLE
Add detection that we are running inside a podman container

### DIFF
--- a/omd/packages/omd/omdlib/utils.py
+++ b/omd/packages/omd/omdlib/utils.py
@@ -33,7 +33,7 @@ import cmk.utils.tty as tty
 
 
 def is_dockerized() -> bool:
-    return os.path.exists("/.dockerenv")
+    return os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Not detecting that we are running in a podman container with --tmpfs makes the ./docker-entrypoint.sh and especially the  'omd create --no-tmpfs -u 1000 -g 1000 --admin-password "$CMK_PASSWORD" "$CMK_SITE_ID"' will fail because it uses the wrong path to check if the cmk site is already existing. Result is that it does not create a new site because it thinks it already exists ( because --tmpfs created the path)