### PR TITLE
systemd_units.services: Include container units

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -278,7 +278,7 @@ sections_systemd() {
         echo "[list-unit-files]"
         systemctl list-unit-files --no-pager | tr -s ' '
         echo "[all]"
-        systemctl --all --no-pager | sed '/^$/q' | tr -s ' '
+        systemctl --all --no-pager -r | sed '/^$/q' | tr -s ' '
     fi
 }
 


### PR DESCRIPTION
The -r flag contains all units of all systemd-nspawn containers, prefixed with the container name.

This way the "Systemd Service Summary" is a summary of all systemd units of the host and all container units.