### PR TITLE
fixes FEED-5673

### DIFF
--- a/agents/check_mk_agent.aix
+++ b/agents/check_mk_agent.aix
@@ -25,6 +25,7 @@ read_python2_version() {
 }
 PYTHON3=$(read_python3_version)
 PYTHON2=$(read_python2_version)
+export PYTHON2 PYTHON3
 
 if [ -e $HOME/.profile ]
 then

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -89,6 +89,8 @@ read_python2_version() {
 PYTHON3=$(read_python3_version)
 PYTHON2=$(read_python2_version)
 
+export PYTHON2 PYTHON3
+
 # Detect whether or not the agent is being executed in a container
 # environment.
 if [ -f /.dockerenv ]; then

--- a/agents/check_mk_agent.solaris
+++ b/agents/check_mk_agent.solaris
@@ -25,6 +25,7 @@ read_python2_version() {
 }
 PYTHON3=$(read_python3_version)
 PYTHON2=$(read_python2_version)
+export PYTHON2 PYTHON3
 
 export LC_ALL=C
 unset LANG


### PR DESCRIPTION
The vars PYTHON2 and PYTHON3 are used in run_agent_plugin()

If run_cached() is involved they have to be exported to the subshell