### PR TITLE
[local] uses urllib.parse.unquote for item name

### DIFF
--- a/cmk/base/plugins/agent_based/local.py
+++ b/cmk/base/plugins/agent_based/local.py
@@ -154,6 +154,7 @@ def _parse_perftxt(string):
 
 
 def parse_local(string_table):
+    import urllib.parse
     now = time.time()
     parsed: Dict[Optional[str], Union[LocalResult, List]] = {}
     for line in string_table:
@@ -174,7 +175,7 @@ def parse_local(string_table):
             continue
 
         raw_state, state_msg = _sanitize_state(stripped_line[0])
-        item = stripped_line[1]
+        item = urllib.parse.unquote(stripped_line[1])
         perfdata, perf_msg = _parse_perftxt(stripped_line[2])
         # convert escaped newline chars
         # (will be converted back later individually for the different cores)

--- a/tests/unit/cmk/base/plugins/agent_based/test_local.py
+++ b/tests/unit/cmk/base/plugins/agent_based/test_local.py
@@ -152,6 +152,19 @@ from cmk.base.plugins.agent_based.agent_based_api.v1.type_defs import Parameters
                 )
             },
         ),
+        (
+            ['0', "With%20Spaces", '-', 'Check', 'with', 'spaces'],
+            {
+                "With Spaces": local.LocalResult(
+                    cached=None,
+                    item="With Spaces",
+                    state=0,
+                    text="",
+                    perfdata=[
+                    ],
+                )
+            },
+        ),
     ])
 def test_parse(string_table_row, expected_parsed_data):
     assert local.parse_local([string_table_row]) == expected_parsed_data

--- a/tests/unit/cmk/base/plugins/agent_based/test_local.py
+++ b/tests/unit/cmk/base/plugins/agent_based/test_local.py
@@ -159,7 +159,7 @@ from cmk.base.plugins.agent_based.agent_based_api.v1.type_defs import Parameters
                     cached=None,
                     item="With Spaces",
                     state=0,
-                    text="",
+                    text="Check with spaces",
                     perfdata=[
                     ],
                 )


### PR DESCRIPTION
Makes it possible to have spaces in service descriptions like with MRPE