### PR TITLE
dell_chassis_slots: Ignore empty Slots on more Models

### DIFF
--- a/checks/dell_chassis_slots
+++ b/checks/dell_chassis_slots
@@ -11,7 +11,9 @@ def inventory_dell_chassis_slots(info):
         number = line[3]
         if saveint(number) in (1, 2, 3, 4, 5, 6, 7, 8, 9):
             number = "0" + number
-        if line[0] != "1" and line[2] != "N/A":
+        # Ignore status which is not 1,
+        # and N/A in service_tage or name field
+        if line[0] != "1" and "N/A" not in line[1:3]:
             inventory.append((number, None))
     return inventory
 


### PR DESCRIPTION
With this Change, the Check ignores the Discovery of empty Slots.