### PR TITLE
ibm_mq: Add High Availability RDQM

### DIFF
--- a/agents/plugins/ibm_mq
+++ b/agents/plugins/ibm_mq
@@ -19,7 +19,13 @@ VERSION="2.1.0i1"
 # - Explicitly skip certain Queue Managers, e.g:
 #     SKIP_QM="FAULTY TOWER"
 #
-# Daniel Steinmann, Swisscom, December 2017
+#
+# Necessary IBM MQ rights, in case script does not run as mqm user:
+#
+#     set authrec objtype(QMGR) principal('cmkagent') authadd(DSP,INQ)
+#     set authrec profile(**) objtype(QUEUE) principal('cmkagent') authadd(DSP)
+#     set authrec profile(**) objtype(CHANNEL) principal('cmkagent') authadd(DSP)
+#     set authrec profile(**) objtype(CLNTCONN) principal('cmkagent') authadd(DSP)
 #
 
 load_config() {
@@ -89,7 +95,7 @@ EOF
         echo "$dspmqline NOW($now)"
         runmqsc -e "$QM" <<EOF
 display qlocal(*) maxdepth maxmsgl crdate crtime altdate alttime monq
-display qstatus(*) monitor
+display qstatus(*) monitor ipprocs opprocs
 EOF
     fi
 done

--- a/checks/ibm_mq_managers
+++ b/checks/ibm_mq_managers
@@ -101,7 +101,13 @@ def check_ibm_mq_managers(item, params, data):
 
     standby = data["STANDBY"]
     instances = data.get("INSTANCES", [])
-    if standby == "PERMITTED":
+    ha = data.get("HA")
+    if ha == "REPLICATED":
+        if len(instances) > 0:
+            yield 0, "High availability: replicated, Instance: %s" % (instances[0][0],)
+        else:
+            yield 0, "High availability: replicated"
+    elif standby == "PERMITTED":
         if len(instances) == 2:
             yield 0, "Multi-Instance: %s=%s and %s=%s" % (instances[0][0], instances[0][1],
                                                           instances[1][0], instances[1][1])

--- a/tests/unit/checks/test_ibm_mq_managers.py
+++ b/tests/unit/checks/test_ibm_mq_managers.py
@@ -94,7 +94,7 @@ QMNAME(THE.STANDBY.RDQM)                                  STATUS(RUNNING ELSEWHE
         (0, u'Status: RUNNING'),
         (0, u'Version: 9.1.0.4'),
         (0, u'Installation: /opt/mqm (Installation1), Default: NO'),
-        (0, u'Single-Instance: sb008877=ACTIVE'),
+        (0, u'High availability: replicated, Instance: sb008877'),
     ]
     assert expected == actual
 


### PR DESCRIPTION
Recognise the Replicated Data Queue Manager (RDQM).

It also contains minor improvements in agent script recognised during RDQM testing:
-  Document as comments the MQ rights in case script does not run under user mqm.
- The `monitor` group does not include `ipprocs` and `opprocs`.