### PR TITLE
Prevent smartctl from running on CDs and DVDs

### DIFF
--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -108,6 +108,9 @@ if which smartctl > /dev/null 2>&1 ; then
             continue
         fi
 
+        # Exlude DVD-RAM
+        [ "$MODEL" != "${MODEL%DVD-RAM\*}" ] && continue
+
         # Avoid duplicate entries for same device
         if [ "${SEEN//.$N./}" != "$SEEN" ] ; then
             continue

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -108,8 +108,8 @@ if which smartctl > /dev/null 2>&1 ; then
             continue
         fi
 
-        # Exlude DVD-RAM
-        [ "$MODEL" != "${MODEL%DVD-RAM\*}" ] && continue
+        # Exlude Removable Media
+        [ $(< /sys/class/block/$N/removable) == "1" ] && continue
 
         # Avoid duplicate entries for same device
         if [ "${SEEN//.$N./}" != "$SEEN" ] ; then

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -11,6 +11,12 @@
 # shellcheck disable=SC2034
 CMK_VERSION="2.1.0i1"
 
+# Function to replace "if type [somecmd]" idiom
+# 'command -v' tends to be more robust vs 'which' and 'type' based tests
+inpath() {
+    command -v "${1:?No command to test}" >/dev/null 2>&1
+}
+
 # This will be called on LSI based raidcontrollers and accesses
 # the SMART data of SATA disks attached to a SAS Raid HBA via
 # SCSI protocol interface.
@@ -109,17 +115,10 @@ if which smartctl > /dev/null 2>&1 ; then
         fi
 
         # Exclude removable media
-        if which udevadm > /dev/null 2>&1; then
-            TMP_FILE=$(mktemp)
-            udevadm info /dev/$N > $TMP_FILE
-            if grep -Fxq "E: ID_CDROM_CD=1" $TMP_FILE; then
-                rm $TMP_FILE
+        if inpath udevadm; then
+            if sh -c "udevadm info /dev/$N | grep -Fxq 'E: ID_CDROM_CD=1'"; then
                 continue
-            else
-                rm $TMP_FILE
             fi
-        else
-            [ $(< /sys/class/block/$N/removable) == "1" ] && continue
         fi
 
         # Avoid duplicate entries for same device

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -108,8 +108,19 @@ if which smartctl > /dev/null 2>&1 ; then
             continue
         fi
 
-        # Exlude Removable Media
-        [ $(< /sys/class/block/$N/removable) == "1" ] && continue
+        # Exclude removable media
+        if which udevadm > /dev/null 2>&1; then
+            TMP_FILE=$(mktemp)
+            udevadm info /dev/$N > $TMP_FILE
+            if grep -Fxq "E: ID_CDROM_CD=1" $TMP_FILE; then
+                rm $TMP_FILE
+                continue
+            else
+                rm $TMP_FILE
+            fi
+        else
+            [ $(< /sys/class/block/$N/removable) == "1" ] && continue
+        fi
 
         # Avoid duplicate entries for same device
         if [ "${SEEN//.$N./}" != "$SEEN" ] ; then

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -88,6 +88,7 @@ if which smartctl > /dev/null 2>&1 ; then
     fi
 
     echo '<<<smart>>>'
+    INPATH_UDEVADM=$(inpath udevadm && echo present)
     SEEN=
     for D in /dev/disk/by-id/{scsi,ata,nvme}-*; do
         [ "$D" != "${D%scsi-\*}" ] && continue
@@ -115,10 +116,8 @@ if which smartctl > /dev/null 2>&1 ; then
         fi
 
         # Exclude removable media
-        if inpath udevadm; then
-            if sh -c "udevadm info /dev/$N | grep -Fxq 'E: ID_CDROM_CD=1'"; then
-                continue
-            fi
+        if [ "$INPATH_UDEVADM" == "present" ] && udevadm info /dev/$N | grep -Fxq 'E: ID_CDROM_CD=1'; then
+            continue
         fi
 
         # Avoid duplicate entries for same device


### PR DESCRIPTION
I've seen the smart plugin running `smartctl -d scsi -i -A /dev/disk/by-id/ata-[...]DVD-RAM_[...]`,
while `/dev/disk/by-id/ata-[...]DVD-RAM_[...]` is a symlink to `/dev/sr0`.
That resulted in 100s of smartctl processes hanging in D-state and a stale host with pretty high load.

This is my attempt to solve that problem.