### PR TITLE
Fix printer_supply output for HP Jetdirect 153

### DIFF
--- a/cmk/base/plugins/agent_based/printer_supply.py
+++ b/cmk/base/plugins/agent_based/printer_supply.py
@@ -86,8 +86,9 @@ def parse_printer_supply(string_table: List[StringTable]) -> Section:
             if color:
                 name = "%s %s" % (color.title(), name)
 
-        # fix trailing zero bytes (seen on HP Jetdirect 143)
+        # fix trailing zero bytes (seen on HP Jetdirect 143 and 153)
         description = name.split(" S/N:")[0].strip("\0")
+        color = color.rstrip("\0")
         unit = get_unit(unit_info)
 
         parsed[description] = PrinterSupply(unit, max_capacity, level, supply_class, color)
@@ -132,8 +133,7 @@ def check_printer_supply(item: str, params: Mapping[str, Any], section: Section)
 
     color_info = ""
     if supply.color and supply.color.lower() not in item.lower():
-        # fix trailing zero byte in output (seen on HP Jetdirect 153)
-        color_info = "[%s] " % supply.color.rstrip('\0')
+        color_info = "[%s] " % supply.color
 
     warn, crit = params["levels"]
 

--- a/cmk/base/plugins/agent_based/printer_supply.py
+++ b/cmk/base/plugins/agent_based/printer_supply.py
@@ -132,7 +132,8 @@ def check_printer_supply(item: str, params: Mapping[str, Any], section: Section)
 
     color_info = ""
     if supply.color and supply.color.lower() not in item.lower():
-        color_info = "[%s] " % supply.color
+        # fix trailing zero byte in output (seen on HP Jetdirect 153)
+        color_info = "[%s] " % supply.color.rstrip('\0')
 
     warn, crit = params["levels"]
 

--- a/tests/unit/cmk/base/plugins/agent_based/test_printer_supply.py
+++ b/tests/unit/cmk/base/plugins/agent_based/test_printer_supply.py
@@ -9,7 +9,7 @@ import pytest
 from cmk.base.plugins.agent_based.agent_based_api.v1 import Service, Result, Metric, State
 from cmk.base.plugins.agent_based.printer_supply import (parse_printer_supply,
                                                          discovery_printer_supply,
-                                                         check_printer_supply)
+                                                         check_printer_supply, PrinterSupply)
 
 
 @pytest.mark.parametrize("info, expected_result", [([
@@ -335,3 +335,13 @@ def test_check_printer_supply(item, params, info, expected_result):
     section = parse_printer_supply(info)
     result = check_printer_supply(item, params, section)
     assert list(result) == expected_result
+
+
+@pytest.mark.parametrize(
+    "info, expected_result",
+    [([[['1.1',
+         'black\x00']], [['Patrone Schwarz 508A HP CF360A\x00', '19', '100', '9', '3', '1']]], {
+             "Patrone Schwarz 508A HP CF360A": PrinterSupply("%", 100, 9, "3", "black")
+         })])
+def test_parse_printer_supply(info, expected_result):
+    assert parse_printer_supply(info) == expected_result


### PR DESCRIPTION
With HP Jetdirect 153 models the value for the color in the printer_supply check could contain a trailing NULL-byte. This would break the output in the webinterface, so that the Service Detail is cut after the color, e.g. it would only show "[black" and there also wouldn't be any performance data.

The SNMP-output from the printer looks as follows - note the  `00` at the end of every value:
```
.1.3.6.1.2.1.43.12.1.1.4.1.1 "62 6C 61 63 6B 00 " // black
.1.3.6.1.2.1.43.12.1.1.4.1.2 "63 79 61 6E 00 " // cyan
.1.3.6.1.2.1.43.12.1.1.4.1.3 "6D 61 67 65 6E 74 61 00 " // magenta
.1.3.6.1.2.1.43.12.1.1.4.1.4 "79 65 6C 6C 6F 77 00 " // yellow
``` 

I could also provide a full SNMP walk from the device in question. As this issue was already discussed on the forum (https://forum.checkmk.com/t/bug-printer-supply-check-for-toner-levels-incorrect-interpretation-of-description/22640/9), this may not be an isolated case and could also be relevant for other printers.
