### PR TITLE
plugin nginx_status: ignore invalid hostname

### DIFF
--- a/agents/plugins/nginx_status
+++ b/agents/plugins/nginx_status
@@ -21,6 +21,7 @@ import os
 import re
 import sys
 import urllib2
+import ssl
 
 # tell urllib2 not to honour "http(s)_proxy" env variables
 urllib2.getproxies = lambda: {}
@@ -109,7 +110,7 @@ for server in servers:
         # Try to fetch the status page for each server
         try:
             request = urllib2.Request(url, headers={"Accept": "text/plain"})
-            fd = urllib2.urlopen(request)
+            fd = urllib2.urlopen(request, context=ssl._create_unverified_context())
         except urllib2.URLError as e:
             if 'SSL23_GET_SERVER_HELLO:unknown protocol' in str(e):
                 # HACK: workaround misconfigurations where port 443 is used for


### PR DESCRIPTION
the agent plugin nginx_status often can not fetch the status page cause of a hostname mismatch in certificates and only prints
`Exception (127.0.0.1:443): hostname '127.0.0.1' doesn't match 'www.domain.de'`

this change ignores the hostname presented by the certificate and fetches the status page