### PR TITLE
agent_graylog: Fix to retrieve more than 50 sidecars

### DIFF
--- a/cmk/special_agents/agent_graylog.py
+++ b/cmk/special_agents/agent_graylog.py
@@ -43,7 +43,7 @@ def main(argv=None):
         GraylogSection(name="license", uri="/plugins/org.graylog.plugins.license/licenses/status"),
         GraylogSection(name="messages", uri="/count/total"),
         GraylogSection(name="nodes", uri="/cluster"),
-        GraylogSection(name="sidecars", uri="/sidecars"),
+        GraylogSection(name="sidecars", uri="/sidecars/all"),
         GraylogSection(name="sources", uri="/sources"),
         GraylogSection(name="streams", uri="/streams"),
     ]


### PR DESCRIPTION
The API endpoint /sidecars lists up to 50 sidecars.
If you have more than 50 sidecars, you have to call /sidecars/all instead (or use pagination).

Graylog API documentation
GET /sidecars Lists existing Sidecar registrations using pagination
GET /sidecars/all Lists all existing Sidecar registrations