### PR TITLE
ActiveCheck check_mail - Fix message cleanup

### DIFF
--- a/active_checks/check_mail
+++ b/active_checks/check_mail
@@ -231,9 +231,9 @@ def check_mail(args: Args) -> CheckResult:
                 mailbox.fetch_mails(args.match_subject),
             )
             result = forward_to_ec(args, messages)
-            if args.cleanup_messages:
-                if args.cleanup_messages != 'delete':
-                    mailbox.copy_mails(forwarded, args.cleanup_messages)
+            if args.cleanup:
+                if args.cleanup != 'delete':
+                    mailbox.copy_mails(forwarded, args.cleanup)
                 mailbox.delete_mails(forwarded)
 
             return result

--- a/cmk/utils/mailbox.py
+++ b/cmk/utils/mailbox.py
@@ -353,9 +353,7 @@ class Mailbox:
                     self._connection.create(target)
 
                 # Copy the mail
-                ty, data = verified_result(self._connection.copy(str(mail_index), folder))
-                if ty != 'OK':
-                    raise Exception("Response from server: [%s]" % data)
+                verified_result(self._connection.copy(str(mail_index), folder))
 
         except Exception as exc:
             raise CleanupMailboxError('Failed to copy mail: %r' % exc) from exc


### PR DESCRIPTION
This fixes the not working message cleanup if check_mail is used with "forward-ec" and "cleanup delete" or "cleanup *folder*"

Without this changes only the following error is shown:
`CRIT - Failed to copy mail: ValueError('not enough values to unpack (expected 2, got 1)')`

Test via CLI:
```bash
OMD[site]:~$ lib/nagios/plugins/check_mail --fetch-protocol=IMAP --fetch-server=*server* --fetch-tls --fetch-username=*username* --fetch-password=*password* --connect-timeout=260 --forward-ec --forward-method= --cleanup *folder* --debug
[b'Logged in']
[b'1']
[b'1']
[(b'1 (RFC822 {1802}', b'Return-Path: ***MASKED***\r\n'), b')']
[b'[COPYUID 1604534060 6492 4912] Copy completed.']
[b'Close completed.']
[b'Logging out']
CRIT - Failed to copy mail: ValueError('not enough values to unpack (expected 2, got 1)'
```
