### PR TITLE
Add "Windows Server 2019" to rds_licenses

### DIFF
--- a/checks/rds_licenses
+++ b/checks/rds_licenses
@@ -19,10 +19,14 @@ from cmk.base.check_legacy_includes.license import *  # pylint: disable=wildcard
 # 17,A02-6.00-S,2,0,Windows Server 2008 oder Windows Server 2008 R2,2,50,18,32,20380101110453.000000-000
 # 18,A02-6.00-S,2,0,Windows Server 2008 oder Windows Server 2008 R2,2,65,22,43,20380101083530.000000-000
 # 19,A02-6.00-S,2,0,Windows Server 2008 oder Windows Server 2008 R2,2,600,0,600,20380101083248.000000-000
+# 2,A02-5.00-EX,6,3,Windows 2000 Server,0,-1,0,-1,20351231230000.000000-000
+# 4,C50-6.02-S,2,1,Windows Server 2012,4,300,0,300,20380101000000.000000-000
+# 3,C50-10.01-S,5,1,Windows Server 2019,6,2000,1,1999,20380101093636.000000-000
 
 # Insert any new keys here
 # https://msdn.microsoft.com/en-us/library/aa383803%28v=vs.85%29.aspx#properties
 rds_licenses_product_versionid_map = {
+    "6": "Windows Server 2016",
     "5": "Windows Server 2016",
     "4": "Windows Server 2012",
     "3": "Windows Server 2008 R2",

--- a/checks/rds_licenses
+++ b/checks/rds_licenses
@@ -19,14 +19,13 @@ from cmk.base.check_legacy_includes.license import *  # pylint: disable=wildcard
 # 17,A02-6.00-S,2,0,Windows Server 2008 oder Windows Server 2008 R2,2,50,18,32,20380101110453.000000-000
 # 18,A02-6.00-S,2,0,Windows Server 2008 oder Windows Server 2008 R2,2,65,22,43,20380101083530.000000-000
 # 19,A02-6.00-S,2,0,Windows Server 2008 oder Windows Server 2008 R2,2,600,0,600,20380101083248.000000-000
-# 2,A02-5.00-EX,6,3,Windows 2000 Server,0,-1,0,-1,20351231230000.000000-000
 # 4,C50-6.02-S,2,1,Windows Server 2012,4,300,0,300,20380101000000.000000-000
 # 3,C50-10.01-S,5,1,Windows Server 2019,6,2000,1,1999,20380101093636.000000-000
 
 # Insert any new keys here
 # https://msdn.microsoft.com/en-us/library/aa383803%28v=vs.85%29.aspx#properties
 rds_licenses_product_versionid_map = {
-    "6": "Windows Server 2016",
+    "6": "Windows Server 2019",
     "5": "Windows Server 2016",
     "4": "Windows Server 2012",
     "3": "Windows Server 2008 R2",


### PR DESCRIPTION
this change adds support for "Windows Server 2019" to the rds_licenses check