### PR TITLE
Bugfix for apt check - added some header lines to output with actual Ubuntu

### DIFF
--- a/checks/apt
+++ b/checks/apt
@@ -33,7 +33,7 @@ factory_settings["apt_default_levels"] = {
 }
 
 NOTHING_PENDING_FOR_INSTALLATION = "No updates pending for installation"
-
+HEADER_LINE = "security update"
 
 # Check that the apt section is in valid format of mk_apt plugin and not
 # from the apt agent plugin which can be found on the Checkmk exchange.
@@ -47,6 +47,9 @@ def apt_valid_info(info):
 
     if first_line[0] == NOTHING_PENDING_FOR_INSTALLATION:
         return True
+
+    if HEADER_LINE in first_line[0]:
+        first_line = info[1]
 
     parts = first_line[0].split()
     if len(parts) < 3:


### PR DESCRIPTION
Actual version of apt adds a header line for security updates are available.
I saw some different versions until now.

3 esm-infra security updates
10 standard security updates
or
1 standard security update

This line will be ignored if found.

Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
