### PR TITLE
Add relative thresholds to checkpoint_connections

### DIFF
--- a/cmk/base/plugins/agent_based/checkpoint_connections.py
+++ b/cmk/base/plugins/agent_based/checkpoint_connections.py
@@ -8,9 +8,12 @@ from typing import NamedTuple
 
 from cmk.base.plugins.agent_based.agent_based_api.v1 import (
     check_levels,
+    Metric,
     register,
+    Result,
     Service,
     SNMPTree,
+    State,
 )
 from cmk.base.plugins.agent_based.agent_based_api.v1.type_defs import (
     CheckResult,
@@ -22,14 +25,20 @@ from cmk.base.plugins.agent_based.utils import checkpoint
 
 class Section(NamedTuple):
     current: int
+    peak: int
+    maximum: int
 
 
 def parse_checkpoint_connections(string_table: StringTable) -> Section:
     """
-    >>> parse_checkpoint_connections([["19190"]])
-    Section(current=19190)
+    >>> parse_checkpoint_connections([["19190","25230","50000"]])
+    Section(current=19190, peak=25230, maximum=50000)
     """
-    return Section(int(string_table[0][0]))
+    return Section(
+        current=int(string_table[0][0]),
+        peak=int(string_table[0][1]),
+        maximum=int(string_table[0][2]),
+    )
 
 
 register.snmp_section(
@@ -40,6 +49,8 @@ register.snmp_section(
         base=".1.3.6.1.4.1.2620.1.1.25",
         oids=[
             "3",  # CHECKPOINT-MIB - fwNumConn - current connections
+            "4",  # CHECKPOINT-MIB - fwPeakNumConn - peak number of connections
+            "10",  # CHECKPOINT-MIB - fwConnTableLimit - connection table limit
         ],
     ),
 )
@@ -53,13 +64,32 @@ def check_checkpoint_connections(
     params,
     section: Section,
 ) -> CheckResult:
+
+    if section.maximum > 0 and "relative_levels" in params:
+        warn_pct, crit_pct = params["relative_levels"]
+        warn = section.maximum * warn_pct / 100
+        crit = section.maximum * crit_pct / 100
+        levels_upper = (warn, crit)
+    else:
+        # use absolute levels if no relative levels provided or no maximum set on CP
+        levels_upper = params["levels"]
     yield from check_levels(
         value=section.current,
-        levels_upper=params["levels"],
+        levels_upper=levels_upper,
         metric_name="connections",
         label="Current connections",
         render_func=str,
     )
+
+    yield Result(state=State.OK, summary="Peak: {0.peak}".format(section))
+    yield Metric(name="peak", value=section.peak, boundaries=(0, None))
+
+    if section.maximum > 0:
+        yield Metric(name="connections_pct",
+                     value=(section.current * 100.0) / section.maximum,
+                     levels=params['relative_levels'],
+                     boundaries=(0, 100))
+        yield Result(state=State.OK, summary="Connection table limit: {0.maximum}".format(section))
 
 
 register.check_plugin(

--- a/cmk/gui/plugins/wato/check_parameters/checkpoint_connections.py
+++ b/cmk/gui/plugins/wato/check_parameters/checkpoint_connections.py
@@ -10,7 +10,7 @@ from cmk.gui.plugins.wato import (
     rulespec_registry,
     RulespecGroupCheckParametersApplications,
 )
-from cmk.gui.valuespec import Dictionary, Integer, Transform, Tuple
+from cmk.gui.valuespec import Dictionary, Integer, Percentage, Transform, Tuple
 
 
 def _parameter_valuespec_checkpoint_connections() -> Transform:
@@ -39,8 +39,29 @@ def _parameter_valuespec_checkpoint_connections() -> Transform:
                         ],
                     ),
                 ),
+                (
+                    "relative_levels",
+                    Tuple(
+                        title=_("Percentage of maximum connections (only used if a limit is "
+                                "defined on the Check Point device)"),
+                        help=
+                        _("This relative threshold can only be used if a maximum number is defined on "
+                          "the firewall side and then read from fwConnTableLimit. By default, this "
+                          "limit is not set in Check Point devices and this check than falls back to "
+                          "the absolute defaults or the ones defined above"),
+                        elements=[
+                            Percentage(
+                                title=_("Warning at"),
+                                unit="%",
+                                minvalue=0.0,
+                                default_value=80.0,
+                            ),
+                            Percentage(
+                                title=_("Critical at"), unit="%", minvalue=0.0, default_value=90.0),
+                        ]),
+                ),
             ],
-            optional_keys=False,
+            optional_keys=["relative_levels"],
         ),
         forth=lambda x: x if isinstance(x, dict) else {"levels": x},
     )


### PR DESCRIPTION
closing PR #312 since PR #316 already ported to the new api, this PR now only adds new relative thresholds.
By default the absolute thresholds are kept + check falls back to absolute thresholds as @thl-cmk remarked, the firewall connection limit is usually not set.