### PR TITLE
port checkpoint_connections to new api and add peak + maximum values as well as relative thresholds

### DIFF
--- a/cmk/base/plugins/agent_based/checkpoint_connections.py
+++ b/cmk/base/plugins/agent_based/checkpoint_connections.py
@@ -9,9 +9,9 @@
 
 from typing import NamedTuple
 
-from .agent_based_api.v1 import check_levels, register, Result, Service, SNMPTree, State
-from .agent_based_api.v1.type_defs import CheckResult, DiscoveryResult, StringTable
-from .utils import checkpoint
+from cmk.base.plugins.agent_based.agent_based_api.v1 import check_levels, register, Result, Service, SNMPTree, State
+from cmk.base.plugins.agent_based.agent_based_api.v1.type_defs import CheckResult, DiscoveryResult
+from cmk.base.plugins.agent_based.utils import checkpoint
 
 checkpoint_connections_default_levels = {"pct": (80, 90)}
 
@@ -22,7 +22,9 @@ class Section(NamedTuple):
     maximum: int
 
 
-def parse_checkpoint_connections(string_table: StringTable) -> Section:
+#def parse_checkpoint_connections(string_table: StringTable) -> Section:
+#for whatever reason, this more specific signature fails, I don't understand the error message
+def parse_checkpoint_connections(string_table) -> Section:
     current_raw_value = string_table[0][0][0]
     peak_raw_value = string_table[0][0][1]
     maximum_raw_value = string_table[0][0][2]

--- a/cmk/base/plugins/agent_based/checkpoint_connections.py
+++ b/cmk/base/plugins/agent_based/checkpoint_connections.py
@@ -7,18 +7,80 @@
 # .1.3.6.1.2.1.1.1.0 Linux gateway1 2.6.18-92cp #1 SMP Tue Dec 4 21:44:22 IST 2012 i686
 # .1.3.6.1.4.1.2620.1.1.25.3.0 19190
 
-from .agent_based_api.v1 import register, SNMPTree
+from collections import namedtuple
+
+from .agent_based_api.v1 import check_levels, register, Result, Service, SNMPTree, state
+from .agent_based_api.v1.type_defs import CheckResult, DiscoveryResult, Parameters, SNMPStringTable
 from .utils import checkpoint
 
+checkpoint_connections_default_levels = {"pct": (80, 90)}
 
-def parse_checkpoint_connections(string_table):
-    raw_value = string_table[0][0][0]
-    return {"count": int(raw_value)}
+Section = namedtuple('Section', 'current peak maximum')
+
+
+def parse_checkpoint_connections(string_table: SNMPStringTable) -> Section:
+    current_raw_value = string_table[0][0][0]
+    peak_raw_value = string_table[0][0][1]
+    maximum_raw_value = string_table[0][0][2]
+    return Section(
+        current=int(current_raw_value),
+        peak=int(peak_raw_value),
+        maximum=int(maximum_raw_value),
+    )
 
 
 register.snmp_section(
     name="checkpoint_connections",
     parse_function=parse_checkpoint_connections,
     detect=checkpoint.DETECT,
-    fetch=[SNMPTree(base=".1.3.6.1.4.1.2620.1.1.25", oids=['3'])],
+    fetch=[
+        SNMPTree(
+            base=".1.3.6.1.4.1.2620.1.1.25",
+            oids=[
+                '3',  # CHECKPOINT-MIB - fwNumConn - current connections
+                '4',  # CHECKPOINT-MIB - fwPeakNumConn - peak number of connections
+                '10',  # CHECKPOINT-MIB - fwConnTableLimit - connection table limit
+            ])
+    ],
+)
+
+
+def discover_checkpoint_connections(section: Section) -> DiscoveryResult:
+    yield Service()
+
+
+def check_checkpoint_connections(
+    params: Parameters,
+    section: Section,
+) -> CheckResult:
+    maximum = section.maximum
+    #infotext = "%d current, %d peak, %d maximum" % (current, peak, maximum)
+
+    if "pct" in params and maximum > 0:
+        warn_pct, crit_pct = params["pct"]
+        warn = maximum * warn_pct / 100
+        crit = maximum * crit_pct / 100
+    else:
+        # up until cmk 1.6 this check only supported user set absolute values
+        warn, crit = params["auto-migration-wrapper-key"]
+
+    upper_boundary = maximum if maximum > 0 else None
+    yield from check_levels(
+        value=section.current,
+        levels_upper=(warn, crit),
+        metric_name="connections",
+        boundaries=(0, upper_boundary),
+        label="Current connections",
+    )
+    yield Result(state=state.OK,
+                 summary="Peak: {0.peak}, Connection table limit: {0.maximum}".format(section))
+
+
+register.check_plugin(
+    name="checkpoint_connections",
+    service_name="Connections",
+    discovery_function=discover_checkpoint_connections,
+    check_function=check_checkpoint_connections,
+    check_default_parameters=checkpoint_connections_default_levels,
+    check_ruleset_name="checkpoint_connections",
 )

--- a/cmk/base/plugins/agent_based/checkpoint_connections.py
+++ b/cmk/base/plugins/agent_based/checkpoint_connections.py
@@ -7,18 +7,22 @@
 # .1.3.6.1.2.1.1.1.0 Linux gateway1 2.6.18-92cp #1 SMP Tue Dec 4 21:44:22 IST 2012 i686
 # .1.3.6.1.4.1.2620.1.1.25.3.0 19190
 
-from collections import namedtuple
+from typing import NamedTuple
 
-from .agent_based_api.v1 import check_levels, register, Result, Service, SNMPTree, state
-from .agent_based_api.v1.type_defs import CheckResult, DiscoveryResult, Parameters, SNMPStringTable
+from .agent_based_api.v1 import check_levels, register, Result, Service, SNMPTree, State
+from .agent_based_api.v1.type_defs import CheckResult, DiscoveryResult, StringTable
 from .utils import checkpoint
 
 checkpoint_connections_default_levels = {"pct": (80, 90)}
 
-Section = namedtuple('Section', 'current peak maximum')
+
+class Section(NamedTuple):
+    current: int
+    peak: int
+    maximum: int
 
 
-def parse_checkpoint_connections(string_table: SNMPStringTable) -> Section:
+def parse_checkpoint_connections(string_table: StringTable) -> Section:
     current_raw_value = string_table[0][0][0]
     peak_raw_value = string_table[0][0][1]
     maximum_raw_value = string_table[0][0][2]
@@ -50,7 +54,7 @@ def discover_checkpoint_connections(section: Section) -> DiscoveryResult:
 
 
 def check_checkpoint_connections(
-    params: Parameters,
+    params,
     section: Section,
 ) -> CheckResult:
     maximum = section.maximum
@@ -72,7 +76,7 @@ def check_checkpoint_connections(
         boundaries=(0, upper_boundary),
         label="Current connections",
     )
-    yield Result(state=state.OK,
+    yield Result(state=State.OK,
                  summary="Peak: {0.peak}, Connection table limit: {0.maximum}".format(section))
 
 

--- a/cmk/gui/plugins/wato/check_parameters/checkpoint_connections.py
+++ b/cmk/gui/plugins/wato/check_parameters/checkpoint_connections.py
@@ -37,7 +37,7 @@ def _parameter_valuespec_checkpoint_connections():
                            ]),
                      Tuple(title=_("Absolute"),
                            elements=[
-                               Integer(title=_("Warning at"), minvalue=0.0),
+                               Integer(title=_("Warning at"), minvalue=0),
                                Integer(
                                    title=_("Critical at"),
                                    minvalue=0,

--- a/cmk/gui/plugins/wato/check_parameters/checkpoint_connections.py
+++ b/cmk/gui/plugins/wato/check_parameters/checkpoint_connections.py
@@ -5,27 +5,48 @@
 # conditions defined in the file COPYING, which is part of this source code package.
 
 from cmk.gui.i18n import _
-from cmk.gui.valuespec import (
-    Integer,
-    Tuple,
-)
-
 from cmk.gui.plugins.wato import (
     CheckParameterRulespecWithoutItem,
     rulespec_registry,
     RulespecGroupCheckParametersApplications,
 )
+from cmk.gui.valuespec import Alternative, Dictionary, Integer, Percentage, Transform, Tuple
 
 
 def _parameter_valuespec_checkpoint_connections():
-    return Tuple(
-        help=_("This rule sets limits to the current number of connections through "
-               "a Checkpoint firewall."),
-        title=_("Maximum number of firewall connections"),
-        elements=[
-            Integer(title=_("Warning at"), default_value=40000),
-            Integer(title=_("Critical at"), default_value=50000),
-        ],
+    return Transform(
+        Dictionary(elements=[
+            ("levels",
+             Alternative(
+                 help=_("This rule sets limits to the current number of connections through "
+                        "a Checkpoint firewall."),
+                 title=_("Maximum number of firewall connections"),
+                 elements=[
+                     Tuple(title=_("Percentage of maximum connections"),
+                           elements=[
+                               Percentage(
+                                   title=_("Warning at"),
+                                   unit="%",
+                                   minvalue=0.0,
+                                   default_value=80.0,
+                               ),
+                               Percentage(title=_("Critical at"),
+                                          unit="%",
+                                          minvalue=0.0,
+                                          default_value=90.0),
+                           ]),
+                     Tuple(title=_("Absolute"),
+                           elements=[
+                               Integer(title=_("Warning at"), minvalue=0.0),
+                               Integer(
+                                   title=_("Critical at"),
+                                   minvalue=0,
+                               ),
+                           ]),
+                 ],
+             )),
+        ]),
+        forth=lambda x: x if isinstance(x, dict) else {"levels": x},
     )
 
 


### PR DESCRIPTION
Checkpoint Connections ported to new api (mostly to get the hang of it.) and included the possibility to set thresholds in percentage, based on the maximum number of open connections that most checkpoint firewalls provide. 