### PR TITLE
fix cannot change locale error

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -193,8 +193,8 @@ preamble_5() {
     unset -v LANG
     if inpath locale && inpath paste; then
         case "$(locale -a | paste -sd ' ' -)" in
-            *'[!A-Za-z]C.UTF-8'*) LC_ALL="C.UTF-8" ;;
-            *'[!A-Za-z]C.utf8'*) LC_ALL="C.utf8" ;;
+            *[!A-Za-z]'C.UTF-8'*) LC_ALL="C.UTF-8" ;;
+            *[!A-Za-z]'C.utf8'*) LC_ALL="C.utf8" ;;
         esac
         LC_ALL="${LC_ALL:-C}"
         export LC_ALL

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -192,9 +192,10 @@ set_up_profiling() {
 preamble_5() {
     unset -v LANG
     if inpath locale && inpath paste; then
-        case "$(locale -a | paste -sd ' ' -)" in
-            *[!A-Za-z]'C.UTF-8'*) LC_ALL="C.UTF-8" ;;
-            *[!A-Za-z]'C.utf8'*) LC_ALL="C.utf8" ;;
+	#     v keep this spaces in place, to catch if string is in first postion
+        case " $(locale -a | paste -sd ' ' -)" in
+            *' C.UTF-8'*) LC_ALL="C.UTF-8" ;;
+            *' C.utf8'*) LC_ALL="C.utf8" ;;
         esac
         LC_ALL="${LC_ALL:-C}"
         export LC_ALL

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -193,8 +193,8 @@ preamble_5() {
     unset -v LANG
     if inpath locale && inpath paste; then
         case "$(locale -a | paste -sd ' ' -)" in
-            *'C.UTF-8'*) LC_ALL="C.UTF-8" ;;
-            *'C.utf8'*) LC_ALL="C.utf8" ;;
+            *'[!A-Za-z]C.UTF-8'*) LC_ALL="C.UTF-8" ;;
+            *'[!A-Za-z]C.utf8'*) LC_ALL="C.utf8" ;;
         esac
         LC_ALL="${LC_ALL:-C}"
         export LC_ALL


### PR DESCRIPTION
This following error is created when es_EC.utf8 is an available locale and a
search for C.utf8 creates a hit and and unsupported locale is set.
This breaks for examle mailman and mysql on RHEL7.

Error message:
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (C.utf8): No such file or directory