### PR TITLE
snmp: Preserve newlines in output

### DIFF
--- a/cmk/base/plugins/agent_based/utils/interfaces.py
+++ b/cmk/base/plugins/agent_based/utils/interfaces.py
@@ -191,7 +191,7 @@ def mac_address_from_hexstring(hexstr: str) -> str:
 # Stupid fix: Remove all 0 bytes. Hope this causes no problems.
 def cleanup_if_strings(s: str) -> str:
     if s and s != '':
-        return "".join([c for c in s if c != chr(0)]).strip()
+        return s.replace('\0', '').replace('\n', ' ').strip()
     return s
 
 

--- a/cmk/core_helpers/snmp_backend/classic.py
+++ b/cmk/core_helpers/snmp_backend/classic.py
@@ -171,7 +171,7 @@ class ClassicSNMPBackend(SNMPBackend):
                                 (value[-1] != '"')):  # to be continued
                 while True:  # scan for end of this dataset
                     nextline = next(line_iter).strip()
-                    value += " " + nextline
+                    value += "\n" + nextline
                     if value[-1] == '"':
                         break
             rowinfo.append((oid, strip_snmp_value(value)))


### PR DESCRIPTION
Newlines were simply replaced with spaces because they were only expected in hexdumps of binary values. They can, however, also be contained in regular string responses.

One realistic example would be in NET-SNMP-EXTEND-MIB, where one can invoke arbitrary commands defined in the snmpd.conf of net-snmp and fetch their output.

The only place where I could find any adverse effects was in the naming of network interfaces, where hex dumps from Windows may actually be contained in the summary of a check, causing the check to fail. Hence the changed `cleanup_if_strings()` function.