### PR TITLE
bugfix in local.py: min/max values are optional

### DIFF
--- a/cmk/base/plugins/agent_based/local.py
+++ b/cmk/base/plugins/agent_based/local.py
@@ -181,8 +181,8 @@ def _parse_perfentry(entry: str) -> Perfdata:
         value,
         levels_upper=optional_tuple(levels[0], levels[1]),
         levels_lower=optional_tuple(levels[2], levels[3]),
-        boundaries=(float(raw[3]) if len(raw) >= 4 else None,
-                    float(raw[4]) if len(raw) >= 5 else None),
+        boundaries=(_try_convert_to_float(raw[3]) if len(raw) >= 4 else None,
+                    _try_convert_to_float(raw[4]) if len(raw) >= 5 else None),
     )
 
 


### PR DESCRIPTION
According to https://docs.checkmk.com/latest/en/localchecks.html the min/max values should be optional. So an empty value should be accepted. However, converting empty values with float() throws a ValueError. So the conversion is now done with _try_convert_to_float, which returns None in such a case.

