### PR TITLE
Logwatch groups icon is missing after update 2.0

### DIFF
--- a/cmk/gui/plugins/views/icons/builtin.py
+++ b/cmk/gui/plugins/views/icons/builtin.py
@@ -534,6 +534,7 @@ class LogwatchIcon(Icon):
         if what != "service" or row[what + "_check_command"] not in [
                 'check_mk-logwatch',
                 'check_mk-logwatch.groups',
+                'check_mk-logwatch_groups',
         ]:
             return
 


### PR DESCRIPTION
The logwatch goups icon was missing as the service name was changed in 2.0.
Only added the right service name to the check list.

Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
