### PR TITLE
WATO Tags: fix exception when changing an existing tag ID

### DIFF
--- a/cmk/gui/watolib/tags.py
+++ b/cmk/gui/watolib/tags.py
@@ -436,7 +436,7 @@ def _change_host_tags_in_rule(operation, mode, ruleset, rule):
 
         # In case it needs to be replaced with a new value, do it now
         if new_tag:
-            was_negated = isinstance(dict, current_value) and "$ne" in current_value
+            was_negated = isinstance(current_value, dict) and "$ne" in current_value
             new_value = {"$ne": new_tag} if was_negated else new_tag
             rule.conditions.host_tags[operation.tag_group_id] = new_value
         elif mode == TagCleanupMode.DELETE:


### PR DESCRIPTION
When changing the tag id of an already used tag and choose "Fix affected folders, hosts and rules" when saving those changes, the following exception appears:

`TypeError (isinstance() arg 2 must be a class, type, or tuple of classes and types)`

```
File "/omd/sites/wsqm/share/check_mk/web/app/index.wsgi", line 101, in _process_request
    self._handle_request()
  File "/omd/sites/wsqm/share/check_mk/web/app/index.wsgi", line 218, in _handle_request
    handler()
  File "/omd/sites/wsqm/lib/python/cmk/gui/pages.py", line 152, in <lambda>
    return lambda: handle_class().handle_page()
  File "/omd/sites/wsqm/lib/python/cmk/gui/pages.py", line 46, in handle_page
    self.page()
  File "/omd/sites/wsqm/lib/python/cmk/gui/pages.py", line 128, in <lambda>
    "page": lambda self: self._wrapped_callable[0]()
  File "/omd/sites/wsqm/lib/python/cmk/gui/wato/__init__.py", line 436, in page_handler
    _wato_page_handler(current_mode, mode_permissions, mode_class)
  File "/omd/sites/wsqm/lib/python/cmk/gui/wato/__init__.py", line 473, in _wato_page_handler
    result = mode.action()
  File "/omd/sites/wsqm/lib/python/cmk/gui/wato/pages/tags.py", line 569, in action
    message = _rename_tags_after_confirmation(operation)
  File "/omd/sites/wsqm/lib/python/cmk/gui/wato/pages/tags.py", line 720, in _rename_tags_after_confirmation
    _change_host_tags_in_folders(operation, mode, watolib.Folder.root_folder())
  File "/omd/sites/wsqm/lib/python/cmk/gui/wato/pages/tags.py", line 839, in _change_host_tags_in_folders
    affected_rulesets += _change_host_tags_in_rules(operation, mode, folder)
  File "/omd/sites/wsqm/lib/python/cmk/gui/wato/pages/tags.py", line 910, in _change_host_tags_in_rules
    affected_rulesets.update(_change_host_tags_in_rule(operation, mode, ruleset, rule))
  File "/omd/sites/wsqm/lib/python/cmk/gui/wato/pages/tags.py", line 974, in _change_host_tags_in_rule
    was_negated = isinstance(dict, current_value) and "$ne" in current_value
```

The problem is quite trivial, as the call to `isinstance()` was taken with the wrong parameter order. First, the checked value (`current_value`) and then after, the data type (`dict`). So I just switched the values. 

With this change, the tag replacements where performed successfully.



