### PR TITLE
mk_msoffice.ps1: Fixed Typo in config path

### DIFF
--- a/agents/windows/plugins/mk_msoffice.ps1
+++ b/agents/windows/plugins/mk_msoffice.ps1
@@ -8,7 +8,7 @@ if (!$MK_CONFDIR) {
 }
 
 ## Source the configuration file for this agent plugin
-$CONFIG_FILE="${MK_CONFDIR}\msoffice_cfg.ps1"
+$CONFIG_FILE="${MK_CONFDIR}\msoffice.cfg.ps1"
 if (test-path -path "${CONFIG_FILE}" ) {
      . "${CONFIG_FILE}"
 } else {


### PR DESCRIPTION
The path to the configuration in the plugin has a simple typo, the bakery configures .cfg, the plugin try to use _cfg