### PR TITLE
Juniper Trapeze device oid was only matching one type

### DIFF
--- a/checks/juniper_trpz_cpu_util
+++ b/checks/juniper_trpz_cpu_util
@@ -70,7 +70,7 @@ check_info["juniper_trpz_cpu_util"] = {
     "service_description": "CPU utilization",
     "has_perfdata": True,
     "snmp_scan_function": lambda oid: oid(".1.3.6.1.2.1.1.2.0").startswith(
-        ".1.3.6.1.4.1.14525.3.1.6"),
+        ".1.3.6.1.4.1.14525.3"),
     # see: http://www.observium.org/svn/observer/trunk/mibs/trapeze/trpz-system-mib.my
     "snmp_info": (
         ".1.3.6.1.4.1.14525.4.8.1.1.11",

--- a/checks/juniper_trpz_flash
+++ b/checks/juniper_trpz_flash
@@ -67,6 +67,7 @@ check_info["juniper_trpz_flash"] = {
             3,  #Flash used
             4,  #Flash_total
         ]),
-    "snmp_scan_function": lambda oid: oid('.1.3.6.1.2.1.1.2.0') == ".1.3.6.1.4.1.14525.3.1.6",
+    "snmp_scan_function": lambda oid: oid(".1.3.6.1.2.1.1.2.0").startswith(
+        ".1.3.6.1.4.1.14525.3"),
     "group": "general_flash_usage",
 }

--- a/checks/juniper_trpz_info
+++ b/checks/juniper_trpz_info
@@ -40,7 +40,7 @@ check_info["juniper_trpz_info"] = {
     "inventory_function": inventory_juniper_trpz_info,
     "service_description": "Info",
     "snmp_scan_function": lambda oid: oid(".1.3.6.1.2.1.1.2.0").startswith(
-        ".1.3.6.1.4.1.14525.3.1.6"),
+        ".1.3.6.1.4.1.14525.3"),
     "snmp_info": (
         ".1.3.6.1.4.1.14525.4.2.1",
         [

--- a/checks/juniper_trpz_mem
+++ b/checks/juniper_trpz_mem
@@ -31,7 +31,7 @@ check_info["juniper_trpz_mem"] = {
     'has_perfdata': True,
     "group": "juniper_mem",
     "snmp_scan_function": lambda oid: oid(".1.3.6.1.2.1.1.2.0").startswith(
-        ".1.3.6.1.4.1.14525.3.1.6"),
+        ".1.3.6.1.4.1.14525.3"),
     "snmp_info": (
         ".1.3.6.1.4.1.14525.4.8.1.1",
         [

--- a/checks/juniper_trpz_power
+++ b/checks/juniper_trpz_power
@@ -53,7 +53,7 @@ check_info["juniper_trpz_power"] = {
     "inventory_function": inventory_juniper_trpz_power,
     "service_description": "PSU %s",
     "snmp_scan_function": lambda oid: oid(".1.3.6.1.2.1.1.2.0").startswith(
-        ".1.3.6.1.4.1.14525.3.1.6"),
+        ".1.3.6.1.4.1.14525.3"),
     "snmp_info": (
         ".1.3.6.1.4.1.14525.4.8.1.1.13.1.2.1",
         [


### PR DESCRIPTION
There are more device types existing.
For reference i used
http://www.circitor.fr/Mibs/Html/T/TRAPEZE-NETWORKS-REGISTRATION-DEVICES-MIB.php