### PR TITLE
Fortinet FortiAuthenticator Authentication Failure Check

### DIFF
--- a/checkman/fortiauthenticator_auth_fail
+++ b/checkman/fortiauthenticator_auth_fail
@@ -1,0 +1,13 @@
+title: Fortinet FortiAuthenticator Authentication Failures
+agents: snmp
+catalog: hw/network/fortinet
+license: GPL
+distribution: check_mk
+description:
+ This check monitors the amount of Authentication Failures 
+ within the last 5 Minute on a Fortinet FortiAuthenticator System.
+ The check changes to {WARN} or {CRIT} if the amount of Failures 
+ exceeds configurable levels.
+
+discovery:
+ One check per host will be created.

--- a/cmk/base/plugins/agent_based/fortiauthenticator_auth_fail.py
+++ b/cmk/base/plugins/agent_based/fortiauthenticator_auth_fail.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# author: Oguzhan Cicek, OpenSource Security GmbH - oguzhan(at)os-s.de
+
+#Example Input:
+#.1.3.6.1.2.1.1.1.0 testname
+#.1.3.6.1.2.1.1.2.0 .1.3.6.1.4.1.8072.3.2.10
+#[...]
+#.1.3.6.1.4.1.12356.113.1.202.23.0 0
+#[...]
+
+#Example GUI Output:
+#OK	FortiAuthenticator Authentication Failures
+#       Authentication Failures within the last 5 Minutes: 0
+
+from .agent_based_api.v1.type_defs import (
+    DiscoveryResult,
+    CheckResult,
+    StringTable,
+)
+from .agent_based_api.v1 import (
+    register,
+    Service,
+    equals,
+    check_levels,
+    SNMPTree,
+)
+from typing import Mapping, List, Tuple
+
+Section = List[str]
+
+
+def parse_fortiauthenticator_auth_fail(string_table: List[StringTable]) -> Section:
+    return string_table[0][0]
+
+
+def discovery_fortiauthenticator_auth_fail(section: Section) -> DiscoveryResult:
+    yield Service()
+
+
+def check_fortiauthenticator_auth_fail(params: Mapping[str, Tuple[float, float]],
+                                       section: Section) -> CheckResult:
+    fail_limit_upper = params.get("auth_fails")
+    fails = int(section[0][0][0])
+    yield from check_levels(
+        fails,
+        levels_upper=fail_limit_upper,
+        metric_name="fortiauthenticator_fails_5min",
+        label="Authentication Failures within the last 5min",
+        render_func=lambda v: "%s" % v,
+    )
+
+
+register.snmp_section(
+    name="fortiauthenticator_auth_fail",
+    parse_function=parse_fortiauthenticator_auth_fail,
+    detect=equals('.1.3.6.1.2.1.1.2.0', '.1.3.6.1.4.1.8072.3.2.10'),
+    fetch=[
+        SNMPTree(
+            base='.1.3.6.1.4.1.12356.113.1.202',
+            oids=[
+                '23.0',  # facAuthFailures5Min
+            ]),
+    ],
+)
+
+register.check_plugin(
+    name="fortiauthenticator_auth_fail",
+    service_name="FortiAuthenticator Authentication Failures",
+    discovery_function=discovery_fortiauthenticator_auth_fail,
+    check_function=check_fortiauthenticator_auth_fail,
+    check_default_parameters={"auth_fails": (100, 200)},
+    check_ruleset_name="fortiauthenticator_auth_fail",
+)

--- a/cmk/gui/plugins/metrics/fortiauthenticator_auth_fail.py
+++ b/cmk/gui/plugins/metrics/fortiauthenticator_auth_fail.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# author: Oguzhan Cicek, OpenSource Security GmbH - oguzhan(at)os-s.de
+
+from cmk.gui.i18n import _
+
+from cmk.gui.plugins.metrics import (metric_info)
+
+metric_info["fortiauthenticator_fails_5min"] = {
+    "title": _("Failures within the last 5min"),
+    "unit": "count",
+    "color": "#60f020",
+}

--- a/cmk/gui/plugins/wato/fortiauthenticator_auth_fail.py
+++ b/cmk/gui/plugins/wato/fortiauthenticator_auth_fail.py
@@ -1,0 +1,38 @@
+#author: Oguzhan Cicek, OpenSource Security GmbH - oguzhan(at)os-s.de
+
+from cmk.gui.i18n import _
+from cmk.gui.valuespec import (
+    Dictionary,
+    Integer,
+    Tuple,
+)
+
+from cmk.gui.plugins.wato import (
+    CheckParameterRulespecWithoutItem,
+    rulespec_registry,
+    RulespecGroupCheckParametersNetworking,
+)
+
+
+def _parameter_valuespec_fortiauthenticator_auth_fail():
+    return Dictionary(elements=[(
+        "auth_fails",
+        Tuple(
+            title=_("Failure count"),
+            help=
+            _("These levels make the check go warning or critical whenever the "
+              "<b>count of Authentication Failures within 5 Minutes</b> of the monitored Fortinet Authentication System is too high."
+             ),
+            elements=[
+                Integer(title=_("warning at"), unit=u"Failures", default_value=100),
+                Integer(title=_("critical at"), unit=u"Failures", default_value=200),
+            ]))])
+
+
+rulespec_registry.register(
+    CheckParameterRulespecWithoutItem(
+        check_group_name="fortiauthenticator_auth_fail",
+        group=RulespecGroupCheckParametersNetworking,
+        parameter_valuespec=_parameter_valuespec_fortiauthenticator_auth_fail,
+        title=lambda: _("Fortinet Authenticator Failure"),
+    ))


### PR DESCRIPTION
This PR adds a SNMP check for Fortinet FortiAuthenticator Systems to check the Failures within the last 5 minutes.