### PR TITLE
[dell_compellent_folder] use df_translation

### DIFF
--- a/cmk/gui/plugins/metrics/translation.py
+++ b/cmk/gui/plugins/metrics/translation.py
@@ -765,6 +765,7 @@ check_metrics["check_mk-zpool"] = df_translation
 check_metrics["check_mk-vnx_quotas"] = df_translation
 check_metrics["check_mk-k8s_stats_fs"] = df_translation
 check_metrics["check_mk-fjdarye200_pools"] = df_translation
+check_metrics["check_mk-dell_compellent_folder"] = df_translation
 check_metrics["check_mk-netapp_api_volumes"] = {
     "fs_used": {
         "scale": MB


### PR DESCRIPTION
use df_translation for the metrics of check dell_compellent_folder
otherwise the scaling is not correct