### PR TITLE
Update cisco_temperature to use entPhysicalName

### DIFF
--- a/checks/cisco_temperature
+++ b/checks/cisco_temperature
@@ -278,7 +278,7 @@ check_info['cisco_temperature'] = {
                                # cisco_temp_sensor data
                                ( ".1.3.6.1.2.1.47.1.1.1.1", [
                                  OID_END,
-                                 CACHED_OID(2), # Description of the sensor
+                                 CACHED_OID(7), # Description of the sensor
                                ]),
 
                                # Type and current state


### PR DESCRIPTION
The cisco_temperature module previously used the entPhysicalDescr MIB instead
of the entPhysicalName MIB (.2 and .7 of 1.3.6.1.2.1.47.1.1.1.1 respectively).

On Cisco IOS-XE the entPhysicalDescr MIB and entPhysicalName MIB are identical.
However on Cisco IOS-XR all fibre module power levels show "Power Sensor" in
entPhysicalDescr, and the unique interface name in entPhysicalName. Before this
change IOS-XR would only have a single power sensor called "DOM Power Sensor".

Let me know if you need anything clarified for this change.

Example on IOS-XE:
```
snmpwalk ... .1.3.6.1.2.1.47.1.1.1.1.2 (entPhysicalDescr)
SNMPv2-SMI::mib-2.47.1.1.1.1.2.1096 = STRING: "subslot 0/0 transceiver 0 Supply Voltage Sensor"
SNMPv2-SMI::mib-2.47.1.1.1.1.2.1097 = STRING: "subslot 0/0 transceiver 0 Bias Current Sensor"
SNMPv2-SMI::mib-2.47.1.1.1.1.2.1098 = STRING: "subslot 0/0 transceiver 0 Tx Power Sensor"

snmpwalk ... .1.3.6.1.2.1.47.1.1.1.1.7 (entPhysicalName)
SNMPv2-SMI::mib-2.47.1.1.1.1.7.1096 = STRING: "subslot 0/0 transceiver 0 Supply Voltage Sensor"
SNMPv2-SMI::mib-2.47.1.1.1.1.7.1097 = STRING: "subslot 0/0 transceiver 0 Bias Current Sensor"
SNMPv2-SMI::mib-2.47.1.1.1.1.7.1098 = STRING: "subslot 0/0 transceiver 0 Tx Power Sensor"
```

Example on IOS-XR:
```
snmpwalk ... .1.3.6.1.2.1.47.1.1.1.1.2 (entPhysicalDescr)
SNMPv2-SMI::mib-2.47.1.1.1.1.2.2130160 = STRING: "Voltage Sensor"
SNMPv2-SMI::mib-2.47.1.1.1.1.2.2130170 = STRING: "Current Sensor"
SNMPv2-SMI::mib-2.47.1.1.1.1.2.2130190 = STRING: "Power Sensor"

snmpwalk ... .1.3.6.1.2.1.47.1.1.1.1.7 (entPhysicalName)
SNMPv2-SMI::mib-2.47.1.1.1.1.7.2130160 = STRING: "TenGigE0/0/0/0-3.3 V"
SNMPv2-SMI::mib-2.47.1.1.1.1.7.2130170 = STRING: "TenGigE0/0/0/0-Tx Lane Current"
SNMPv2-SMI::mib-2.47.1.1.1.1.7.2130190 = STRING: "TenGigE0/0/0/0-Tx Lane Power"
```
