### PR TITLE
oracle_recovery_status: offline datafiles are ignorred from 12.1+

### DIFF
--- a/agents/plugins/mk_oracle
+++ b/agents/plugins/mk_oracle
@@ -1246,14 +1246,13 @@ sql_recovery_status () {
                      ||'|'|| dh.RECOVER
                      ||'|'|| dh.FUZZY
                      ||'|'|| dh.CHECKPOINT_CHANGE#
-                     ||'|'|| vb.STATUS
-                     ||'|'|| round((sysdate-vb.TIME)*24*60*60)
+                     ||'|'|| nvl(vb.STATUS, 'unknown')
+                     ||'|'|| nvl2(vb.TIME, round((sysdate-vb.TIME)*24*60*60), 0)
               FROM  V\$datafile_header dh
               JOIN v\$database d on 1=1
               JOIN v\$instance i on 1=1
-              JOIN v\$backup vb on 1=1
+              LEFT OUTER JOIN v\$backup vb on vb.file# = dh.file#
               LEFT OUTER JOIN V\$PDBS vp on dh.con_id = vp.con_id
-              WHERE vb.file# = dh.file#
               ORDER BY dh.file#;"
     elif [ "$NUMERIC_ORACLE_VERSION" -ge 101 ]; then
         echo "SELECT upper(decode(${IGNORE_DB_NAME:-0}, 0, d.NAME, i.instance_name))

--- a/agents/windows/plugins/mk_oracle.ps1
+++ b/agents/windows/plugins/mk_oracle.ps1
@@ -1034,14 +1034,13 @@ Function sql_recovery_status {
                  ||'|'|| dh.RECOVER
                  ||'|'|| dh.FUZZY
                  ||'|'|| dh.CHECKPOINT_CHANGE#
-                 ||'|'|| vb.STATUS
-                 ||'|'|| round((sysdate-vb.TIME)*24*60*60)
+                 ||'|'|| nvl(vb.STATUS, 'unknown')
+                 ||'|'|| nvl2(vb.TIME, round((sysdate-vb.TIME)*24*60*60), 0)
           FROM V$datafile_header dh
           JOIN v$database d on 1=1
           JOIN v$instance i on 1=1
-          JOIN v$backup vb on 1=1
+          LEFT OUTER JOIN v$backup vb on vb.file# = dh.file#
           LEFT OUTER JOIN V$PDBS vp on dh.con_id = vp.con_id
-          WHERE vb.file# = dh.file#
           ORDER BY dh.file#;
 
 '@


### PR DESCRIPTION
This is a critical bugfix for all environments with phsical standby
databases, because informations from offline datafiles were removed from
the plugin output. Instead of CRIT state the informations were ignored
and the check is stale, when all daafiles are offline.
The has been fixed.

Important Note:

Please update the mk_oracle plugin for this fix!