### PR TITLE
mtr check perfdata broken with too many entries

### DIFF
--- a/checks/mtr
+++ b/checks/mtr
@@ -142,10 +142,7 @@ def check_mtr(item, params, parsed):
 
     for idx in range(0, hc):
         state, text, perfdata = get_hop_info(hops, idx + 1, apply_levels=(idx + 1 == hc))
-        if state is None:
-            # This is perfdata from a hop, we do not yield it yet (looks ugly..)
-            hop_perfdata.extend(perfdata)
-        else:
+        if state is not None:
             # Last hop with state, text and perfdata. Yield everything we have
             yield 0, "Number of Hops: %d" % hc, hop_perfdata
             yield state, text + "\r\n%s" % format_hopnames(hopnames), perfdata


### PR DESCRIPTION
The mtr was outputting performance data for every hop and all the hops before. That means if you have 8 hops you have 7 times the performance data from hop 1, 6 times hop 2 and so on. The graph template then only crashes with an error message.
With this modification only the last hop outputs the complete data. This can be changed if the internal function "get_hop_info" don't append the performance data to the list "perfdata".

Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
