### PR TITLE
added support of petabytes in zpool check

### DIFF
--- a/checks/zpool
+++ b/checks/zpool
@@ -44,7 +44,7 @@ def check_zpool(item, params, parsed):
                 break
         num = float(val[:idx])
         unit = val[idx:].lstrip().lower()
-        unit = ["b", "k", "m", "g", "t"].index(unit)
+        unit = ["b", "k", "m", "g", "t", "p"].index(unit)
 
         return num * (1024**(unit - 2))
 


### PR DESCRIPTION
Zpool check was failing on a 2 PB infra, with the exception: "ValueError (u'p' is not in list)".