### PR TITLE
McAfee Endpoint Security (ENS) DAT date detection

### DIFF
--- a/agents/windows/plugins/mcafee_av_client.bat
+++ b/agents/windows/plugins/mcafee_av_client.bat
@@ -1,25 +1,31 @@
 set VERSION="2.1.0i1"
 @echo off
 rem #  -----------------------------------------------------------------------------
-rem #  Checkmk windows agent plugin to gather information about signature date
-rem #  of Mcafee Anti-Virus software.
+rem #  Check_MK windows agent plugin to gather information about signature date
+rem #  of Mcafee Virusscan and ENS Anti-Virus software.
 rem #  -----------------------------------------------------------------------------
 
 
 setlocal enableDelayedExpansion
 set dateval=
 
-rem # on 64 bit systems
-if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
-  for /f "eol=S skip=2 tokens=3" %%a in ('reg query "HKLM\SOFTWARE\Wow6432Node\McAfee\AvEngine" /v AVDatDate /t REG_SZ 2^>nul') do @set dateval=%%a
+rem # check for ENS DAT date (returned as yyyy-mm-dd)
+for /f "skip=2 tokens=3" %%a in ('reg query "HKLM\SOFTWARE\McAfee\AvSolution\DS\DS" /v szContentCreationDate 2^>nul') do @set dateval=%%a
+if "%dateval%"=="" (
+  rem # ENS not installed, check for Virusscan DAT date (returned as yyyy/mm/dd)
+  rem # on 64 bit systems
+  if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
+    for /f "eol=S skip=2 tokens=3" %%a in ('reg query "HKLM\SOFTWARE\Wow6432Node\McAfee\AvEngine" /v AVDatDate /t REG_SZ 2^>nul') do @set dateval=%%a
+  )
+  rem # on 32 bit systems
+  if "%PROCESSOR_ARCHITECTURE%" == "x86" (
+    for /f "eol=S skip=2 tokens=3" %%a in ('reg query "HKLM\SOFTWARE\McAfee\AvEngine" /v AVDatDate /t REG_SZ 2^>nul') do @set dateval=%%a
+  )
 )
 
-rem # on 32 bit systems
-if "%PROCESSOR_ARCHITECTURE%" == "x86" (
-  for /f "eol=S skip=2 tokens=3" %%a in ('reg query "HKLM\SOFTWARE\McAfee\AvEngine" /v AVDatDate /t REG_SZ 2^>nul') do @set dateval=%%a
-)
+rem # if dateval was found, return it in the form yyyy/mm/dd
 
 if not "%dateval%"=="" (
   echo ^<^<^<mcafee_av_client^>^>^>
-  echo %dateval%
+  echo %dateval:-=/%
 )


### PR DESCRIPTION
Add detection of McAfee ENS DAT dates.

Returns the DAT date in the identical format as Virusscan date.

No changes required in the main code.