### PR TITLE
agent_3par extension for port setting

### DIFF
--- a/checks/agent_3par
+++ b/checks/agent_3par
@@ -18,6 +18,9 @@ def agent_3par_arguments(params, hostname, ipaddress):
     if "values" in params:
         args += ["--values", ",".join(params["values"])]
 
+    if "port" in params:
+        args += ['-P', '%d' % params['port']]
+
     args.append(ipaddress)
 
     return args

--- a/cmk/gui/plugins/wato/datasource_programs.py
+++ b/cmk/gui/plugins/wato/datasource_programs.py
@@ -2115,6 +2115,13 @@ def _valuespec_special_agents_3par():
                     title=_("Password"),
                     allow_empty=False,
                 )),
+                ("port", Integer(
+                    title=_('TCP port number'),
+                    help=_('Port number that 3par is listening on. The default is 8080.'),
+                    default_value=8080,
+                    minvalue=1,
+                    maxvalue=65535,
+                )),
                 ("verify_cert",
                  DropdownChoice(
                      title=_("SSL certificate verification"),

--- a/cmk/special_agents/agent_3par.py
+++ b/cmk/special_agents/agent_3par.py
@@ -31,6 +31,7 @@ def parse_arguments(argv):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-u', '--user', required=True, help="Username for 3par login")
     parser.add_argument('-p', '--password', required=True, help="Password for 3par login")
+    parser.add_argument('-P', '--port', type=int, default=8080, help="Port for connection to 3par")
     parser.add_argument('--no-cert-check',
                         action='store_true',
                         help="Disable verification of the servers ssl certificate")
@@ -52,7 +53,7 @@ def main(argv=None):
         argv = sys.argv[1:]
     args = parse_arguments(argv)
 
-    url = "https://%s:8080/api/v1" % args.host
+    url = "https://%s:%s/api/v1" % (args.host, args.port)
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json",


### PR DESCRIPTION
The agent_3par is extended with the possibility to define the connection port inside WATO.
Default behavior is the usage of port 8080.