### PR TITLE
Use lower case "k" for "kilo" as prefix for units

### DIFF
--- a/cmk/utils/render.py
+++ b/cmk/utils/render.py
@@ -299,7 +299,7 @@ def calculate_physical_precision(v: float, precision: int) -> Tuple[str, int, in
         -2: u"µ",
         -1: "m",
         0: "",
-        1: "K",
+        1: "k",
         2: "M",
         3: "G",
         4: "T",


### PR DESCRIPTION
The decimal unit prefix for kilo, denoting multiplication by one
thousand has the symbol k, in lower case. The render function
mistakenly used K, upper case.

See https://en.wikipedia.org/wiki/Kilo-