### PR TITLE
Added Checking State for areca raid controller

### DIFF
--- a/checks/arc_raid_status
+++ b/checks/arc_raid_status
@@ -27,6 +27,9 @@ def check_arc_raid_status(item, params, info):
             elif raid_state == "Rebuilding":
                 state = 1
                 label = "(!)"
+            elif raid_state == "Checking":
+                state = 0
+                label = ""
             elif raid_state != "Normal":
                 state = 2
                 label = "(!!)"


### PR DESCRIPTION
Hello!

Areca Raid Controller have the feature to make a schedule check of the raid consisty. The status of the raid is then "Checking". Currently the check_mk check reports state critical, which is wrong as there is no problem with the volume! Checking is only a periodic task, so the state should be normal.

From the manual:
4.6.5 Schedule Volume Check
A volume check is a process that verifies the integrity of redundant data. To verify RAID 3, 5 or 6 redundancy, a volume check
reads all associated data blocks, computes parity, reads parity, and verifies that the computed parity matches the read parity.
Volume checks are very important because they detect and correct parity errors or bad disk blocks in the drive. A consistency
check forces every block on a volume to be read, and any bad blocks are marked; those blocks are not used again. This is critical and important because a bad disk block can prevent a disk rebuild from completing. We strongly recommend that you run
consistency checks on a regular basis—at least once per week (set on “Scheduler”). Volume checks degrade performance, so
you can also run them when the system is idle (set on “Checking After System Idle”). 