### PR TITLE
oracle_jobs: ValueError for setups with CDB and nonCDB on same host

### DIFF
--- a/checks/oracle_jobs
+++ b/checks/oracle_jobs
@@ -76,7 +76,7 @@ def check_oracle_jobs(item, params, info):
         # check for pdb_name in agent output
         # => the agentoutput is responsible for the format of item from Checkmk!
         # item could have the following formats. Keep in mind, that job_name could include a '.'!
-        if len(line) == 11:
+        if len(line) == 11 and item.count('.') >= 3:
             # => sid.pdb_name.job_owner.job_name
             itemsid, itempdb, itemowner, itemname = item.split('.', 3)
             lineformat = 3

--- a/tests/unit/checks/generictests/datasets/oracle_jobs_cdb_noncdb.py
+++ b/tests/unit/checks/generictests/datasets/oracle_jobs_cdb_noncdb.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 tribe29 GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
+
+# yapf: disable
+# type: ignore
+
+checkname = 'oracle_jobs'
+
+info = [
+          [u'CDB',
+           u'CDB$ROOT',
+           u'SYS',
+           u'AUTO_SPACE_ADVISOR_JOB',
+           u'SCHEDULED',
+           u'0',
+           u'46',
+           u'TRUE',
+           u'15-JUN-21 01.01.01.143871 AM +00:00',
+           u'-',
+           u'SUCCEEDED'],
+          [u'NONCDB',
+           u'SYS',
+           u'AUTO_SPACE_ADVISOR_JOB',
+           u'SCHEDULED',
+           u'995',
+           u'1129',
+           u'TRUE',
+           u'16-JUN-21 01.01.01.143871 AM +00:00',
+           u'MAINTENANCE_WINDOW_GROUP',
+           u''],
+
+]
+
+discovery = {
+    '': [
+      ('CDB.CDB$ROOT.SYS.AUTO_SPACE_ADVISOR_JOB', {}),
+      ('NONCDB.SYS.AUTO_SPACE_ADVISOR_JOB', {})
+    ]
+}
+
+checks = {
+    '': [
+        (
+            'CDB.CDB$ROOT.SYS.AUTO_SPACE_ADVISOR_JOB', {
+                'disabled': False,
+                'status_missing_jobs': 2,
+                'missinglog': 0
+            }, [
+                (
+                    0,
+                    'Job-State: SCHEDULED, Enabled: Yes, Last Duration: 0.00 s, Next Run: 15-JUN-21 01.01.01.143871 AM +00:00, Last Run Status: SUCCEEDED (ignored disabled Job)',
+                    [('duration', 0, None, None, None, None)]
+                )
+            ]
+        ),
+
+
+        (
+            'NONCDB.SYS.AUTO_SPACE_ADVISOR_JOB', {
+                'disabled': False,
+                'status_missing_jobs': 2,
+                'missinglog': 1
+            }, [
+                (
+                    1,
+                    'Job-State: SCHEDULED, Enabled: Yes, Last Duration: 16 m, Next Run: 16-JUN-21 01.01.01.143871 AM +00:00,  no log information found(!)',
+                    [('duration', 995, None, None, None, None)]
+                )
+            ]
+        )
+    ]
+}


### PR DESCRIPTION
If a host has multiple Databases with CDB and nonCDB Databases
with enabled oracle_jobs sections, all services for scheduler jobs
will crash due to wrong comparison for a nonCDB services against a CDB
agent line.

This bug has been introduced with the support for Multitenant Option
in 2018 and is fixed now.
