### PR TITLE
busybox df does not support -x or -l

### DIFF
--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -265,13 +265,15 @@ section_df() {
     # These should generally be monitored on the NFS server, not on the clients.
 
     echo '<<<df>>>'
-    df -PTk | sed 1d
+    _df_excludefs="Type|smbfs|cifs|iso9660|udf|nfsv4|nfs|mvfs|zfs|prl_fs"
+    df -kPT | awk -v filter="${_df_excludefs}" '$2 !~ filter'
 
     # df inodes information
-    echo '<<<df>>>'
-    echo '[df_inodes_start]'
-    df -PTi | sed 1d
-    echo '[df_inodes_end]'
+    if df -i >/dev/null 2>&1; then
+        printf -- '%s\n' "<<<df>>>" "[df_inodes_start]"
+        df -PTi | awk -v filter="${_df_excludefs}" '$2 !~ filter'
+        printf -- '%s\n'  '[df_inodes_end]'
+    fi
 }
 
 section_zfsget() {

--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -263,16 +263,15 @@ section_df() {
     # settings, accessing those mounts from the agent would leave you with
     # thousands of agent processes and, ultimately, a dead monitored system.
     # These should generally be monitored on the NFS server, not on the clients.
-
     echo '<<<df>>>'
-    _df_excludefs="Type|smbfs|cifs|iso9660|udf|nfsv4|nfs|mvfs|zfs|prl_fs"
-    df -kPT | awk -v filter="${_df_excludefs}" '$2 !~ filter'
+    df -kPT
 
     # df inodes information
     if df -i >/dev/null 2>&1; then
-        printf -- '%s\n' "<<<df>>>" "[df_inodes_start]"
-        df -PTi | awk -v filter="${_df_excludefs}" '$2 !~ filter'
-        printf -- '%s\n'  '[df_inodes_end]'
+        echo '<<<df>>>'
+        echo '[df_inodes_start]'
+        df -PTi
+        echo '[df_inodes_end]'
     fi
 }
 

--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -265,15 +265,12 @@ section_df() {
     # These should generally be monitored on the NFS server, not on the clients.
 
     echo '<<<df>>>'
-    # The exclusion list is getting a bit of a problem. -l should hide any remote FS but seems
-    # to be all but working.
-    excludefs="-x smbfs -x cifs -x iso9660 -x udf -x nfsv4 -x nfs -x mvfs -x zfs -x prl_fs"
-    df -PTlk $excludefs | sed 1d
+    df -PTk | sed 1d
 
     # df inodes information
     echo '<<<df>>>'
     echo '[df_inodes_start]'
-    df -PTli $excludefs | sed 1d
+    df -PTi | sed 1d
     echo '[df_inodes_end]'
 }
 


### PR DESCRIPTION
The df part of the OpenWRT agent does nor work with busybox.
busybox does not support -x or -l. It works when both are removed.
 