### PR TITLE
apache_status: Fix execution with python3

### DIFF
--- a/agents/plugins/apache_status
+++ b/agents/plugins/apache_status
@@ -201,7 +201,7 @@ def main():
 
         try:
             response = get_response(proto, cafile, address, portspec, page)
-            for line in response.read().split('\n'):
+            for line in response.read().splitlines():
                 if not line.strip():
                     continue
                 if line.lstrip()[0] == '<':
@@ -209,7 +209,7 @@ def main():
                     break
                 if not name:
                     name = get_instance_name(address, port, get_instance_name_map(config))
-                sys.stdout.write("%s|%s|%s|%s\n" % (address, port, name, line))
+                sys.stdout.write("%s|%s|%s|%s\n" % (address, port, name, line.encode('utf-8'))
         except HTTPError as exc:
             sys.stderr.write('HTTP-Error (%s%s): %s %s\n' % (address, portspec, exc.code, exc))
 


### PR DESCRIPTION
So far this plugin failed on Ubuntu 20.04 if it's executed by python3 with an error similar to `Exception (127.0.0.1:80): a bytes-like object is required, not 'str'`, using splitlines instead of split works fine for python2 and python3 at the same time.