### PR TITLE
cisco_redundancy: Don't discover check if the peer_state is unkown

### DIFF
--- a/checks/cisco_redundancy
+++ b/checks/cisco_redundancy
@@ -15,10 +15,11 @@
 def inventory_cisco_redundancy(info):
     try:
         swact_reason = info[0][5]
+        peer_state = info[0][3]
     except IndexError:
         pass
     else:
-        if swact_reason != "1":
+        if "1" not in [swact_reason, peer_state]:
             return [(None, {"init_states": info[0][:5]})]
     return []
 


### PR DESCRIPTION
I discovered on Cisco Nexus9000 devices that when the Redundancy is not configured, they report an unknown peer_state.
This fix prevents them from be discovered because the service would be Critical for no reason.

Switch Details:

> Software
>   BIOS: version 07.66
> NXOS: version 9.3(3)
>   BIOS compile time:  06/11/2019
>   NXOS image file is: bootflash:///nxos.9.3.3.bin
>   NXOS compile time:  12/22/2019 2:00:00 [12/22/2019 15:00:37]
>  
> Hardware
>   cisco Nexus9000 93180YC-EX chassis
>   Intel(R) Xeon(R) CPU  @ 1.80GHz with 24632280 kB of memory.