### PR TITLE
[dell_compellent_folder] correction for PR #261

### DIFF
--- a/checks/dell_compellent_folder
+++ b/checks/dell_compellent_folder
@@ -30,7 +30,7 @@ check_info['dell_compellent_folder'] = {
         '.1.3.6.1.4.1.674.11000.2000.500.1.2.32.1',
         [
             2,  # DELL-STORAGE-SC-MIB::scDiskFolderSUNbr
-            7,  # DELL-STORAGE-SC-MIB::scDiskFolderSUAllocSpace
+            5,  # DELL-STORAGE-SC-MIB::scDiskFolderSUTotalSpace2
             6,  # DELL-STORAGE-SC-MIB::scDiskFolderSUUsedSpace2
         ]),
     'snmp_scan_function': lambda oid: oid(".1.3.6.1.4.1.674.11000.2000.500.1.2.1.0"),


### PR DESCRIPTION
This is a correction for PR #261 , sorry for the noise.

We should use DELL-STORAGE-SC-MIB::scDiskFolderSUTotalSpace2 instead of
DELL-STORAGE-SC-MIB::scDiskFolderSUAllocSpace according to a Dell
Compellent administrator