### PR TITLE
check_sftp: fixed validation for private-key arg

### DIFF
--- a/active_checks/check_sftp
+++ b/active_checks/check_sftp
@@ -21,7 +21,7 @@ OPTIONS:
   --host HOST            SFTP server address
   --user USER            Username for sftp login
   --secret SECRET        Secret/Password for sftp login
-  --private-key KEY      Path to private Key file for sftp login (Must be in openssh format!!)
+  --private-key KEY      Path to rsa private Key file for sftp login
   --port PORT            Alternative port number (default is 22 for the connection)
   --get-remote FILE      Path to the file which to pull from SFTP server (e.g.
                          /tmp/testfile.txt)

--- a/active_checks/check_sftp
+++ b/active_checks/check_sftp
@@ -18,20 +18,20 @@ def usage():
 USAGE: check_sftp [OPTIONS] HOST
 
 OPTIONS:
-  --host HOST            SFTP server address
-  --user USER            Username for sftp login
-  --secret SECRET        Secret/Password for sftp login
-  --private-key-file KEY      Path to rsa private Key file for sftp login
-  --port PORT            Alternative port number (default is 22 for the connection)
-  --get-remote FILE      Path to the file which to pull from SFTP server (e.g.
-                         /tmp/testfile.txt)
-  --get-local PATH       Path to store the pulled file locally (e.g. $OMD_ROOT/tmp/)
-  --put-local FILE       Path to the file to push to the sftp server. See above for example
-  --put-remote PATH      Path to save the pushed file (e.g. /tmp/)
-  --get-timestamp PATH   Path to the file for getting the timestamp of this file
-  --timeout SECONDS      Set timeout for connection (default is 10 seconds)
-  --verbose              Output some more detailed information
-  -h, --help             Show this help message and exit
+  --host HOST                SFTP server address
+  --user USER                Username for sftp login
+  --secret SECRET            Secret/Password for sftp login
+  --private-key-file PATH    Path to rsa private Key file for sftp login
+  --port PORT                Alternative port number (default is 22 for the connection)
+  --get-remote FILE          Path to the file which to pull from SFTP server (e.g.
+                             /tmp/testfile.txt)
+  --get-local PATH           Path to store the pulled file locally (e.g. $OMD_ROOT/tmp/)
+  --put-local FILE           Path to the file to push to the sftp server. See above for example
+  --put-remote PATH          Path to save the pushed file (e.g. /tmp/)
+  --get-timestamp PATH       Path to the file for getting the timestamp of this file
+  --timeout SECONDS          Set timeout for connection (default is 10 seconds)
+  --verbose                  Output some more detailed information
+  -h, --help                 Show this help message and exit
     """
     )
     sys.exit(1)

--- a/active_checks/check_sftp
+++ b/active_checks/check_sftp
@@ -46,7 +46,7 @@ def connection(opt_key, opt_host, opt_user, opt_pass, opt_port, opt_timeout):
         )
     else:
         client.connect(
-            opt_host, username=opt_user, pkey=opt_key, port=opt_port, timeout=opt_timeout
+            opt_host, username=opt_user, key_filename=opt_key, port=opt_port, timeout=opt_timeout
         )
     return client
 
@@ -164,7 +164,7 @@ def parse_arguments(sys_args):
         elif opt in ["--secret"]:
             opt_pass = arg
         elif opt in ["--private-key"]:
-            opt_pass = arg
+            opt_key = arg
         elif opt in ["--port"]:
             opt_port = int(arg)
         elif opt in ["--timeout"]:

--- a/active_checks/check_sftp
+++ b/active_checks/check_sftp
@@ -136,7 +136,7 @@ def parse_arguments(sys_args):
         "host=",
         "user=",
         "secret=",
-        "privat-key",
+        "private-key=",
         "port=",
         "get-remote=",
         "get-local=",

--- a/active_checks/check_sftp
+++ b/active_checks/check_sftp
@@ -21,7 +21,7 @@ OPTIONS:
   --host HOST            SFTP server address
   --user USER            Username for sftp login
   --secret SECRET        Secret/Password for sftp login
-  --private-key KEY      Private Key for sftp login
+  --private-key KEY      Path to private Key file for sftp login (Must be in openssh format!!)
   --port PORT            Alternative port number (default is 22 for the connection)
   --get-remote FILE      Path to the file which to pull from SFTP server (e.g.
                          /tmp/testfile.txt)

--- a/active_checks/check_sftp
+++ b/active_checks/check_sftp
@@ -21,7 +21,7 @@ OPTIONS:
   --host HOST            SFTP server address
   --user USER            Username for sftp login
   --secret SECRET        Secret/Password for sftp login
-  --private-key KEY      Path to rsa private Key file for sftp login
+  --private-key-file KEY      Path to rsa private Key file for sftp login
   --port PORT            Alternative port number (default is 22 for the connection)
   --get-remote FILE      Path to the file which to pull from SFTP server (e.g.
                          /tmp/testfile.txt)
@@ -136,7 +136,7 @@ def parse_arguments(sys_args):
         "host=",
         "user=",
         "secret=",
-        "private-key=",
+        "private-key-file=",
         "port=",
         "get-remote=",
         "get-local=",
@@ -163,7 +163,7 @@ def parse_arguments(sys_args):
             opt_user = arg
         elif opt in ["--secret"]:
             opt_pass = arg
-        elif opt in ["--private-key"]:
+        elif opt in ["--private-key-file"]:
             opt_key = arg
         elif opt in ["--port"]:
             opt_port = int(arg)


### PR DESCRIPTION
corrected argument name to expect to prevent the error: `option --private-key not recognized`