### PR TITLE
Changed plugin nginx_status.py, now fully python3 compatible and added detection of ss as alternative to netstat.

### DIFF
--- a/agents/plugins/nginx_status.py
+++ b/agents/plugins/nginx_status.py
@@ -36,7 +36,6 @@ else:
     from urllib.request import Request, urlopen  # pylint: disable=import-error,no-name-in-module
     from urllib.error import URLError, HTTPError  # pylint: disable=import-error,no-name-in-module
     import urllib
-    import shutil
     urllib.getproxies = lambda: {}  # type: ignore[attr-defined]
 
 PY2 = sys.version_info[0] == 2
@@ -112,9 +111,10 @@ def try_detect_servers():
         elif ss:
             if len(parts) < 6 or '),(' not in parts[5]:
                 continue
-            parentproc = re.split ('^users:.\((.*?),(.*?),(.*?)\),(\((.*?),(.*?),(.*?)\))+', parts[5])
-            proc = re.sub('"','',parentproc[5])
-            pid = re.sub('pid=','',parentproc[6])
+            parentproc = re.split(r'^users:.\((.*?),(.*?),(.*?)\),(\((.*?),(.*?),(.*?)\))+',
+                                  parts[5])
+            proc = re.sub('"', '', parentproc[5])
+            pid = re.sub('pid=', '', parentproc[6])
 
         procs = ['nginx', 'nginx:', 'nginx.conf']
         # the pid/proc field length is limited to 19 chars. Thus in case of


### PR DESCRIPTION
Last commit did not work, because the implemented function ensure_str has not been called. 

test-bandit failed, because of the calling of netstat respectively ss:

`>> Issue: [B605:start_process_with_a_shell] Starting a process with a shell, possible injection detected, security issue.
   Severity: High   Confidence: High
   Location: /home/kleinski/checkmk/agents/plugins/nginx_status.py:104
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b605_start_process_with_a_shell.html`
`103`
`104         for netstat_line in os.popen(socket_cmd).readlines():`
`105             parts = netstat_line.split()`