### PR TITLE
Adapt ceph_df headers to ceph  15.2.8-1focal

### DIFF
--- a/checks/ceph_df
+++ b/checks/ceph_df
@@ -44,11 +44,11 @@ def parse_ceph_df(info):
     pools_headers = None
 
     for line in info:
-        if line[0] in ["GLOBAL:", "RAW"]:
+        if line[0] in ["GLOBAL:", "RAW"] or "RAW" in line[1]:
             section = "global"
             continue
 
-        elif line[0] == "POOLS:":
+        elif line[0] == "POOLS:" or "POOLS" in line[1]:
             section = "pools"
             continue
 

--- a/checks/ceph_df
+++ b/checks/ceph_df
@@ -91,6 +91,17 @@ def parse_ceph_df(info):
                     'QUOTA OBJECTS', 'QUOTA BYTES', 'DIRTY', 'USED COMPR', 'UNDER COMPR'
                 ]
 
+            elif line == [
+                    'POOL', 'ID', 'PGS', 'STORED', '(DATA)', '(OMAP)', 'OBJECTS', 'USED', '(DATA)',
+                    '(OMAP)', '%USED', 'MAX', 'AVAIL', 'QUOTA', 'OBJECTS', 'QUOTA', 'BYTES', 'DIRTY', 
+                    'USED', 'COMPR', 'UNDER', 'COMPR'
+            ]:
+                pools_headers = [
+                    'POOL', 'ID', 'PGS', 'STORED', 'STORED (DATA)', 'STORED (OMAP)', 'OBJECTS', 'USED', 
+                    'USED (DATA)', 'USED (OMAP)','%USED', 'MAX AVAIL', 'QUOTA OBJECTS', 'QUOTA BYTES', 
+                    'DIRTY', 'USED COMPR', 'UNDER COMPR'
+                ]
+
             elif pools_headers is not None:
                 parsed.setdefault(line[0], dict(zip(pools_headers[1:], line[1:])))
 


### PR DESCRIPTION
The headers of ceph 15.2.8-1focal agent output are changing to a new format like 
--- RAW STORAGE --- and 
--- POOLS ---
Also the headers of POOLS section changes to
POOL       ID  PGS  STORED   (DATA)   (OMAP)   OBJECTS  USED     (DATA)   (OMAP)   %USED  MAX AVAIL  QUOTA OBJECTS  QUOTA BYTES  DIRTY  USED COMPR  UNDER COMPR

The changes in this pull request will cover new header, too.