### PR TITLE
orcale_jobs crashes if used in mixed environments

### DIFF
--- a/checks/oracle_jobs
+++ b/checks/oracle_jobs
@@ -77,6 +77,8 @@ def check_oracle_jobs(item, params, info):
         # => the agentoutput is responsible for the format of item from Checkmk!
         # item could have the following formats. Keep in mind, that job_name could include a '.'!
         if len(line) == 11 and item.count('.') >= 3:
+            if len(item.split('.', 3)) != 4:
+                continue
             # => sid.pdb_name.job_owner.job_name
             itemsid, itempdb, itemowner, itemname = item.split('.', 3)
             lineformat = 3


### PR DESCRIPTION
oracle_jobs crashes if you have a mixed environment with container database and classical ones.
The data from the Oracle agent plugins contains lines with 10 and 11 entries.
Discovery is working fine but if the system tries to check a item what was created from a 10 entry line it crashes as the check for the 11 item line tries to compare the 3 parts item with it expected 4 parts item.

Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
