### PR TITLE
diskspace: Fix RuntimeError in cleanup_aged

### DIFF
--- a/omd/packages/maintenance/diskspace
+++ b/omd/packages/maintenance/diskspace
@@ -188,7 +188,7 @@ def cleanup_aged():
     max_age = time.time() - max_file_age
 
     for plugin in plugins.values():
-        for path, (_size, mtime) in plugin.get('file_infos', {}).items():
+        for path, (_size, mtime) in list(plugin.get('file_infos', {}).items()):
             if mtime < max_age:
                 if delete_file(path, 'too old'):
                     del plugin['file_infos'][path]


### PR DESCRIPTION
The error was:
```
RuntimeError: dictionary changed size during iteration
```
To trigger it, you have to set `max_file_age` to something greater 0 in `$OMD_ROOT/etc/diskspace.conf`

We now simply iterate over a copy of the dictionary.

(Also, added a license header to make pre-commit happy)