### PR TITLE
fixed downtime error-div-detection

### DIFF
--- a/.werks/12119
+++ b/.werks/12119
@@ -1,0 +1,14 @@
+Title: docker_container_cpu check accepts cgroup v2 values
+Class: fix
+Compatible: compat
+Component: checks
+Date: 1613572324
+Edition: cre
+Knowledge: doc
+Level: 1
+State: unknown
+Version: 2.1.0i1
+
+Before this werk, the check crashed with `KeyError (percpu_usage)` on
+hosts with cgroups v2 enabled
+

--- a/checks/docker_container_cpu
+++ b/checks/docker_container_cpu
@@ -25,7 +25,12 @@ def parse_docker_container_cpu(info):
         return parsed
 
     raw = docker.json_get_obj(info[1])
-    parsed["num_cpus"] = len(raw['cpu_usage']['percpu_usage'])
+    # https://github.com/moby/moby/blob/646072ed6524f159c214f830f0049369db5a9441/docs/api/v1.41.yaml#L6125-L6127
+    if "online_cpus" in raw:
+        num_cpus = raw["online_cpus"]
+    else:
+        num_cpus = len(raw['cpu_usage']['percpu_usage'])
+    parsed["num_cpus"] = num_cpus
     parsed["system_ticks"] = raw['system_cpu_usage']
     parsed["container_ticks"] = raw['cpu_usage']['total_usage']
     return parsed

--- a/doc/treasures/downtime
+++ b/doc/treasures/downtime
@@ -20,7 +20,7 @@
 #    implement the "Remove all downtimes" button in a normal hosts/
 #    services views.
 
-import os, sys, getopt, time, urllib
+import os, sys, getopt, time, urllib, re
 
 omd_site = os.getenv("OMD_SITE")
 omd_root = os.getenv("OMD_ROOT")
@@ -165,8 +165,9 @@ def set_downtime(variables, add_vars):
             for line in lines:
                 verbose("OUTPUT: %s" % line.rstrip())
         for line in lines:
-            if line.startswith('<div class=error>'):
-                bail_out(line[17:].split('<')[0])
+            errors = re.findall('<div class="error">([^<]+)', line)
+            for error in errors:
+              bail_out(error)
     except Exception as e:
         bail_out("Cannot call Multisite URL: %s" % e)
 

--- a/livestatus/src/IntLambdaColumn.h
+++ b/livestatus/src/IntLambdaColumn.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <string>
 #include <utility>
+#include <variant>
 
 #include "IntColumn.h"
 #include "contact_fwd.h"
@@ -26,23 +27,32 @@ struct IntColumn : ::IntColumn {
 
 template <class T, int32_t Default = 0>
 class IntLambdaColumn : public detail::IntColumn {
+    using f0_t = std::function<int(const T&)>;
+    using f1_t = std::function<int(const T&, const contact*)>;
+    using function_type = std::variant<f0_t, f1_t>;
+
 public:
     using ::detail::IntColumn::Constant;
     using ::detail::IntColumn::Reference;
     IntLambdaColumn(const std::string& name, const std::string& description,
-                    const ColumnOffsets& offsets,
-                    const std::function<int(const T&)>& f)
+                    const ColumnOffsets& offsets, const function_type& f)
         : detail::IntColumn{name, description, offsets}, f_{f} {}
     ~IntLambdaColumn() override = default;
 
-    std::int32_t getValue(Row row,
-                          const contact* /*auth_user*/) const override {
+    std::int32_t getValue(Row row, const contact* auth_user) const override {
         const T* data = columnData<T>(row);
-        return data == nullptr ? Default : f_(*data);
+        if (std::holds_alternative<f0_t>(f_)) {
+            return data == nullptr ? Default : std::get<f0_t>(f_)(*data);
+        } else if (std::holds_alternative<f1_t>(f_)) {
+            return data == nullptr ? Default
+                                   : std::get<f1_t>(f_)(*data, auth_user);
+        } else {
+            throw std::runtime_error("unreachable");
+        }
     }
 
 private:
-    const std::function<int(const T&)> f_;
+    const function_type f_;
 };
 
 class detail::IntColumn::Constant : public detail::IntColumn {

--- a/livestatus/src/test/test_IntColumn.cc
+++ b/livestatus/src/test/test_IntColumn.cc
@@ -3,7 +3,6 @@
 // terms and conditions defined in the file COPYING, which is part of this
 // source code package.
 
-#include <functional>
 #include <string>
 
 #include "IntLambdaColumn.h"

--- a/tests/unit/checks/generictests/datasets/docker_container_cpu_plugin_section_cgroups2.py
+++ b/tests/unit/checks/generictests/datasets/docker_container_cpu_plugin_section_cgroups2.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (C) 2020 tribe29 GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+
+# yapf: disable
+# type: ignore
+
+checkname = 'docker_container_cpu'
+
+info = [
+    [
+        '@docker_version_info',
+        '{"PluginVersion": "0.1", "DockerPyVersion": "4.1.0", "ApiVersion": "1.41"}'
+    ],
+    [
+        '{"cpu_usage": {"total_usage": 422857000, "usage_in_kernelmode": 67657000, "usage_in_usermode": 35520'
+        '0000}, "system_cpu_usage": 7609030000000, "online_cpus": 8, "throttling_data": {"periods": 0, "throt'
+        'tled_periods": 0, "throttled_time": 0}}'
+    ]
+]
+
+discovery = {'': [(None, {})]}
+
+checks = {
+    '': [(None, {}, [
+        (0, 'Total CPU: 0.04%', [
+            ('util', 0.044458439512000875, None, None, 0, 800),
+        ]),
+    ]),],
+}
+
+mock_item_state = {'': (0, 0)}

--- a/tests/unit/cmk/gui/test_gui_config.py
+++ b/tests/unit/cmk/gui/test_gui_config.py
@@ -116,7 +116,6 @@ def test_registered_permissions():
         'dashboard.main',
         'dashboard.problems',
         'dashboard.simple_problems',
-        'dashboard.site',
         'dashboard.checkmk',
         'dashboard.checkmk_host',
         'general.acknowledge_werks',
@@ -525,6 +524,7 @@ def test_registered_permissions():
 
     if not cmk_version.is_raw_edition():
         expected_permissions += [
+            'dashboard.site',
             'dashboard.ntop_alerts',
             'dashboard.ntop_flows',
             'dashboard.ntop_top_talkers',


### PR DESCRIPTION
There is a script in /opt/omd/versions/default/share/doc/check_mk/treasures/downtime which allows to add a downtime.

Unfortunately this script has a bug when processing/searching for errors in the result. The script searches for “<div class=error” at the beginning of a line but 

- the whole html-result is provided in one line (so div is not at beginning of line)
- class-tag is quoted

I fixed this by replacing the search with an appropriate regex but do not know how to share this fix for getting applied to the official distribution.