### PR TITLE
Preventing Crash of Oracle RMAN Archivelog Service

### DIFF
--- a/cmk/base/plugins/agent_based/oracle_rman.py
+++ b/cmk/base/plugins/agent_based/oracle_rman.py
@@ -105,6 +105,10 @@ def parse_oracle_rman(string_table: StringTable) -> SectionOracleRman:
         except (ValueError, TypeError):
             backupage = None
 
+        # sysdate can be old on slow databases with long running SQLs...
+        if backupage < 0:
+            backupage = 0
+            
         section.setdefault(
             item,
             {


### PR DESCRIPTION
We have some slow Oracle Databases where the "ORA .ARCHIVELOG RMAN Backup" will crash every time when the Archivelog backup is running due to a negative number.
Here is an example output where we can see that the backup was just run, the sysdate from oracle seems to be evaluated when the query starts and as result we have a negative number which will cause a crash of the service:

host1.local:MIDI|COMPLETED|2021-09-15_16:18:14|2021-09-15_16:19:12|ARCHIVELOG||-1|

This will result in a crash of the service:
![man crash](https://user-images.githubusercontent.com/71772009/134022997-14451861-113d-403a-86a0-98e011fb2ec9.jpg)

The ntp settings on the server are fine, faster DBs on the same DB host don't have this issue.

The change will ensure that we will have no crash in these case. 
Reporting 0 is better than reporting nothing, otherwhise we would have a stale service everytime when the Archivelog Backup is done.