### PR TITLE
create labels for docker containers

### DIFF
--- a/checkman/docker_container_labels
+++ b/checkman/docker_container_labels
@@ -1,0 +1,16 @@
+title: Docker: Container Labels
+agents: linux
+catalog: containerization/docker
+license: GPL
+distribution: check_mk
+description:
+ The check plugin creates host labels based on the Docker labels of the containers.
+ The labels imported from Docker are prefixed with "docker/" in CheckMK.
+
+ To make this check work the agent plugin {{mk_docker.py}} has to be installed.
+ If you are using agent bakery rules, you must enable "Piggybacked docker containers".
+ If you are configuring the plugin via the configuration file, make sure you do not skip the
+ section "docker_containers_client" (the default setting is fine).
+
+inventory:
+ No service check is created.

--- a/checks/docker_container_labels
+++ b/checks/docker_container_labels
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 tribe29 GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+
+import cmk.base.plugins.agent_based.utils.docker as docker
+
+def parse_docker_container_labels(info):
+    '''process the first line to a JSON object
+
+    In case there are multiple lines of output sent by the agent only process the first
+    line. We assume that this a full JSON object. The rest of the section is skipped.
+    When a container got piggyback data from multiple hosts (e.g. a cluster) this results
+    in multiple JSON objects handed over to this check.
+    '''
+    version = docker.get_version(info)  # pylint: disable=undefined-variable
+
+    index = 0 if version is None else 1
+    parsed = docker.json_get_obj(info[index]) or {} if info[index:] else {}  # pylint: disable=undefined-variable
+
+    if version is None:
+        return DeprecatedDict(parsed)  # pylint: disable=undefined-variable
+    return parsed
+
+def discover_docker_container_labels(parsed):
+    for label, value in parsed.items():
+        yield HostLabel('docker/%s' % label, value)
+
+check_info['docker_container_labels'] = {
+    'parse_function': parse_docker_container_labels,
+    'inventory_function': discover_docker_container_labels,
+    'service_description': 'Docker container labels',
+    'includes': ['legacy_docker.include'],
+}

--- a/inventory/docker_container_labels
+++ b/inventory/docker_container_labels
@@ -14,7 +14,10 @@ def parse_docker_container_labels(info):
 
 
 def inv_docker_container_labels(info, inventory_tree):
-    data = parse_docker_container_labels(info)
+    if isinstance(data, list):
+        data = parse_docker_container_labels(info)
+    else:
+        data = info
     if data is None:
         return
     container = inventory_tree.get_dict("software.applications.docker.container.")

--- a/tests/unit/checks/test_generic_legacy_conversion.py
+++ b/tests/unit/checks/test_generic_legacy_conversion.py
@@ -1675,6 +1675,7 @@ def test_no_new_or_vanished_legacy_checks(config_check_info):
         'dmraid.pdisks',
         'docker_container_cpu',
         'docker_container_diskstat',
+        'docker_container_labels',
         'docker_container_status.health',
         'docker_container_status',
         'docker_container_status.uptime',


### PR DESCRIPTION
Docker containers do have an agent data section called "docker_container_labels" which AFAICT is currently no used anywhere.

This check plugin creates host labels from this data section. The labels are prefixed with "docker/".