### PR TITLE
[dell_compellent_folder] uses other values for folder usage

### DIFF
--- a/checks/dell_compellent_folder
+++ b/checks/dell_compellent_folder
@@ -34,5 +34,6 @@ check_info['dell_compellent_folder'] = {
             6,  # DELL-STORAGE-SC-MIB::scDiskFolderSUUsedSpace2
         ]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.4.1.674.11000.2000.500.1.2.1.0"),
+    'group': 'filesystem',
     'includes': ['df.include', 'size_trend.include'],
 }

--- a/checks/dell_compellent_folder
+++ b/checks/dell_compellent_folder
@@ -14,11 +14,11 @@ def inventory_dell_compellent_folder(info):
 
 
 def check_dell_compellent_folder(item, params, info):
-    for number, total, free in info:
+    for number, total, used in info:
         if number == item:
             # sizes delivered in GiB
             total = float(total) * 1024
-            free = float(free) * 1024
+            free = total - float(used) * 1024
             yield df_check_filesystem_list(item, params, [(item, total, free, 0)])
 
 
@@ -30,8 +30,8 @@ check_info['dell_compellent_folder'] = {
         '.1.3.6.1.4.1.674.11000.2000.500.1.2.32.1',
         [
             2,  # DELL-STORAGE-SC-MIB::scDiskFolderSUNbr
-            5,  # DELL-STORAGE-SC-MIB::scDiskFolderSUTotalSpace2
-            8,  # DELL-STORAGE-SC-MIB::scDiskFolderSUFreeSpace
+            7,  # DELL-STORAGE-SC-MIB::scDiskFolderSUAllocSpace
+            6,  # DELL-STORAGE-SC-MIB::scDiskFolderSUUsedSpace2
         ]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.4.1.674.11000.2000.500.1.2.1.0"),
     'includes': ['df.include', 'size_trend.include'],


### PR DESCRIPTION
DELL-STORAGE-SC-MIB::scDiskFolderSUTotalSpace2 is the available space
for the folder
DELL-STORAGE-SC-MIB::scDiskFolderSUFreeSpace is the difference of
configured space and available space

Both values (available space and configured space) are configured by
the admin and do not change with the usage of the folder.

DELL-STORAGE-SC-MIB::scDiskFolderSUAllocSpace is the space allocated to
the folder (i.e. the total space)
DELL-STORAGE-SC-MIB::scDiskFolderSUUsedSpace2 is the space used by the
data stored in the folder

Therefor it seems more consistent to use the difference of the later two
values to compute the free space available for data in the folder.