### PR TITLE
infoblox_dns_stats copy and paste error

### DIFF
--- a/checks/infoblox_dns_stats
+++ b/checks/infoblox_dns_stats
@@ -27,13 +27,13 @@
 
 def check_infoblox_dns_stats(_no_item, _no_params, info):
     successes, referrals, nxrrset, nxdomain, \
-        _recursion, failures = map(int, info[0])
+        recursion, failures = map(int, info[0])
 
     return check_infoblox_statistics(
         "dns",
         [("successes", successes, "Since DNS process started", "successful responses"),
          ("referrals", referrals, "Since DNS process started", "referrals"),
-         ("recursion", successes, "Since DNS process started", "queries received using recursion"),
+         ("recursion", recursion, "Since DNS process started", "queries received using recursion"),
          ("failures", failures, "Since DNS process started", "queries failed"),
          ("nxrrset", nxrrset, "Queries", "for non-existent records"),
          ("nxdomain", nxdomain, "Queries", "for non-existent domain")])


### PR DESCRIPTION
Copy and paste error at creation time of this check 4 years ago :)
Commit https://github.com/tribe29/checkmk/commit/cbabb14858569eb06e239ab898f1d6c9f2103836
don't fixed it only hided it from the world
The actual 2.0 version has the exact same error inside

It is a compatible !!! change without any impact for the user - only the correct data now