### PR TITLE
kaspersky_av_client.vbs - support multiple locales

### DIFF
--- a/agents/windows/plugins/kaspersky_av_client.vbs
+++ b/agents/windows/plugins/kaspersky_av_client.vbs
@@ -9,6 +9,7 @@ Option Explicit
 Const CMK_VERSION = "2.1.0i1"
 dim strStatisticsLoc, strProtection_BasesDate, strProtection_LastFscan, strProtection_LastConnected
 dim strBIASLoc, strBIAS
+dim strLocaleID, strDelimiter
 dim objShell
 
 Set objShell = CreateObject("WScript.Shell")
@@ -19,8 +20,8 @@ End Function
 
 Function Kasp2Win(TimeStamp)
   dim strTimeStampRepl
-  strTimeStampRepl = Replace(TimeStamp, "-", ".", 1, 2)
-  Kasp2Win = Replace(strTimeStampRepl, "-", ":")
+  strTimeStampRepl = Replace(TimeStamp, "-", ":")
+  Kasp2Win = Replace(strTimeStampRepl, ":", strDelimiter, 1, 2)
 End Function
 
 strBIASLoc = "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\TimeZoneInformation\ActiveTimeBias"
@@ -36,6 +37,16 @@ strProtection_LastConnected = objShell.RegRead(strProtection_LastConnected)
 if err.number = 0 then
 	WScript.Echo("<<<kaspersky_av_client>>>")
 
+    'Retrieve the locale to define the correct date separator to avoid CDate errors
+    strLocaleID = GetLocale()
+    'Default delimiter (German)
+    strDelimiter = "."
+    select case strLocaleID
+        case "1043"
+            'Dutch
+            strDelimiter = "-"
+    end select
+    
 	'Protection_BasesDate key is set with old signatures from installer
 	strProtection_BasesDate = strStatisticsLoc & "Protection_BasesDate"
 	strProtection_BasesDate = objShell.RegRead(strProtection_BasesDate)


### PR DESCRIPTION
The script used a hardcoded "." as date separator. As a result, the script (CDate) failed on non-German locales. The proposed change uses the system locale to define the separator (by using a select case), with the current "."  as default. Currently I've only added LCID 1043 (Dutch), but this approach is extendable as long as the locale's date format is DD MM YYYY.

Old flow:
dd-mm-yyyy hh-mm-ss (from registry) --> dd.mm.yyyy hh-mm-ss --> dd.mm.yyyy hh:mm:ss

New flow:
dd-mm-yyyy hh-mm-ss (from registry) --> dd:mm:yyyy hh:mm:ss --> dd.mm.yyyy hh:mm:ss (default) / dd-mm-yyyy hh:mm:ss (Dutch locale)

Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
