### PR TITLE
Prevent crash of logwatch_ec in cluster setup

### DIFF
--- a/cmk/base/plugins/agent_based/logwatch_ec.py
+++ b/cmk/base/plugins/agent_based/logwatch_ec.py
@@ -210,11 +210,13 @@ def discover_logwatch_ec_common(
 def _filter_accumulated_lines(cluster_section: ClusterSection, item: str) -> Iterable[str]:
     # node info ignored (only used in regular logwatch check)
     for node_data in cluster_section.values():
-        for line in node_data.logfiles[item]["lines"]:
-            # skip context lines and ignore lines
-            # skip context lines, ignore lines and empty lines
-            if line[0] not in [".", "I"] and len(line) > 1:
-                yield line
+        if item in node_data.logfiles:
+            # in a cluster setup, it's possible that not all nodes always send every logfile
+            for line in node_data.logfiles[item]["lines"]:
+                # skip context lines and ignore lines
+                # skip context lines, ignore lines and empty lines
+                if line[0] not in [".", "I"] and len(line) > 1:
+                    yield line
 
 
 def check_logwatch_ec_common(


### PR DESCRIPTION
Not all nodes of a cluster always provide all logfiles, that should't lead to a crash, but did if logwatch event console forwarding was used with a separate service for each log file.

Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
