### PR TITLE
Fix Logwatch groups

### DIFF
--- a/cmk/base/plugins/agent_based/logwatch.py
+++ b/cmk/base/plugins/agent_based/logwatch.py
@@ -268,19 +268,20 @@ def _match_group_patterns(
 
 def check_logwatch_groups_node(
     item: str,
+    params: AllParams,
     section: logwatch.Section,
 ) -> CheckResult:
     """fall back to the cluster case with node=None"""
-    yield from check_logwatch_groups(item, {None: section})
+    yield from check_logwatch_groups(item, params, {None: section})
 
 
 def check_logwatch_groups(
     item: str,
+    params: AllParams,
     section: ClusterSection,
 ) -> CheckResult:
     yield from logwatch.errors(section)
 
-    params = _compile_params()
 
     group_patterns = set(params['group_patterns'])
 
@@ -292,6 +293,8 @@ def check_logwatch_groups(
                 if _match_group_patterns(logfile_name, inclusion, exclusion):
                     loglines.extend(item_data['lines'])
                 break
+
+    params = _compile_params()
 
     yield from check_logwatch_generic(item, params, loglines, True)
 
@@ -305,6 +308,7 @@ register.check_plugin(
     discovery_ruleset_type=register.RuleSetType.ALL,
     discovery_default_parameters={},
     check_function=check_logwatch_groups_node,
+    check_default_parameters={},
     cluster_check_function=check_logwatch_groups,
 )
 

--- a/cmk/base/plugins/agent_based/logwatch.py
+++ b/cmk/base/plugins/agent_based/logwatch.py
@@ -299,6 +299,7 @@ def check_logwatch_groups(
 register.check_plugin(
     name='logwatch_groups',
     service_name="Log %s",
+    sections=['logwatch'],
     discovery_function=discover_logwatch_groups,
     discovery_ruleset_name="logwatch_groups",
     discovery_ruleset_type=register.RuleSetType.ALL,


### PR DESCRIPTION
There are two bugs in the logwatch_groups plugin/check.

* Its never even discovered as there is no logwatch_groups section
* The check does not use the discovered parameters.