### PR TITLE
fixes mem_used.py inventory plugin

### DIFF
--- a/cmk/base/plugins/agent_based/mem_used.py
+++ b/cmk/base/plugins/agent_based/mem_used.py
@@ -218,13 +218,15 @@ register.check_plugin(
 
 
 def inventory_mem_used(section: memory.SectionMemUsed) -> InventoryResult:
-    yield Attributes(
-        path=["hardware", "memory"],
-        inventory_attributes={
-            "total_ram_usable": section["MemTotal"],
-            "total_swap": section["SwapTotal"],
-        },
-    )
+    for key, value in [
+        ("total_ram_usable", section.get("MemTotal")),
+        ("total_swap", section.get("SwapTotal"))
+    ]:
+        if value:
+            yield Attributes(
+                path=["hardware", "memory"],
+                inventory_attributes={key: value}
+            )
 
 
 register.inventory_plugin(


### PR DESCRIPTION
The inventory plugin "mem_used.py" crashes with "KeyError: 'SwapTotal'"  in line 225
because "SwapTotal" is not always set in "hr_mem.py" -> "aggregate_meminfo".

This PR adds a check to the inventory function of "mem_used.py" to avoid this error.
