### PR TITLE
Preventing Crash of Oracle RMAN Archivelog Service

### DIFF
--- a/agents/plugins/mk_oracle
+++ b/agents/plugins/mk_oracle
@@ -1347,7 +1347,7 @@ sql_rman () {
                      || '|'|| to_char(sysdate, 'YYYY-mm-dd_HH24:MI:SS')
                      || '|'|| to_char(completed, 'YYYY-mm-dd_HH24:MI:SS')
                      || '|ARCHIVELOG||'
-                     || round((sysdate - completed)*24*60,0)
+                     || case WHEN (sysdate - completed) < 0 THEN 0 ELSE round((sysdate - completed)*24*60,0) END
                      || '|'
               from (
                     select upper(decode(${IGNORE_DB_NAME:-0}, 0, d.NAME, i.instance_name)) name
@@ -1415,7 +1415,7 @@ sql_rman () {
                      || '|'|| to_char(sysdate, 'YYYY-mm-dd_HH24:MI:SS')
                      || '|'|| to_char(completed, 'YYYY-mm-dd_HH24:MI:SS')
                      || '|ARCHIVELOG||'
-                     || round((sysdate - completed)*24*60,0)
+                     || case WHEN (sysdate - completed) < 0 THEN 0 ELSE round((sysdate - completed)*24*60,0) END
                      || '|'
               from (
                     select upper(decode(${IGNORE_DB_NAME:-0}, 0, d.NAME, i.instance_name)) name


### PR DESCRIPTION
We have some slow Oracle Databases where the "ORA <SID>.ARCHIVELOG RMAN Backup" will crash every time when the Archivelog backup is running due to a negative number.
Here is an example output where we can see that the backup was just run, the sysdate from oracle seems to be evaluated when the query starts and as result we have a negative number which will cause a crash of the service:

host1.local:MIDI|COMPLETED|2021-09-15_16:18:14|2021-09-15_16:19:12|ARCHIVELOG||-1|

This will result in a crash of the service:

![man crash](https://user-images.githubusercontent.com/71772009/133777382-928be222-6990-485a-a17a-356f640a734d.jpg)

The ntp settings on the server is fine, faster DBs on the same DB host don't have this issue.

The change will ensure that a 0 is returned when the calculation will give a negative number.