### PR TITLE
Add support for Delta InsightPower UPS

### DIFF
--- a/checks/ups_generic.include
+++ b/checks/ups_generic.include
@@ -33,6 +33,7 @@ def ups_generic_scan_function(oid):
             '.1.3.6.1.4.1.534.1',
             '.1.3.6.1.4.1.935',
             '.1.3.6.1.4.1.8072.3.2.10',
+            '.1.3.6.1.4.1.2254.2.5',
     ]:
         return True
     for oid_prefix in [


### PR DESCRIPTION
To add support for the 'Delta InsightPower UPS' a slight modification is required to have Check_MK detect the UPS related services.

The UPS complies with standard 'RFC1628'.

The response of the UPS for OID '.1.3.6.1.2.1.1.2.0' is '.1.3.6.1.4.1.2254.2.5'.
These OIDs provide the following manufacturer/model information:

.1.3.6.1.4.1.2254.2.5.1.1 Delta
.1.3.6.1.4.1.2254.2.5.1.2 UPS302R2RT2B035
.1.3.6.1.4.1.2254.2.5.1.3 0F0006AR00.02.00
.1.3.6.1.4.1.2254.2.5.1.4 01.12.20a
