### PR TITLE
Fix display Error in changesets when renaming hosts.

### DIFF
--- a/cmk/gui/wato/pages/host_rename.py
+++ b/cmk/gui/wato/pages/host_rename.py
@@ -503,7 +503,7 @@ def rename_host_in_rulesets(folder, oldname, newname):
         if changed:
             add_change("edit-ruleset",
                        _("Renamed host in %d rulesets of folder %s") %
-                       (len(changed_rulesets), folder.title),
+                       (len(changed_rulesets), folder.title()),
                        obj=folder,
                        sites=folder.all_site_ids())
             rulesets.save()


### PR DESCRIPTION
The title of the folder is no longer shown as function pointer when displaying changesets after host renaming.
From: Renamed host in 3 rulesets of folder <bound method CREFolder.title of Folder('', u'Main directory')>
To:      Renamed host in 3 rulesets of folder Main directory

Trivial fix, already fixed in Version 2.0