### PR TITLE
add pool header with PGS for ceph 15.2.8-1focal

### DIFF
--- a/checks/ceph_df
+++ b/checks/ceph_df
@@ -101,6 +101,17 @@ def parse_ceph_df(info):
                     'USED COMPR', 'UNDER COMPR'
                 ]
 
+            elif line == [
+                    'POOL', 'ID', 'PGS', 'STORED', '(DATA)', '(OMAP)', 'OBJECTS', 'USED', '(DATA)', 
+                    '(OMAP)', '%USED', 'MAX', 'AVAIL', 'QUOTA', 'OBJECTS', 'QUOTA', 'BYTES', 'DIRTY', 
+                    'USED', 'COMPR', 'UNDER', 'COMPR'
+            ]:
+                pools_headers = [
+                    'POOL', 'ID', 'PGS', 'STORED', 'STORED (DATA)', 'STORED (OMAP)', 'OBJECTS', 'USED',
+                    'USED (DATA)', 'USED (OMAP)','%USED', 'MAX AVAIL', 'QUOTA OBJECTS', 'QUOTA BYTES',
+                    'DIRTY', 'USED COMPR', 'UNDER COMPR'
+                ]                
+
             elif pools_headers is not None:
                 parsed.setdefault(line[0], dict(zip(pools_headers[1:], line[1:])))
 


### PR DESCRIPTION
The headers for ceph pools on ceph 15.2.8-1focal contain PGS, too.