### PR TITLE
Add missing "protocol" to activemq agent options

### DIFF
--- a/cmk/special_agents/agent_activemq.py
+++ b/cmk/special_agents/agent_activemq.py
@@ -18,7 +18,7 @@ from cmk.special_agents.utils.request_helper import (
 def usage():
     print("Usage:")
     print(
-        "agent_activemq --servername {servername} --port {port} [--piggyback] [--username {username} --password {password}]\n"
+        "agent_activemq --servername {servername} --port {port} [--piggyback] [--username {username} --password {password}] [--protocol {http|https}]\n"
     )
 
 
@@ -27,7 +27,7 @@ def main(sys_argv=None):
         sys_argv = sys.argv[1:]
 
     short_options = ""
-    long_options = ["piggyback", "servername=", "port=", "username=", "password="]
+    long_options = ["piggyback", "servername=", "port=", "username=", "password=", "protocol="]
 
     try:
         opts, _args = getopt.getopt(sys_argv, short_options, long_options)


### PR DESCRIPTION
This adds the missing option "--protocol" to the list of command line options of the activemq special agent, including the corresponding mention in the usage for the agent.

Currently when configuring a host with the activemq-special agent, the corresponding rule adds the parameter `--protocol`. The agent however does not know that parameter and immediatly exits with an error message. The parameter is already correctly parsed in the agent, it was just missing in the `long_options` array.
