### PR TITLE
Update utils.py

### DIFF
--- a/cmk/notification_plugins/utils.py
+++ b/cmk/notification_plugins/utils.py
@@ -344,7 +344,7 @@ def process_by_result_map(response: requests.models.Response, result_map: Dict[S
     details = ""
 
     for status_code_range, state_info in result_map.items():
-        if status_code in status_code_range:
+        if status_code_range[0] <= status_code <= status_code_range[1]:
             if state_info.type == 'json':
                 details = response.json()
                 details = get_details_from_json(details, state_info.title)


### PR DESCRIPTION
# Fixed Range Check

I realized that SIGNL4 notifications fail in beta 3 with "Details for Status Code are not defined -- 201: Created". However, 201 should be success.

The reason seems to be that the line:
if status_code in status_code_range:
returns true for 200 and 299. But the line
if status_code_range[0] <= status_code <= status_code_range[1]:
returns true for any value between 200 and 299.

The change should make sure that all 2xx status codes are processed as success.

I hope this makes sense and I did not miss anything.