### PR TITLE
Fix failing pagerduty notification when host has no IP address.

### DIFF
--- a/cmk/notification_plugins/pagerduty.py
+++ b/cmk/notification_plugins/pagerduty.py
@@ -57,8 +57,7 @@ def pagerduty_msg(context: Dict) -> Dict:
         "dedup_key": incident_key,
         "payload": {
             "summary": incident,
-            "source": context.get('HOSTADDRESS',
-                                  context.get('HOSTNAME', 'Undeclared Host identifier')),
+            "source": context.get('HOSTADDRESS') or context.get('HOSTNAME') or 'Undeclared Host identifier',
             "severity": pagerduty_severity(state),
             "custom_details": {
                 "info": output,


### PR DESCRIPTION
Sending notifications to Pagerduty are failing when you have a host that does not have an IP address (for example because all check info comes from piggypack checks). 

What happens is that the payload.source which is send to Pagerduty is filled with the HOSTADDRESS key of the context dictionary. Unless the key doesn't exist, then it uses HOSTNAME. In practice, the HOSTADDRESS key will always exist. Even if you haven't configured an IP in your hosts config, then it will just  be an empy string. Since an empty string is a valid value, the lookup for HOSTNAME will never happen. 

As a result, payload.source wil be an empty string. When send to the Pagerduty API this way, it will return a HTTP 400 (Bad Request) with the message: `"'payload.source' is missing or blank"`

This small fix makes sure the correct info is send to Pagerduty. 