### PR TITLE
removed useless cluster inventory data if no cluster is present

### DIFF
--- a/cmk/base/inventory.py
+++ b/cmk/base/inventory.py
@@ -380,8 +380,9 @@ def _set_cluster_property(
     inventory_tree: StructuredDataTree,
     host_config: config.HostConfig,
 ) -> None:
-    inventory_tree.get_dict(
-        "software.applications.check_mk.cluster.")["is_cluster"] = host_config.is_cluster
+    if host_config.is_cluster:
+        inventory_tree.get_dict(
+            "software.applications.check_mk.cluster.")["is_cluster"] = host_config.is_cluster
 
 
 class _TreeAggregator:


### PR DESCRIPTION
As the title says only inventory cluster if cluster is present.