### PR TITLE
Ignore mdstat lines starting with "Personalities"

### DIFF
--- a/checks/md
+++ b/checks/md
@@ -104,6 +104,8 @@ def parse_md(info):
     parsed = {}
     instance = {}
     for line in info:
+        if line[0].startswith("Personalities"):
+            continue
         if line[0].startswith("md") and line[1] == ':':
             if line[3].startswith("(") and line[3].endswith(")"):
                 raid_state = line[2] + line[3]


### PR DESCRIPTION
In case of clustered servers where software RAIDs are part of
the clustered services, "Personalities" lines may appear multiple
times in agent output.
Without this change, there are false alerts about RAID failure in
that particular corner case.