### PR TITLE
[docker_container_status_health] discovers exited containers

### DIFF
--- a/checkman/docker_container_status_health
+++ b/checkman/docker_container_status_health
@@ -16,5 +16,5 @@ description:
  section "docker_container_status" (the default setting is fine).
 
 inventory:
- One service is created for each active container (running or restart policy 'always')
+ One service is created for each active container (running or exited or restart policy 'always')
  that has a health test configured.

--- a/cmk/base/plugins/agent_based/docker_container_status.py
+++ b/cmk/base/plugins/agent_based/docker_container_status.py
@@ -39,7 +39,7 @@ HEALTH_STATUS_MAP = {
 
 def _is_active_container(section: Dict[str, Any]) -> bool:
     '''return wether container is or should be running'''
-    if section.get("Status") == "running":
+    if section.get("Status") in [ "running", "exited" ]:
         return True
     restart_policy_name = section.get("RestartPolicy", {}).get("Name")
     return restart_policy_name in RESTART_POLICIES_TO_DISCOVER


### PR DESCRIPTION
The service check "Docker container status" is vital for the host state
of containers.
DCD will create hosts for exited containers, because piggyback data is still delivered.
These need the service check to properly display a host state.