### PR TITLE
Add Support for Hitachi VSP G370 Devices

### DIFF
--- a/checks/hitachi_hus.include
+++ b/checks/hitachi_hus.include
@@ -27,8 +27,9 @@
 
 
 def scan_hitachi_hus(oid):
-    return "hm700" in oid(".1.3.6.1.2.1.1.1.0").lower() or \
-           "hm800" in oid(".1.3.6.1.2.1.1.1.0").lower()
+    return ("hm700" in oid(".1.3.6.1.2.1.1.1.0").lower() or \
+           "hm800" in oid(".1.3.6.1.2.1.1.1.0").lower() or \
+           "hm850" in oid(".1.3.6.1.2.1.1.1.0").lower() )
 
 
 def inventory_hitachi_hus(info):


### PR DESCRIPTION
Added Support for Hitachi VSP G370 Storage Devices (Model Name HM850.

Tested in productive environment.