### PR TITLE
fixed missing f-string in check_mail

### DIFF
--- a/checks/check_mail
+++ b/checks/check_mail
@@ -46,7 +46,7 @@ def check_mail_arguments(params):
     args.append(passwordstore_get_cmdline("--fetch-password=%s", password))
 
     if "connect_timeout" in params:
-        args.append("--connect-timeout={params['connect_timeout']}")
+        args.append(f"--connect-timeout={params['connect_timeout']}")
 
     if "forward" in params:
         forward = params["forward"]


### PR DESCRIPTION
As described in description. Here was a missing tag that marks the string as f-string.