### PR TITLE
mk_errpt.aix fails when last Errorlog Message contains a slash

### DIFF
--- a/agents/plugins/mk_errpt.aix
+++ b/agents/plugins/mk_errpt.aix
@@ -51,6 +51,6 @@ fi
 
 if [ "$OUT" ]; then
     # output data; if successful, remember most recent
-    echo "$OUT" && echo "$OUT" | head -n1 | sed 's/^C\ //' > "$MK_ERRPT_AIX_STATE"
+    echo "$OUT" && echo "$OUT" | head -n1 | sed 's/^C\ //' | sed 's/\//\\\//g' > "$MK_ERRPT_AIX_STATE"
 fi
 


### PR DESCRIPTION
Without this modification we have a bug when the last Errorlog Message contains a slash (/) and is stored in the file mk_errpt_aix.last_reported, so we need to prevent this.
The awk in line 47 will fail with a syntax error when the variable $LINE contains a slash.

Example without this modification:
<<<logwatch>>>
[[[errorlog]]]
syntax error The source line is 1.
The error context is
                /0873CF9F   0617123820 T S pts/7          TTYHOG OVER-RUN/ >>>  { <<<
awk: Quitting
The source line is 1.