### PR TITLE
[bugfix] [agent] adds test for /var/qmail/bin/qmail-qstat

### DIFF
--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -454,7 +454,10 @@ run_purely_synchronous_sections() {
     fi
 
     # Check status of qmail mailqueue
-    if inpath qmail-qstat; then
+    if [ -x /var/qmail/bin/qmail-qstat ]; then
+       echo "<<<qmail_stats>>>"
+       /var/qmail/bin/qmail-qstat
+    elif inpath qmail-qstat; then
        echo "<<<qmail_stats>>>"
        qmail-qstat
     fi

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -889,7 +889,10 @@ section_mailqueue() {
     fi
 
     # Check status of qmail mailqueue
-    if inpath qmail-qstat; then
+    if [ -x /var/qmail/bin/qmail-qstat ]; then
+        echo "<<<qmail_stats>>>"
+        /var/qmail/bin/qmail-qstat
+    elif inpath qmail-qstat; then
         echo "<<<qmail_stats>>>"
         qmail-qstat
     fi

--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -666,7 +666,10 @@ section_postfix() {
 
 section_qmail() {
     # Check status of qmail mailqueue
-    if inpath qmail-qstat; then
+    if [ -x /var/qmail/bin/qmail-qstat ]; then
+        echo "<<<qmail_stats>>>"
+        /var/qmail/bin/qmail-qstat
+    elif inpath qmail-qstat; then
         echo "<<<qmail_stats>>>"
         qmail-qstat
     fi


### PR DESCRIPTION
Qmail is usually installed in /var/qmail, but /var/qmail/bin is not in PATH.

This patch tests for /var/qmail/bin/qmail-qstat and executes it before searching for qmail-qstat in $PATH.

Fixes https://forum.checkmk.com/t/qmail-queue-qmail-stats-not-working/25361