### PR TITLE
De-bash: remove function keyword from shell scripts

### DIFF
--- a/agents/check_mk_agent.aix
+++ b/agents/check_mk_agent.aix
@@ -57,8 +57,7 @@ fi
 # commands. This version does not conserve the original exit code
 # of the command. It is successfull if the command terminated
 # in time.
-function waitmax
-{
+waitmax() {
    TIMEOUT=${1}0
    SIGNAL=9
    shift
@@ -83,7 +82,7 @@ function waitmax
    return 255
 }
 
-function run_cached {
+run_cached() {
     NAME=$1
     # Be aware: Maxage was expected to be given in minutes but this was
     # confusing because all other agents use seconds here. So this has

--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -50,7 +50,7 @@ else
 fi
 
 # Runs a command asynchronous by use of a cache file
-function run_cached() {
+run_cached() {
     if [ "$1" = -s ] ; then local section="echo '<<<$2>>>' ; " ; shift ; fi
     local NAME=$1
     local MAXAGE=$2

--- a/agents/check_mk_agent.solaris
+++ b/agents/check_mk_agent.solaris
@@ -40,7 +40,7 @@ else
     exec </dev/null 2>/dev/null
 fi
 
-function file_age() {
+file_age() {
     /usr/bin/perl -e 'if (! -f $ARGV[0]){die "0000000"};$mtime=(stat($ARGV[0]))[9];print ($^T-$mtime);' "$1"
 }
 
@@ -49,7 +49,7 @@ file_mtime () {
 }
 
 
-function run_mrpe() {
+run_mrpe() {
     local descr=$1
     shift
     local cmdline="$@"
@@ -66,7 +66,7 @@ export -f run_mrpe
 
 
 # Runs a command asynchronous by use of a cache file
-function run_cached () {
+run_cached() {
     local mrpe=0
     local append_age=0
     # TODO: this function is unable to handle mulitple args at once

--- a/agents/plugins/mk_apt
+++ b/agents/plugins/mk_apt
@@ -25,7 +25,7 @@ UPGRADE=upgrade
 DO_UPDATE=yes
 
 
-function check_apt_update {
+check_apt_update() {
     if [ "$DO_UPDATE" = yes ] ; then
         # NOTE: Even with -qq, apt-get update can output several lines to
         # stderr, e.g.:

--- a/agents/plugins/mk_informix
+++ b/agents/plugins/mk_informix
@@ -21,7 +21,7 @@ set -a
 #   '----------------------------------------------------------------------'
 
 
-function do_check () {
+do_check() {
     # $1:section, $2:excludelist
     if echo "$2" | grep -qe "${1}"; then
         return 1
@@ -31,7 +31,7 @@ function do_check () {
 }
 
 
-function sql () {
+sql() {
     db="sysmaster"
     sqltxt="$1"
     dbaccess_par=
@@ -40,7 +40,7 @@ function sql () {
 }
 
 
-function set_excludes () {
+set_excludes() {
     excludes=""
     if [ "$EXCLUDES" = "ALL" ]; then
         excludes="$all_sections"
@@ -77,7 +77,7 @@ function set_excludes () {
 all_sections="sessions locks tabextents dbspaces logusage"
 
 
-function informix_status(){
+informix_status(){
     echo "<<<informix_status:sep(58)>>>"
     echo "[[[$INFORMIXSERVER/$SERVERNUM]]]"
     $INFORMIXDIR/bin/onstat - >/dev/null 2>&1
@@ -89,7 +89,7 @@ function informix_status(){
 }
 
 
-function informix_sessions(){
+informix_sessions(){
     echo "<<<informix_sessions>>>"
     echo "[[[$INFORMIXSERVER/$SERVERNUM]]]"
     # don't count our own session
@@ -97,7 +97,7 @@ function informix_sessions(){
 }
 
 
-function informix_locks(){
+informix_locks(){
     echo "<<<informix_locks>>>"
     echo "[[[$INFORMIXSERVER/$SERVERNUM]]]"
     # don't count our own session
@@ -105,7 +105,7 @@ function informix_locks(){
 }
 
 
-function informix_tabextents(){
+informix_tabextents(){
     echo "<<<informix_tabextents>>>"
     echo "[[[$INFORMIXSERVER/$SERVERNUM]]]"
     sql "select first 10
@@ -123,7 +123,7 @@ function informix_tabextents(){
 }
 
 
-function informix_dbspaces(){
+informix_dbspaces(){
     echo "<<<informix_dbspaces>>>"
     echo "[[[$INFORMIXSERVER/$SERVERNUM]]]"
     sql "select
@@ -147,7 +147,7 @@ function informix_dbspaces(){
 }
 
 
-function informix_logusage(){
+informix_logusage(){
     echo "<<<informix_logusage>>>"
     echo "[[[$INFORMIXSERVER/$SERVERNUM]]]"
     sql "select 'LOGUSAGE',

--- a/agents/plugins/mk_mysql
+++ b/agents/plugins/mk_mysql
@@ -8,7 +8,7 @@
 VERSION="2.1.0i1"
 
 # gets optional socket as argument
-function do_query() {
+do_query() {
 
   # we use the sockets full name as instance name:
   INSTANCE_HEADER="[[$2]]"

--- a/agents/plugins/mk_oracle
+++ b/agents/plugins/mk_oracle
@@ -2967,7 +2967,7 @@ do_dummy_sections
 
 #   ---local----------------------------------------------------------------
 
-function execute_queries_for_sid () {
+execute_queries_for_sid() {
     local sid="$1"
     set_ora_env "$sid"
     if [ $? -eq 2 ] ; then

--- a/agents/plugins/mk_oracle_crs
+++ b/agents/plugins/mk_oracle_crs
@@ -26,7 +26,7 @@ resourcefilter="^NAME=|^TYPE=|^STATE=|^TARGET=|^ENABLED="
 #   |                                                                      |
 #   '----------------------------------------------------------------------'
 
-function set_has_env(){
+set_has_env(){
     test -f ${ocrcfgfile} || exit 0
     local_has_type=$(cat $ocrcfgfile | grep "^local_only=" | cut -d"=" -f2 | tr '[:lower:]' '[:upper:]')
     local_has_type=${local_has_type:-"FALSE"}
@@ -50,7 +50,7 @@ function set_has_env(){
     CRS_STAT=${has_ORACLE_HOME}/bin/crs_stat
 }
 
-function printhasdata() {
+printhasdata() {
     ps -e | grep cssd.bin > /dev/null || exit 0
 
     echo "<<<oracle_crs_version:sep(124)>>>"
@@ -60,7 +60,7 @@ function printhasdata() {
     $CRSCTL stat res -f | grep -E $resourcefilter
 }
 
-function printcrsdata() {
+printcrsdata() {
     ps -e | grep -e ohasd.bin -e crsd.bin > /dev/null || exit 0
 
     echo "<<<oracle_crs_version:sep(124)>>>"

--- a/agents/plugins/mk_sap_hana
+++ b/agents/plugins/mk_sap_hana
@@ -11,7 +11,7 @@ VERSION="2.1.0i1"
 # Copyright Gerd Stolz - SVA - 2016
 # (c) 2017 Heinlein Support GmbH, Robert Sander <r.sander@heinlein-support.de>
 
-display_usage () {
+display_usage() {
     cat <<USAGE
 
 USAGE:
@@ -84,7 +84,7 @@ fi
 #   '----------------------------------------------------------------------'
 
 
-function mk_hdbsql () {
+mk_hdbsql() {
     local sid="$1"
     local instance="$2"
     local instance_user="$3"
@@ -124,7 +124,7 @@ function mk_hdbsql () {
 #   '----------------------------------------------------------------------'
 
 
-function query_sap_hana_status () {
+query_sap_hana_status() {
     cat <<QUERY
 SELECT Name, Status, Value FROM M_SYSTEM_OVERVIEW Where NAME='Version' or
 NAME='All Started'
@@ -132,7 +132,7 @@ QUERY
 }
 
 
-function query_sap_hana_backup_snapshots () {
+query_sap_hana_backup_snapshots() {
     cat <<QUERY
 Select TOP 1 entry_type_name, sys_end_time, state_name, comment, message from
 M_BACKUP_CATALOG where entry_type_name = 'data snapshot' AND state_name <>
@@ -141,7 +141,7 @@ QUERY
 }
 
 
-function query_sap_hana_backup_complete () {
+query_sap_hana_backup_complete() {
     cat <<QUERY
 Select TOP 1 entry_type_name, sys_end_time, state_name, comment, message from
 M_BACKUP_CATALOG where entry_type_name = 'complete data backup' AND state_name
@@ -150,7 +150,7 @@ QUERY
 }
 
 
-function query_sap_hana_backup_log () {
+query_sap_hana_backup_log() {
     cat <<QUERY
 Select TOP 1 entry_type_name, sys_end_time, state_name, comment, message from
 M_BACKUP_CATALOG where entry_type_name = 'log backup' AND state_name <>
@@ -159,7 +159,7 @@ QUERY
 }
 
 
-function query_sap_hana_diskusage () {
+query_sap_hana_diskusage() {
     cat <<QUERY
 SELECT name,status,value FROM M_SYSTEM_OVERVIEW Where NAME='Data' or NAME='Log'
 or NAME='Trace'
@@ -167,7 +167,7 @@ QUERY
 }
 
 
-function query_sap_hana_data_volume () {
+query_sap_hana_data_volume() {
     local hostname="$1"
     cat <<QUERY
 SELECT FILE_TYPE, SERVICE_NAME, VOLUME_ID, FILE_NAME, DISK_USED_SIZE,
@@ -190,7 +190,7 @@ QUERY
 }
 
 
-function query_sap_hana_license () {
+query_sap_hana_license() {
     cat <<QUERY
 SELECT
 ENFORCED,PERMANENT,LOCKED_DOWN,PRODUCT_USAGE,PRODUCT_LIMIT,VALID,EXPIRATION_DATE
@@ -199,7 +199,7 @@ QUERY
 }
 
 
-function query_logwatch_alerts_last_check () {
+query_logwatch_alerts_last_check() {
     local alerts_last_check="$1"
     cat <<QUERY
 Select ALERT_TIMESTAMP,ALERT_ID,ALERT_RATING,ALERT_DETAILS from
@@ -210,7 +210,7 @@ QUERY
 }
 
 
-function query_logwatch_no_alerts () {
+query_logwatch_no_alerts() {
     cat <<QUERY
 Select ALERT_TIMESTAMP,ALERT_ID,ALERT_RATING,ALERT_DETAILS from
 _SYS_STATISTICS.STATISTICS_ALERTS Where ALERT_TIMESTAMP IN (Select
@@ -221,7 +221,7 @@ QUERY
 }
 
 
-function query_sap_hana_ess_started () {
+query_sap_hana_ess_started() {
     local hostname="$1"
     cat <<QUERY
 SELECT 'started', count(*) FROM M_SERVICE_THREADS where
@@ -230,7 +230,7 @@ QUERY
 }
 
 
-function query_sap_hana_ess_active () {
+query_sap_hana_ess_active() {
     cat <<QUERY
 select 'active', MAP(IFNULL(SYSTEM_VALUE, IFNULL(HOST_VALUE,DEFAULT_VALUE)),
 'true', 'yes', 'false', 'no', 'unknown') FROM (SELECT  MAX(MAP(LAYER_NAME,
@@ -241,14 +241,14 @@ SYSTEM_VALUE FROM  M_INIFILE_CONTENTS WHERE  FILE_NAME IN ('indexserver.ini',
 QUERY
 }
 
-function query_sap_hana_ess_migration () {
+query_sap_hana_ess_migration() {
     cat << QUERY
 select value from _SYS_STATISTICS.STATISTICS_PROPERTIES where key = 'internal.installation.state'
 QUERY
 }
 
 
-function query_sap_hana_memrate () {
+query_sap_hana_memrate() {
     local hostname="$1"
     cat <<QUERY
 SELECT 'mem_rate', INSTANCE_TOTAL_MEMORY_USED_SIZE, ALLOCATION_LIMIT FROM
@@ -257,14 +257,14 @@ QUERY
 }
 
 
-function query_sap_hana_events_open () {
+query_sap_hana_events_open() {
     cat <<QUERY
 select 'open_events', count(*) from m_events where acknowledged='FALSE'
 QUERY
 }
 
 
-function query_sap_hana_events_disabled_alerts () {
+query_sap_hana_events_disabled_alerts() {
     cat <<QUERY
 select 'disabled_alerts', count(*) from _sys_statistics.STATISTICS_SCHEDULE
 where status='Disabled'
@@ -272,7 +272,7 @@ QUERY
 }
 
 
-function query_sap_hana_events_high_alerts () {
+query_sap_hana_events_high_alerts() {
     cat <<QUERY
 select 'high_alerts', count(*) from _sys_statistics.statistics_current_alerts
 where  alert_rating >=4
@@ -280,7 +280,7 @@ QUERY
 }
 
 
-function query_sap_hana_proc () {
+query_sap_hana_proc() {
     local hostname="$1"
     cat <<QUERY
 SELECT PORT,SERVICE_NAME,PROCESS_ID,DETAIL,ACTIVE_STATUS,SQL_PORT,COORDINATOR_TYPE
@@ -289,7 +289,7 @@ QUERY
 }
 
 
-function query_sap_hana_threads_max () {
+query_sap_hana_threads_max() {
     local hostname="$1"
     cat <<QUERY
 select MAX(CPU_TIME_CUMULATIVE), THREAD_METHOD from M_SERVICE_THREADS where
@@ -298,7 +298,7 @@ QUERY
 }
 
 
-function query_sap_hana_threads_service_name () {
+query_sap_hana_threads_service_name() {
     local hostname="$1"
     cat <<QUERY
 SELECT SERVICE_NAME, CONNECTION_ID, THREAD_ID, THREAD_METHOD, CALLER, DURATION
@@ -307,7 +307,7 @@ QUERY
 }
 
 
-function query_fileinfo () {
+query_fileinfo() {
     local sid="$1"
     local instance="$2"
     local hostname="$3"
@@ -330,7 +330,7 @@ QUERY
 #   '----------------------------------------------------------------------'
 
 
-function sap_hana_check_alerts () {
+sap_hana_check_alerts() {
     local sid="$1"
     local instance="$2"
     local instance_user="$3"
@@ -370,7 +370,7 @@ function sap_hana_check_alerts () {
 }
 
 
-function sap_hana_replication_status () {
+sap_hana_replication_status() {
     local sid="$1"
     local instance="$2"
     local instance_user="$3"
@@ -379,7 +379,7 @@ function sap_hana_replication_status () {
     echo "$result"
 }
 
-function sap_hana_connect() {
+sap_hana_connect() {
     local sid="$1"
     local instance="$2"
     local instance_user="$3"
@@ -415,7 +415,7 @@ function sap_hana_connect() {
     echo "$resp" | tr ';' ','  |  tr '\n' ';' | sed -e "s/^;//g" -e "s/;$/\n/g"
 }
 
-function sap_hana_role_from_landscape() {
+sap_hana_role_from_landscape() {
     local landscape="$1"
     local hostname="$2"
 
@@ -452,7 +452,7 @@ function sap_hana_role_from_landscape() {
     done <<< "$landscape"
 }
 
-function sap_hana_host_from_landscape() {
+sap_hana_host_from_landscape() {
     local landscape=$1
 
     local col_hosts=1
@@ -509,7 +509,7 @@ function sap_hana_host_from_landscape() {
 #   '----------------------------------------------------------------------'
 
 
-function do_query () {
+do_query() {
     local SID="$1"
     local INSTANCE="$2"
     local INSTANCE_USER="$3"

--- a/agents/plugins/mk_site_object_counts
+++ b/agents/plugins/mk_site_object_counts
@@ -17,7 +17,7 @@ VERSION="2.1.0i1"
 #   '----------------------------------------------------------------------'
 
 
-function get_tag_stats () {
+get_tag_stats() {
     local socket="$1"
     local site="$2"
     local header="$3"
@@ -34,7 +34,7 @@ function get_tag_stats () {
 }
 
 
-function get_check_command_stats () {
+get_check_command_stats() {
     local socket="$1"
     local site="$2"
     local header="$3"

--- a/agents/windows/do-chroot
+++ b/agents/windows/do-chroot
@@ -50,8 +50,7 @@ else
     EXIT_CODE=$?
 fi
 
-function unmount()
-{
+unmount() {
     target=$1
     umount $target
     if [ $? != 0 ] ; then

--- a/buildscripts/scripts/sign-packages.sh
+++ b/buildscripts/scripts/sign-packages.sh
@@ -35,7 +35,7 @@ fi
 cp -a /bauwelt/etc/.gnupg /gnupg
 export GNUPGHOME=/gnupg
 
-function is_already_signed() {
+is_already_signed() {
     if [[ "$FILE_PATH" == *rpm ]]; then
         if rpm -qp "$FILE_PATH" --qf='%-{NAME} %{SIGPGP:pgpsig}\n' | grep -i "Key ID $KEY_ID"; then
             return 0
@@ -52,7 +52,7 @@ function is_already_signed() {
     exit 1
 }
 
-function sign_package() {
+sign_package() {
     if [[ "$FILE_PATH" == *rpm ]]; then
         echo "$GPG_PASSPHRASE" |
             rpm \

--- a/doc/treasures/deprecated/mk_oracle.old
+++ b/doc/treasures/deprecated/mk_oracle.old
@@ -61,8 +61,7 @@ fi
 # The cache is used for $CACHE_MAXAGE seconds. The CACHE_MAXAGE
 # option is pre-set to 120 seconds but can be changed in mk_oracle.cfg.
 
-function sqlplus ()
-{
+sqlplus() {
     if OUTPUT=$({ echo 'set pages 0' ; echo 'whenever sqlerror exit 1'; echo 'set lines 8000' ; echo 'set feedback off'; cat ; } | $MK_CONFDIR/sqlplus.sh $1)
     then
         echo "${OUTPUT}" | sed -e 's/[[:space:]]\+/ /g' -e '/^[[:space:]]*$/d' -e "s/^/$1 /"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,7 +7,7 @@ set -e -o pipefail
 
 HOOKROOT=/docker-entrypoint.d
 
-function exec_hook() {
+exec_hook() {
     HOOKDIR="$HOOKROOT/$1"
     if [ -d "$HOOKDIR" ]; then
         pushd "$HOOKDIR" >/dev/null
@@ -21,7 +21,7 @@ function exec_hook() {
     fi
 }
 
-function create_system_apache_config() {
+create_system_apache_config() {
     # We have the special situation that the site apache is directly accessed from
     # external without a system apache reverse proxy. We need to disable the canonical
     # name redirect here to make redirects work as expected.

--- a/livestatus/src/test/.f12
+++ b/livestatus/src/test/.f12
@@ -8,7 +8,7 @@ set -e
 CONTAINER="artifacts.lan.tribe29.com:4000/ubuntu-20.04:master-latest"
 REPO_DIR=$(git rev-parse --show-toplevel)
 
-function execute_test() {
+execute_test() {
     LANG=C make -C ../../.. config.status
     (cd ../../.. && ./config.status)
     LANG=C make -j4 -C .. unit-test

--- a/omd/packages/pnp4nagios/skel/etc/init.d/pnp_gearman_worker
+++ b/omd/packages/pnp4nagios/skel/etc/init.d/pnp_gearman_worker
@@ -42,7 +42,7 @@ USER=###SITE###
 USERID=`id -u`
 CMD="$DAEMON --pidfile=$PIDFILE --config=$CFG $GM_PORT --daemon"
 
-function get_status() {
+get_status() {
         pid=`cat $PIDFILE 2>/dev/null`
         if [ "$pid" != "" ]; then
             ps -p $pid > /dev/null 2>&1
@@ -55,7 +55,7 @@ function get_status() {
         return 1;
 }
 
-function kill_procs() {
+kill_procs() {
     pid=`cat $PIDFILE 2>/dev/null`
     if [ -z $pid ]; then
         echo ". Not running."

--- a/scripts/lib-precommit
+++ b/scripts/lib-precommit
@@ -2,7 +2,7 @@
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
 
-function python_files() {
+python_files() {
     local shebang
     local prefix
     if [ $1 -eq 2 ]; then

--- a/scripts/run-cxx-linter
+++ b/scripts/run-cxx-linter
@@ -9,7 +9,7 @@ PATCHSET_REVISION=$2
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 REPO_DIR="$(dirname "$(cd "$(dirname "$SCRIPT_PATH")" >/dev/null 2>&1 && pwd)")"
 
-function execute_test() {
+execute_test() {
     # Prevpare Makefiles, otherwise "make compile_commands.json" will fail
     make -C "$REPO_DIR" config.h
 


### PR DESCRIPTION
The 'function' keyword is a non-portable bashism that is considered deprecated and obsolete.  This PR simply removes it from all identified shell scripts.