### PR TITLE
fix allnet_ip_sensoric check/special agent

### DIFF
--- a/cmk/special_agents/agent_allnet_ip_sensoric.py
+++ b/cmk/special_agents/agent_allnet_ip_sensoric.py
@@ -63,7 +63,7 @@ def get_allnet_ip_sensoric_info(host_address, opt_debug):
         raise RequestError('Error during http call')
 
     infos = handle.info()
-    contents = handle.read()
+    contents = handle.read().decode('utf-8')
 
     if opt_debug:
         sys.stdout.write('----------------------------\n')


### PR DESCRIPTION
After upgrading to CheckMK 2.0.0 we noticed that the check for the Allnet devices was not working anymore.

The problem seems to be that the related script is not Python 3 compatible: read() of urllib.request returns bytes and not a string like urllib2 on Python 2.

This patch brings the Allnet temperature sensor check back to life.