### PR TITLE
Update mtr.py

### DIFF
--- a/agents/plugins/mtr.py
+++ b/agents/plugins/mtr.py
@@ -181,13 +181,15 @@ _punct_re = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.:]+')
 def host_to_filename(host, delim=u'-'):
     # Get rid of gibberish chars, stolen from Django
     """Generates an slightly worse ASCII-only slug."""
-    hostname = host.decode("utf8")
+    if not isinstance(host, (str, bytes)):
+        raise TypeError("not expecting type '%s'" % type(host))
+    hostname = ensure_str(host)
     result = []
     for word in _punct_re.split(hostname.lower()):
         word = ensure_str(normalize('NFKD', word))
         if word:
             result.append(word)
-    return delim.join(result).decode("utf8")
+    return delim.join(result)
 
 
 def check_mtr_pid(pid):


### PR DESCRIPTION
Phyton3 shows  AttributeError: 'str' object has no attribute 'decode'. Under python3 string is utf8 per default.

Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
