### PR TITLE
Update mk_cups_queues

### DIFF
--- a/agents/plugins/mk_cups_queues
+++ b/agents/plugins/mk_cups_queues
@@ -16,7 +16,7 @@ if type lpstat > /dev/null 2>&1 ; then
     echo "<<<cups_queues>>>"
     CPRINTCONF=/etc/cups/printers.conf
     if  [ -r "$CPRINTCONF" ] ; then
-        LOCAL_PRINTERS=$(perl -ne '/<(?:Default)?Printer (\w+)>/ && print "$1\n"' $CPRINTCONF)
+        LOCAL_PRINTERS=$(perl -ne '/<(?:Default)?Printer ([\w-]+)>/ && print "$1\n"' $CPRINTCONF)
         lpstat -h localhost -p | while read LINE
         do
             PRINTER=$(echo "$LINE" | awk '{print $2}')


### PR DESCRIPTION
expand printer name filter to accept printer names with hyphen (-). Example: printer_work-01