### PR TITLE
Fixed special agent Netapp command line creation.

### DIFF
--- a/checks/agent_netapp
+++ b/checks/agent_netapp
@@ -13,7 +13,7 @@ def agent_netapp_arguments(params, hostname, ipaddress):
     if params.get("skip_elements"):
         no_ctrs = [x[4:] for x in params["skip_elements"] if x.startswith("ctr_")]
         if no_ctrs:
-            args += ["--nocounters %s" % ",".join(no_ctrs)]
+            args += ["--nocounters", "%s" % ",".join(no_ctrs)]
 
     args += [ipaddress]
     return args


### PR DESCRIPTION
### Original created command line for Netapp special agent

/omd/sites/cmk/share/check_mk/agents/special/agent_netapp '-u' 'user' '-s' 'password' '--nocounters volumes' '127.0.0.1'
usage: agent_netapp [-h] [-u USER] [-s SECRET] [--vcrtrace TRACEFILE] [-t TIMEOUT] [--nocounters {volumes}] [--xml] [--debug] [--legacy] host_address
agent_netapp: error: unrecognized arguments: 127.0.0.1

### Bugfixed

/omd/sites/cmk/share/check_mk/agents/special/agent_netapp '-u' 'user' '-s' 'password' '--nocounters' 'volumes' '127.0.0.1'
<<<netapp_api_connection>>>
.......


Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
