### PR TITLE
Match mail subjects case insentive in check_mail_loop

### DIFF
--- a/active_checks/check_mail_loop
+++ b/active_checks/check_mail_loop
@@ -178,7 +178,7 @@ def fetch_mail_timestamps(
     try:
         obsolete_mails, fetched_mails = {}, {}
         # Now filter out the messages for this check
-        pattern = re.compile(r'(?:Re: |WG: )?%s ([^\s]+) ([^\s]+)' % args.subject)
+        pattern = re.compile(r'(?i)(?:Re: |WG: )?%s ([^\s]+) ([^\s]+)' % args.subject)
 
         for index, msg in mails.items():
             matches = pattern.match(msg.get('Subject', ''))


### PR DESCRIPTION
Some servers respond to mails with 'RE:' instead of 'Re:', by making the pattern case insensitive, check_mail_loop can still find the replies and the check continues to work.