### PR TITLE
Smart with LSI raid controller

### DIFF
--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -82,11 +82,8 @@ storcli_info()
                             break
                         ;;
                         *)
-                            EID_Slt=$( echo "$line" | awk '{print $1}' )
+                            echo "$line" | IFS=' ' read -r EID_Slt DID _ _ _ _ VEND _ _ _ _ MODEL _
                             echo "$EID_Slt" | IFS=: read -r EID Slt 
-                            DID=$( echo "$line" | awk '{print $2}' )
-                            MODEL=$( echo "$line" | awk '{print $12}' )
-                            VEND=$( echo "$line" | awk '{print $7}' )
                             smartctl -d "megaraid,${DID}" -v 9,raw48 -A /dev/${SG}     | \
                               grep Always  | grep -E -v '^190(.*)Temperature(.*)' | \
                               sed "s|^|Enc${EID}/Slot${Slt} $VEND $MODEL |"

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -86,7 +86,7 @@ storcli_info()
                             echo "$EID_Slt" | IFS=: read -r EID Slt 
                             smartctl -d "megaraid,${DID}" -v 9,raw48 -A /dev/${SG}     | \
                               grep Always  | grep -E -v '^190(.*)Temperature(.*)' | \
-                              sed "s|^|Enc${EID}/Slot${Slt} $VEND $MODEL |"
+                              sed "s|^|Contr${CTRL}/Enc${EID}/Slot${Slt} $VEND $MODEL |"
                         ;;
                     esac
                 done

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -85,12 +85,11 @@ storcli_info()
                             EID_Slt=$( echo "$line" | awk '{print $1}' )
                             echo "$EID_Slt" | IFS=: read -r EID Slt 
                             DID=$( echo "$line" | awk '{print $2}' )
-                            #DG=$( echo "$line" | awk '{print $4}' )
                             MODEL=$( echo "$line" | awk '{print $12}' )
-                            VENDOR=${MODEL}
+                            VEND=$( echo "$line" | awk '{print $7}' )
                             smartctl -d "megaraid,${DID}" -v 9,raw48 -A /dev/${SG}     | \
                               grep Always  | grep -E -v '^190(.*)Temperature(.*)' | \
-                              sed "s|^|Enc${EID}/Slot${Slt} $VENDOR $MODEL |"
+                              sed "s|^|Enc${EID}/Slot${Slt} $VEND $MODEL |"
                         ;;
                     esac
                 done

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -62,6 +62,43 @@ megaraid_info()
        done
 }
 
+storcli_info()
+{
+    $1 /call show all | while read -r line; do
+        case "$line" in
+            "Controller = "*)
+                CTRL=$( echo "$line" | cut -d ' ' -f 3 )
+            ;;
+            "PCI Address = "*)
+		    PCIA=$( echo "$line" | cut -d ' ' -f 4 | (IFS=: read -r _d _c _b _a; echo ${_a}${_b}:$_c:$_d) )
+		_SGP=( "/sys/devices/pci*/*/*$PCIA.*/*/*/*/*/sg*" )
+		SG=$( basename $( echo $_SGP | cut -d ' ' -f 1 ) )
+            ;;
+            "EID:Slt "*)
+                read -r line;
+                while read -r line; do
+                    case "$line" in
+                        "---"*)
+                            break
+                        ;;
+                        *)
+                            EID=$( echo "$line" | awk '{print $1}' | cut -d ':' -f 1 )
+                            Slt=$( echo "$line" | awk '{print $1}' | cut -d ':' -f 2 )
+                            DID=$( echo "$line" | awk '{print $2}' )
+                            #DG=$( echo "$line" | cut -d ' ' -f 4 )
+			    MODEL=$( echo "$line" | awk '{print $12}' )
+			    VENDOR=${MODEL}
+			    smartctl -d "megaraid,${DID}" -v 9,raw48 -A /dev/${SG}     | \
+                              grep Always  | grep -E -v '^190(.*)Temperature(.*)' | \
+                              sed "s|^|Enc${EID}/Slot${Slt} $VENDOR $MODEL |"
+                        ;;
+                    esac
+                done
+            ;;
+        esac
+    done
+}
+
 
 # Only handle always updated values, add device path and vendor/model
 if which smartctl > /dev/null 2>&1 ; then
@@ -169,9 +206,15 @@ if which smartctl > /dev/null 2>&1 ; then
             fi
     done 2>/dev/null
 
+    if inpath storcli; then
+        storcli_info storcli
+        MegaCli_bin="unknown"
+    elif inpath storcli64; then
+        storcli_info storcli64
+        MegaCli_bin="unknown"
 
     # Call MegaRaid submodule if conditions are met
-    if type MegaCli >/dev/null 2>&1; then
+    elif type MegaCli >/dev/null 2>&1; then
         MegaCli_bin="MegaCli"
     elif type MegaCli64 >/dev/null 2>&1; then
         MegaCli_bin="MegaCli64"

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -82,8 +82,12 @@ storcli_info()
                             break
                         ;;
                         *)
-                            echo "$line" | IFS=' ' read -r EID_Slt DID _ _ _ _ VEND _ _ _ _ MODEL _
-                            echo "$EID_Slt" | IFS=: read -r EID Slt 
+                            EID_Slt=$( echo "$line" | awk '{print $1}' )
+                            EID=$( echo "$EID_Slt" | cut -d ':' -f 1 )
+                            Slt=$( echo "$EID_Slt" | cut -d ':' -f 2 )
+                            DID=$( echo "$line" | awk '{print $2}' )
+                            MODEL=$( echo "$line" | awk '{print $12}' )
+                            VEND=$( echo "$line" | awk '{print $7}' )
                             smartctl -d "megaraid,${DID}" -v 9,raw48 -A /dev/${SG}     | \
                               grep Always  | grep -E -v '^190(.*)Temperature(.*)' | \
                               sed "s|^|Contr${CTRL}/Enc${EID}/Slot${Slt} $VEND $MODEL |"

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -70,9 +70,9 @@ storcli_info()
                 CTRL=$( echo "$line" | cut -d ' ' -f 3 )
             ;;
             "PCI Address = "*)
-		    PCIA=$( echo "$line" | cut -d ' ' -f 4 | (IFS=: read -r _d _c _b _a; echo ${_a}${_b}:$_c:$_d) )
-		_SGP=( "/sys/devices/pci*/*/*$PCIA.*/*/*/*/*/sg*" )
-		SG=$( basename $( echo $_SGP | cut -d ' ' -f 1 ) )
+                PCIA=$( echo "$line" | cut -d ' ' -f 4 | (IFS=: read -r _d _c _b _a; echo ${_a}${_b}:$_c:$_d) )
+                _SGP=( "/sys/devices/pci*/*/*$PCIA.*/*/*/*/*/sg*" )
+                SG=$( basename $( echo $_SGP | cut -d ' ' -f 1 ) )
             ;;
             "EID:Slt "*)
                 read -r line;
@@ -85,10 +85,10 @@ storcli_info()
                             EID=$( echo "$line" | awk '{print $1}' | cut -d ':' -f 1 )
                             Slt=$( echo "$line" | awk '{print $1}' | cut -d ':' -f 2 )
                             DID=$( echo "$line" | awk '{print $2}' )
-                            #DG=$( echo "$line" | cut -d ' ' -f 4 )
-			    MODEL=$( echo "$line" | awk '{print $12}' )
-			    VENDOR=${MODEL}
-			    smartctl -d "megaraid,${DID}" -v 9,raw48 -A /dev/${SG}     | \
+                            #DG=$( echo "$line" | awk '{print $4}' )
+                            MODEL=$( echo "$line" | awk '{print $12}' )
+                            VENDOR=${MODEL}
+                            smartctl -d "megaraid,${DID}" -v 9,raw48 -A /dev/${SG}     | \
                               grep Always  | grep -E -v '^190(.*)Temperature(.*)' | \
                               sed "s|^|Enc${EID}/Slot${Slt} $VENDOR $MODEL |"
                         ;;

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -71,8 +71,8 @@ storcli_info()
             ;;
             "PCI Address = "*)
                 PCIA=$( echo "$line" | cut -d ' ' -f 4 | (IFS=: read -r _d _c _b _a; echo ${_a}${_b}:$_c:$_d) )
-                _SGP=( "/sys/devices/pci*/*/*$PCIA.*/*/*/*/*/sg*" )
-                SG=$( basename $( echo $_SGP | cut -d ' ' -f 1 ) )
+                SG_PATH=( "/sys/devices/pci*/*/*$PCIA.*/*/*/*/*/sg*" )
+                SG=$( basename $( echo $SG_PATH | cut -d ' ' -f 1 ) )
             ;;
             "EID:Slt "*)
                 read -r line;
@@ -82,8 +82,8 @@ storcli_info()
                             break
                         ;;
                         *)
-                            EID=$( echo "$line" | awk '{print $1}' | cut -d ':' -f 1 )
-                            Slt=$( echo "$line" | awk '{print $1}' | cut -d ':' -f 2 )
+                            EID_Slt=$( echo "$line" | awk '{print $1}' )
+                            echo "$EID_Slt" | IFS=: read -r EID Slt 
                             DID=$( echo "$line" | awk '{print $2}' )
                             #DG=$( echo "$line" | awk '{print $4}' )
                             MODEL=$( echo "$line" | awk '{print $12}' )


### PR DESCRIPTION
I experienced some problems with the megacli "submodule":
1. when there is more than one controller, only the data of the first one can be gathered
2. when there is some SCSI compatible device directly attached, `/dev/sg0` may be something else than the raid controller (some hard drive or DVD drive connected to a SAS/SATA compatible port)

So we just added support for storcli and determine the sg device dynamically.

I know, this may be considered not to be a bugfix, because it adds a feature, but storcli support could be a benefit after all.