### PR TITLE
Fix mk_docker exceptions for python3 by default (future import and section_container_agent exception)

### DIFF
--- a/agents/plugins/mk_docker.py
+++ b/agents/plugins/mk_docker.py
@@ -17,8 +17,6 @@ plugin ("pip install docker").
 This plugin it will be called by the agent without any arguments.
 """
 
-__version__ = "2.1.0i1"
-
 # N O T E:
 # docker is available for python versions from 2.6 / 3.3
 
@@ -35,6 +33,7 @@ import functools
 import multiprocessing
 import logging
 
+__version__ = "2.1.0i1"
 
 def which(prg):
     for path in os.environ["PATH"].split(os.pathsep):
@@ -211,7 +210,7 @@ class MKDockerClient(docker.DockerClient):
                 length -= len(data)
                 LOGGER.debug("Received data: %r", data)
                 if actual_descriptor == descriptor:
-                    yield data
+                    yield data.decode('UTF-8')
             header = docker.utils.socket.read(sock, 8)
 
     def get_stdout(self, exec_return_val):


### PR DESCRIPTION
Fixes 2 problems on machine with package `python-is-python3` installed:

- `SyntaxError: from __future__ imports must occur at the beginning of the file`
- `Plugin exception in section_container_agent: sequence item 0: expected str instance, bytes found`