### PR TITLE
Fixes wrong results when there are 0 bytes availible in a ZFS dataset.

### DIFF
--- a/checks/zfsget
+++ b/checks/zfsget
@@ -96,7 +96,7 @@ def _parse_zfs(lines):
     for entry in data.values():
         if entry["mountpoint"].startswith("/"):
             entry["is_pool"] = "/" not in entry["name"]
-            if entry["available"] != 0 and entry["type"] == "filesystem":
+            if entry["type"] == "filesystem":
                 parsed[entry["name"]] = entry
     return parsed
 


### PR DESCRIPTION
`if entry["available"] != 0`` results in the plugin reporting the available disk space of another dataset when there are 0 bytes available in a dataset.

See https://forum.checkmk.com/t/zfs-plugin-reports-wrong-free-space/21296 

Test data has been send to https://forum.checkmk.com/u/andreas-doehler and he confirmed this bug. Thanx @Yogibaer75 !