### PR TITLE
Oracle jobs parameters

### DIFF
--- a/checks/oracle_jobs
+++ b/checks/oracle_jobs
@@ -34,7 +34,7 @@
 factory_settings["oracle_jobs_defaults"] = {
     "disabled": True,
     "missinglog": 1,
-    "missingjob": 3,
+    "status_missing_jobs": 3,
 }
 
 
@@ -132,7 +132,7 @@ def check_oracle_jobs(item, params, info):
         raise MKCounterWrapped("Login not possible for check %s" % item)
 
     if not service_found:
-        missingjob = params.get('missingjob')
+        missingjob = params.get('status_missing_jobs')
         state = max(state, missingjob)
         return (state, 'Job is missing')
 

--- a/tests/unit/checks/generictests/datasets/oracle_jobs.py
+++ b/tests/unit/checks/generictests/datasets/oracle_jobs.py
@@ -24,7 +24,7 @@ checks = {
         (
             'DB19.CDB$ROOT.ORACLE_OCM.MGMT_STATS_CONFIG_JOB', {
                 'disabled': True,
-                'missingjob': 3,
+                'status_missing_job': 3,
                 'missinglog': 1
             }, [
                 (

--- a/tests/unit/checks/generictests/datasets/oracle_jobs_old.py
+++ b/tests/unit/checks/generictests/datasets/oracle_jobs_old.py
@@ -24,7 +24,7 @@ checks = {
         (
             'DB1.SYS.BSLN_MAINTAIN_STATS_JOB', {
                 'disabled': True,
-                'missingjob': 3,
+                'status_missing_job': 3,
                 'missinglog': 1
             }, [
                 (

--- a/tests/unit/checks/generictests/datasets/oracle_jobs_regression.py
+++ b/tests/unit/checks/generictests/datasets/oracle_jobs_regression.py
@@ -33,7 +33,7 @@ checks = {
         (
             'ORCLCDB.CDB$ROOT.SYS.CLEANUP_ONLINE_PMO', {
                 'disabled': True,
-                'missingjob': 3,
+                'status_missing_job': 3,
                 'missinglog': 1
             }, [
                 (
@@ -46,7 +46,7 @@ checks = {
         (
             'ORCLCDB.CDB$ROOT.SYS.PURGE_LOG', {
                 'disabled': True,
-                'missingjob': 3,
+                'status_missing_job': 3,
                 'missinglog': 1
             }, [
                 (


### PR DESCRIPTION
The parameter "missingjob" was not set anywhere. Inside the rule the parameter name is "status_missing_jobs".
There is also the possibility to change the WATO parameters to keep the check the same as before.