### PR TITLE
Make check oracle_crs_res configurable with WATO

### DIFF
--- a/checks/oracle_crs_res
+++ b/checks/oracle_crs_res
@@ -68,10 +68,10 @@ def parse_oracle_crs_res(info):
 
 
 def inventory_oracle_crs_res(parsed):
-    return [(name, None) for name in parsed[1]]
+    return [(name, {}) for name in parsed[1]]
 
 
-def check_oracle_crs_res(item, _no_params, parsed):
+def check_oracle_crs_res(item, params, parsed):
     _crs_nodename, ressources = parsed
 
     # In case of missing information we assume that the clusterware
@@ -98,7 +98,10 @@ def check_oracle_crs_res(item, _no_params, parsed):
             infotext = ""
         infotext += resstate.lower()
 
-        if resstate != restarget:
+        if params:
+            restarget = params.get('restarget')
+
+        if resstate.lower() != restarget.lower():
             state = 2
             infotext += ", target state %s" % restarget.lower()
         else:
@@ -107,8 +110,9 @@ def check_oracle_crs_res(item, _no_params, parsed):
 
 
 check_info['oracle_crs_res'] = {
-    "parse_function": parse_oracle_crs_res,
-    "check_function": check_oracle_crs_res,
-    "inventory_function": inventory_oracle_crs_res,
+    "parse_function":      parse_oracle_crs_res,
+    "check_function":      check_oracle_crs_res,
+    "inventory_function":  inventory_oracle_crs_res,
     "service_description": "ORA-GI %s Resource",
+    "group":               "oracle_crs_res",
 }

--- a/cmk/gui/plugins/wato/check_parameters/oracle_crs_res.py
+++ b/cmk/gui/plugins/wato/check_parameters/oracle_crs_res.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 tribe29 GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+
+from cmk.gui.i18n import _
+from cmk.gui.valuespec import (
+    Age,
+    Dictionary,
+    TextAscii,
+    Tuple,
+    Integer,
+    DropdownChoice
+)
+from cmk.gui.plugins.wato import (
+    RulespecGroupCheckParametersStorage,
+    CheckParameterRulespecWithItem,
+    rulespec_registry,
+    HostRulespec,
+)
+
+
+def _item_spec_oracle_crs_res():
+    return TextAscii(
+        title=_("Queue Name"),
+        help=_("The name of the queue like in the Apache queue manager")
+    )
+
+
+def _parameter_valuespec_orcale_crs_res():
+    return Dictionary(
+        elements=[
+            ("restarget",
+                DropdownChoice(
+                    title=_("Override target state"),
+                    choices=[
+                        ('online', 'ONLINE'),
+                        ('intermediate', 'INTERMEDIATE')
+                    ]
+                )
+            ),
+        ],
+    )
+
+
+rulespec_registry.register(
+    CheckParameterRulespecWithItem(
+        check_group_name="orcale_crs_res",
+        item_spec=_item_spec_oracle_crs_res,
+        group=RulespecGroupCheckParametersStorage,
+        match_type="dict",
+        parameter_valuespec=_parameter_valuespec_orcale_crs_res,
+        title=lambda: _("Oracle CRS Resource"),
+    ))


### PR DESCRIPTION
Customer needs a way to configure Oracle Clusterware/Grid-Infrastructure to adjust it to the current environment.
At the moment there is no other possibility available. It is a very small change and only added a WATO rule for configuration.

Signed-off-by: Sven Rueß <github@sritd.de>