### PR TITLE
[smart] Do not wake up disks to read their smart attributes

### DIFF
--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -137,7 +137,7 @@ if which smartctl > /dev/null 2>&1 ; then
                 DNAME="${VEND}_${MODEL}_${SN}"
             fi
         else
-            CMD="smartctl -d ata -v 9,raw48 -A $D"
+            CMD="smartctl -d ata -v 9,raw48 -n standby,0 -A $D"
         fi
 
             if [ $VEND == "NVME" ]; then
@@ -166,4 +166,3 @@ if which smartctl > /dev/null 2>&1 ; then
 else
     echo "ERROR: smartctl not found" >&2
 fi
-

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -137,7 +137,7 @@ if which smartctl > /dev/null 2>&1 ; then
                 DNAME="${VEND}_${MODEL}_${SN}"
             fi
         else
-            CMD="smartctl -d ata -v 9,raw48 -n standby,0 -A $D"
+            CMD="smartctl -d ata -v 9,raw48 -n standby -A $D"
         fi
 
             if [ $VEND == "NVME" ]; then


### PR DESCRIPTION
Currently, disks in standby might potentially be woken up. I know both kinds of disks, once that spin up and once that hand out all attributes without. Standby mode for spinning disks saves considerable amounts of electrical energy.  Therefore, depending on the workload, admins might like to configure automatic standby for disks.

"Randomly" waking up disks are difficult to debug (caused by the agent). This change will create unknowns for disks that are not online. Not ideal, but arguably more transparent than waking up disks unnoticed.  For now, a rule could be created to not notify on unknown for those services. This is how I test this currently.

Some rationality: I consider this WIP. I am open for input how this could be improved. I could implement caching in the agent. Or do you have something in place to do caching in CheckMK for this case?

I realize that most businesses might not care about putting disks to standby to save energy because their power cost might be ridiculously cheap, but I hope we can agree that saving power matters.