### PR TITLE
Ignore default version in omd cleanup.

### DIFF
--- a/omd/packages/omd/omdlib/main.py
+++ b/omd/packages/omd/omdlib/main.py
@@ -3097,7 +3097,7 @@ def main_cleanup(version_info: VersionInfo, site: SiteContext, global_opts: 'Glo
     if package_manager is None:
         bail_out("Command is not supported on this platform")
 
-    for version in omd_versions():
+    for version in [v for v in omd_versions() if not v == default_version()]:
         site_ids = [s for s in all_sites() if SiteContext(s).version == version]
         if site_ids:
             sys.stdout.write("%s%-20s%s In use (by %s). Keeping this version.\n" %


### PR DESCRIPTION
Reference: https://forum.checkmk.com/t/omd-cleanup-default-link/26726?u=amandahla

omd cleanup remove version even if is set as default without warning.

Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
