### PR TITLE
support standard SATA drives in smart checks

### DIFF
--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -145,7 +145,7 @@ if which smartctl > /dev/null 2>&1 ; then
                 DNAME="${VEND}_${MODEL}_${SN}"
             fi
         else
-            CMD="smartctl -d ata -v 9,raw48 -A $D"
+            CMD="smartctl -d auto -v 9,raw48 -A $D"
         fi
 
             if [ $VEND == "NVME" ]; then


### PR DESCRIPTION
This small change will enable normal SATA drives checking. Checked on everything else I have whether this still works. Needs checking on megaraids etc.