### PR TITLE
Fix get_ntpq not working on Slackware and other distros

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1236,6 +1236,11 @@ section_ntp() {
                     return
                 fi
             fi
+            # this is for systems that don't use initd or systemd, we can't check the service status but can check if the service exists in sbin
+            if [ -x /usr/sbin/"${_ntp_daemon}" ]; then
+                get_ntpq
+                return
+            fi
         done
         unset -v _ntp_daemon
     fi

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1236,8 +1236,9 @@ section_ntp() {
                     return
                 fi
             fi
-            # this is for systems that don't use initd or systemd, we can't check the service status but can check if the service exists in sbin
-            if [ -x /usr/sbin/"${_ntp_daemon}" ]; then
+
+            # For other systems such as Slackware
+            if [ -x "/etc/rc.d/rc.ntpd" ]; then
                 get_ntpq
                 return
             fi


### PR DESCRIPTION
Since Checkmk 2.0, get_ntpq isn't executed by the agent for systems that don't use systemd or init.d. This fixes it for the systems where ntp_daemon is located in /usr/sbin/.

Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
