### PR TITLE
Abort docker-entrypoint script when a hook fails and add earlier hook

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -14,7 +14,7 @@ function exec_hook() {
         for hook in *; do
             if [ ! -d "$hook" ] && [ -x "$hook" ]; then
                 echo "### Running $HOOKDIR/$hook"
-                ./"$hook" || true
+                ./"$hook"
             fi
         done
         popd >/dev/null

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -38,6 +38,8 @@ function create_system_apache_config() {
     echo -e "# Redirect top level requests to the sites base url\\nRedirectMatch 302 ^/$ /$CMK_SITE_ID/\\n" >>"$APACHE_DOCKER_CFG"
 }
 
+exec_hook pre-entrypoint
+
 if [ -z "$CMK_SITE_ID" ]; then
     echo "ERROR: No site ID given"
     exit 1


### PR DESCRIPTION
This PR allows the docker hooks to abort script execution. This allows ensuring that the container is in a defined state when its running.

I also added a new hook at the very beginning. It can be used to fail early if e.g. mandatory environment variables are missing.
