### PR TITLE
[qnap_disks] Resolved issue with bad disks reporting OK.

### DIFF
--- a/checkman/qnap_disks
+++ b/checkman/qnap_disks
@@ -6,9 +6,9 @@ distribution: check_mk
 description:
  This check monitors the health and current Status of
  Hardisks attached to a QNAP NAS device.
- The check returns an {CRIT} in case of an error state reported
- by the device. The check also reports the model number, size and the
- temperature for each disk.
+ The check returns {CRIT} in case of an error state reported by the device.
+ If the SMART status is missing or not "GOOD", {WARN} will be returned.
+ The check also reports the model number, size and temperature for each disk.
 
 item:
  The name of the disk like reported in the MIB

--- a/checks/qnap_disks
+++ b/checks/qnap_disks
@@ -25,8 +25,10 @@ def check_qnap_disks(item, _no_params, info):
 
             if "--" in cond:
                 yield 1, "SMART Information missing"
+            elif cond != "GOOD":
+                yield 1, "SMART Warnings"
 
-            yield 0 , "Model: %s, Temperatur: %s, Size: %s" % \
+            yield 0 , "Model: %s, Temperature: %s, Size: %s" % \
                       (model, temp, size)
 
 


### PR DESCRIPTION
### Expected behaviour
If the QNAP detects problems with the SMART smart status of the disks, check_mk should show WARN or CRIT state. 

### Actual behaviour
If the disk is connected and available for the system, the check_mk state will be OK unless the SMART status is missing (returns "--").

### Fix
If the QNAP disk status is not reported as "GOOD", add the text "SMART Warnings" to the check_mk status detail, and change the state to WARN.

All QNAP models I've been able to test return "GOOD" in the status (OID .1.3.6.1.4.1.24681.1.2.11.1.7.x) when the web UI reports that the drive is OK. Newer models reports "Warning", but old firmware seems to return "Normal" when the SMART status is bad.

### Examples
Original check output, with one good disk (the first) and two bad disks:
```
OK - Status: ready (GOOD), Model: ST6000VN0033-2EE, Temperature: 40 C/104 F, Size: 5.46 TB
OK - Status: ready (Normal), Model: ST6000VN0033-2EE, Temperature: 40 C/104 F, Size: 5.46 TB
OK - Status: ready (Warning), Model: ST3000VN007-2AH16M, Temperature: 34 C/93 F, Size: 2.73 TB

```
Check output after the change is applied: 
```
OK - Status: ready (GOOD), Model: ST6000VN0033-2EE, Temperature: 40 C/104 F, Size: 5.46 TB
WARN - Status: ready (Normal), SMART Warnings, Model: ST6000VN0033-2EE, Temperature: 40 C/104 F, Size: 5.46 TB
WARN - Status: ready (Warning), SMART Warnings, Model: ST3000VN007-2AH16M, Temperature: 34 C/93 F, Size: 2.73 TB

```