### PR TITLE
Fix jvm_memory transform

### DIFF
--- a/cmk/gui/plugins/wato/check_parameters/jvm_memory.py
+++ b/cmk/gui/plugins/wato/check_parameters/jvm_memory.py
@@ -43,6 +43,9 @@ def _transform_legacy_parameters_jvm_memory(params):
         ("heap", "perc_heap"),
         ("nonheap", "perc_nonheap"),
     ):
+        if newkey in params:
+            new_params[newkey] = params[newkey]
+            continue
         levels = params.get(key)
         if isinstance(levels, tuple) and isinstance(levels[0], float):
             new_params[newkey] = levels


### PR DESCRIPTION
Do not ignore already updated parameter name. Otherwise rules in the new format will lose there values upon edit as the new keys are lost in translation.