### PR TITLE
Small typo fixes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To prepare your system for building, you need to execute this command:
 
 This will install the missing build dependencies, at least if you are working on
 a supported Linux distribution. Then you can either create RPM or DEB packages,
-depending on your Linux-distribution.
+depending on your Linux distribution.
 
 To build an RPM:
 
@@ -49,6 +49,6 @@ To create a DEB package:
 
     DEBFULLNAME="Mr. Buildmaster" DEBEMAIL="mail@buildmaster.com" make deb
 
-Don't forget to insert your name and mail address. As a result your should find
+Don't forget to insert your name and mail address. As a result you should find
 packages of the form `check-mk-[edition]-[version].[deb|rpm]` in your current
 directory.


### PR DESCRIPTION
Came for the `your` => `you` change and found I can unify the `Linux(-)distribution` situation as well :)