### PR TITLE
CMCIII Bugfix invalid literal for int

### DIFF
--- a/checks/cmciii
+++ b/checks/cmciii
@@ -158,9 +158,9 @@ def parse_cmciii(info):
             # neg. scale: "-X" => "/ X"
             # pos. scale: "X"  => "* X"
             # else:            => "* 1"
-            if int(scale) < 0:
+            if scale != "" and int(scale) < 0:
                 value = float(value_int) * (-1.0 / float(scale))
-            elif int(scale) > 0:
+            elif scale != "" and int(scale) > 0:
                 value = float(value_int) * float(scale)
             else:
                 value = int(value_int)


### PR DESCRIPTION
This PR fixes a bug where the variable scale is not always a integer but can also be an empty string. Without this fix the entire Check aborts with the error Message: ValueError("invalid literal for int() with base 10: ''",)