### PR TITLE
check_mk_agent.openwrt: do not use brace expansion

### DIFF
--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -725,7 +725,7 @@ if ls /sys/class/thermal/thermal_zone* >/dev/null 2>&1; then
     for F in /sys/class/thermal/thermal_zone*; do
         echo -n "${F##*/} "
         if [ ! -e $F/mode ]; then echo -n "- "; fi
-        cat $F/{mode,type,temp,trip_point_*} | tr \\n " "
+        cat $F/mode $F/type $F/temp $F/trip_point_* | tr \\n " "
         echo
     done
 fi


### PR DESCRIPTION
This feature is not supported by the busybox ash by default.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>