### PR TITLE
Update lnx_distro

### DIFF
--- a/inventory/lnx_distro
+++ b/inventory/lnx_distro
@@ -41,8 +41,6 @@ def inv_lnx_distro(info, inventory_tree):
     ]:
         if file_name in parsed:
             handler(node, parsed[file_name])
-            break
-
 
 def _parse_lnx_distro(info):
     parsed = {}


### PR DESCRIPTION
Removed break, so that the /etc/debian_version will be parsed even if /etc/os-release exists.  /etc/debian_version has more detailed version info, e.g. 9.13 instead of only 9 in /etc/os-release