### PR TITLE
Use legacy output on drbd9

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -743,6 +743,7 @@ fi
 if [ -z "$IS_DOCKERIZED" ] && [ -z "$IS_LXC_CONTAINER" ] && [ -e /proc/drbd ]; then
     echo '<<<drbd>>>'
     cat /proc/drbd
+    cat /sys/kernel/debug/drbd/resources/*/connections/*/0/proc_drbd 2>/dev/null
 fi
 
 # Heartbeat monitoring

--- a/checks/drbd
+++ b/checks/drbd
@@ -166,6 +166,7 @@ drbd_cs_map = {
     'WFConnection': 2,
     'WFReportParams': 1,
     'Connected': 0,
+    'Established': 0,
     'StartingSyncS': 1,
     'StartingSyncT': 1,
     'WFBitMapS': 1,


### PR DESCRIPTION
Just the same as #215, but for 1.6.0 branch.