### PR TITLE
Update 0001-global.php.dif

### DIFF
--- a/omd/packages/nagvis/patches/0001-global.php.dif
+++ b/omd/packages/nagvis/patches/0001-global.php.dif
@@ -6,9 +6,9 @@
  
 +$_path_parts = explode('/', dirname($_SERVER["SCRIPT_FILENAME"]));
 +if($_path_parts[count($_path_parts) - 6] == 'local') // handle OMD local/ hierarchy
-+    $_base_dir = join(array_slice(explode('/' ,dirname($_SERVER["SCRIPT_FILENAME"])), 0, -6), '/');
++    $_base_dir = join('/', array_slice(explode('/' ,dirname($_SERVER["SCRIPT_FILENAME"])), 0, -6));
 +else
-+    $_base_dir = join(array_slice(explode('/' ,dirname($_SERVER["SCRIPT_FILENAME"])), 0, -5), '/');
++    $_base_dir = join('/', array_slice(explode('/' ,dirname($_SERVER["SCRIPT_FILENAME"])), 0, -5));
 +
  /**
   * Set the search path for included files


### PR DESCRIPTION
fix php's join command use to be compatible with PHP 7.4+.
In join()/implode() putting the glue string second has been marked as deprecated before, and is not working in 7.4 and later.