### PR TITLE
Update rds_licenses

### DIFF
--- a/checks/rds_licenses
+++ b/checks/rds_licenses
@@ -23,6 +23,7 @@ from cmk.base.check_legacy_includes.license import *  # pylint: disable=wildcard
 # Insert any new keys here
 # https://msdn.microsoft.com/en-us/library/aa383803%28v=vs.85%29.aspx#properties
 rds_licenses_product_versionid_map = {
+    "6": "Windows Server 2019",
     "5": "Windows Server 2016",
     "4": "Windows Server 2012",
     "3": "Windows Server 2008 R2",
@@ -62,9 +63,9 @@ def check_rds_licenses(item, params, parsed):
     used = 0
     for pack in license_pack:
         pack_total = int(pack.get("TotalLicenses"))
-        pack_avail = int(pack.get("AvailableLicenses"))
+        pack_used = int(pack.get("IssuedLicenses"))
         total += pack_total
-        used += pack_total - pack_avail
+        used += pack_used
 
     return license_check_levels(total, used, params)
 


### PR DESCRIPTION
Add Support for Windows Server 2019 RDS CAL
Use the "IssuedLicenses" value for calculating the used licenses, instead of using "TotalLicenses - AvailableLicenses", as "AvailableLicenses" will never have a negative value, but User RDS CALs can be overallocated (https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-client-access-license) so IssuedLicenses can be greater than TotalLicenses minus AvailableLicenses