### PR TITLE
Add MK_OSSTR var handling to nix agent scripts

### DIFF
--- a/agents/check_mk_agent.aix
+++ b/agents/check_mk_agent.aix
@@ -80,6 +80,43 @@ set_variable_defaults() {
     : "${MK_VARDIR:=/tmp/check_mk}"
     : "${MK_LOGDIR:=/var/log/check_mk}"
 
+    # Ensure that the MK_OSSTR environment variable is set.
+    # This imitates the 'OSTYPE' variable from bash
+    # We use this variable later on for OS specific behaviour
+    case $(uname -s) in
+        ("AIX")
+            MK_OSSTR=aix
+        ;;
+        ("Darwin")
+            MK_OSSTR=mac
+        ;;
+        ("FreeBSD")
+            MK_OSSTR=freebsd
+        ;;
+        ("HPUX")
+            MK_OSSTR=hpux
+        ;;
+        ("Linux"|"linux-gnu"|"GNU"*)
+            MK_OSSTR=linux
+            [ -e /etc/openwrt_release ] && MK_OSSTR=openwrt
+        ;;
+        ("NetBSD")
+            MK_OSSTR=netbsd
+        ;;
+        ("OpenBSD")
+            MK_OSSTR=openbsd
+        ;;
+        ("SunOS"|"solaris")
+            MK_OSSTR=solaris
+        ;;
+        (*)
+            printf -- '%s\n' "Unrecognized OS: $(uname -s)" >&2
+            exit 1
+        ;;
+    esac
+    readonly MK_OSSTR
+    export MK_OSSTR
+
     # some 'booleans'
     [ "${MK_RUN_SYNC_PARTS}" = "false" ] || MK_RUN_SYNC_PARTS=true
     [ "${MK_RUN_ASYNC_PARTS}" = "false" ] || MK_RUN_ASYNC_PARTS=true
@@ -794,7 +831,8 @@ run_partially_asynchronous_sections() {
 
 main_setup() {
     exec </dev/null 9>&2 2>/dev/null
-    set_up_process_commandline_arguments "$@" 
+    set_up_process_commandline_arguments "$@"
+    set_variable_defaults
     preamble_1
     preamble_2
     preamble_3

--- a/agents/check_mk_agent.freebsd
+++ b/agents/check_mk_agent.freebsd
@@ -94,6 +94,43 @@ set_variable_defaults() {
     : "${MK_LOGDIR:=/var/log/check_mk_agent}"
     : "${SPOOLDIR:=/var/spool/check_mk_agent}"
 
+    # Ensure that the MK_OSSTR environment variable is set.
+    # This imitates the 'OSTYPE' variable from bash
+    # We use this variable later on for OS specific behaviour
+    case $(uname -s) in
+        ("AIX")
+            MK_OSSTR=aix
+        ;;
+        ("Darwin")
+            MK_OSSTR=mac
+        ;;
+        ("FreeBSD")
+            MK_OSSTR=freebsd
+        ;;
+        ("HPUX")
+            MK_OSSTR=hpux
+        ;;
+        ("Linux"|"linux-gnu"|"GNU"*)
+            MK_OSSTR=linux
+            [ -e /etc/openwrt_release ] && MK_OSSTR=openwrt
+        ;;
+        ("NetBSD")
+            MK_OSSTR=netbsd
+        ;;
+        ("OpenBSD")
+            MK_OSSTR=openbsd
+        ;;
+        ("SunOS"|"solaris")
+            MK_OSSTR=solaris
+        ;;
+        (*)
+            printf -- '%s\n' "Unrecognized OS: $(uname -s)" >&2
+            exit 1
+        ;;
+    esac
+    readonly MK_OSSTR
+    export MK_OSSTR
+
     # some 'booleans'
     [ "${MK_RUN_SYNC_PARTS}" = "false" ] || MK_RUN_SYNC_PARTS=true
     [ "${MK_RUN_ASYNC_PARTS}" = "false" ] || MK_RUN_ASYNC_PARTS=true

--- a/agents/check_mk_agent.hpux
+++ b/agents/check_mk_agent.hpux
@@ -21,6 +21,43 @@ PLUGINSDIR=$MK_LIBDIR/plugins
 # refer to online documentation for details about local checks.
 LOCALDIR=$MK_LIBDIR/local
 
+# Ensure that the MK_OSSTR environment variable is set.
+# This imitates the 'OSTYPE' variable from bash
+# We use this variable later on for OS specific behaviour
+case $(uname -s) in
+    ("AIX")
+        MK_OSSTR=aix
+    ;;
+    ("Darwin")
+        MK_OSSTR=mac
+    ;;
+    ("FreeBSD")
+        MK_OSSTR=freebsd
+    ;;
+    ("HPUX")
+        MK_OSSTR=hpux
+    ;;
+    ("Linux"|"linux-gnu"|"GNU"*)
+        MK_OSSTR=linux
+        [ -e /etc/openwrt_release ] && MK_OSSTR=openwrt
+    ;;
+    ("NetBSD")
+        MK_OSSTR=netbsd
+    ;;
+    ("OpenBSD")
+        MK_OSSTR=openbsd
+    ;;
+    ("SunOS"|"solaris")
+        MK_OSSTR=solaris
+    ;;
+    (*)
+        printf -- '%s\n' "Unrecognized OS: $(uname -s)" >&2
+        exit 1
+    ;;
+esac
+readonly MK_OSSTR
+export MK_OSSTR
+
 # close standard input (for security reasons) and stderr
 if [ "$1" = -d ]; then
     set -xv

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -80,6 +80,43 @@ set_variable_defaults() {
     : "${MK_VARDIR:=/var/lib/check_mk_agent}"
     : "${MK_LOGDIR:=/var/log/check_mk_agent}"
 
+    # Ensure that the MK_OSSTR environment variable is set.
+    # This imitates the 'OSTYPE' variable from bash
+    # We use this variable later on for OS specific behaviour
+    case $(uname -s) in
+        ("AIX")
+            MK_OSSTR=aix
+        ;;
+        ("Darwin")
+            MK_OSSTR=mac
+        ;;
+        ("FreeBSD")
+            MK_OSSTR=freebsd
+        ;;
+        ("HPUX")
+            MK_OSSTR=hpux
+        ;;
+        ("Linux"|"linux-gnu"|"GNU"*)
+            MK_OSSTR=linux
+            [ -e /etc/openwrt_release ] && MK_OSSTR=openwrt
+        ;;
+        ("NetBSD")
+            MK_OSSTR=netbsd
+        ;;
+        ("OpenBSD")
+            MK_OSSTR=openbsd
+        ;;
+        ("SunOS"|"solaris")
+            MK_OSSTR=solaris
+        ;;
+        (*)
+            printf -- '%s\n' "Unrecognized OS: $(uname -s)" >&2
+            exit 1
+        ;;
+    esac
+    readonly MK_OSSTR
+    export MK_OSSTR
+
     # some 'booleans'
     [ "${MK_RUN_SYNC_PARTS}" = "false" ] || MK_RUN_SYNC_PARTS=true
     [ "${MK_RUN_ASYNC_PARTS}" = "false" ] || MK_RUN_ASYNC_PARTS=true

--- a/agents/check_mk_agent.macosx
+++ b/agents/check_mk_agent.macosx
@@ -16,6 +16,43 @@ export MK_CONFDIR="/to/be/changed"
 # Optionally set a tempdir for all subsequent calls
 #export TMPDIR=
 
+# Ensure that the MK_OSSTR environment variable is set.
+# This imitates the 'OSTYPE' variable from bash
+# We use this variable later on for OS specific behaviour
+case $(uname -s) in
+    ("AIX")
+        MK_OSSTR=aix
+    ;;
+    ("Darwin")
+        MK_OSSTR=mac
+    ;;
+    ("FreeBSD")
+        MK_OSSTR=freebsd
+    ;;
+    ("HPUX")
+        MK_OSSTR=hpux
+    ;;
+    ("Linux"|"linux-gnu"|"GNU"*)
+        MK_OSSTR=linux
+        [ -e /etc/openwrt_release ] && MK_OSSTR=openwrt
+    ;;
+    ("NetBSD")
+        MK_OSSTR=netbsd
+    ;;
+    ("OpenBSD")
+        MK_OSSTR=openbsd
+    ;;
+    ("SunOS"|"solaris")
+        MK_OSSTR=solaris
+    ;;
+    (*)
+        printf -- '%s\n' "Unrecognized OS: $(uname -s)" >&2
+        exit 1
+    ;;
+esac
+readonly MK_OSSTR
+export MK_OSSTR
+
 # close standard input (for security reasons) and stderr
 if [ "$1" = -d ]; then
     set -xv

--- a/agents/check_mk_agent.netbsd
+++ b/agents/check_mk_agent.netbsd
@@ -32,6 +32,42 @@ PLUGINSDIR=$MK_LIBDIR/plugins
 # to online documentation for details.
 LOCALDIR=$MK_LIBDIR/local
 
+# Ensure that the MK_OSSTR environment variable is set.
+# This imitates the 'OSTYPE' variable from bash
+# We use this variable later on for OS specific behaviour
+case $(uname -s) in
+    ("AIX")
+        MK_OSSTR=aix
+    ;;
+    ("Darwin")
+        MK_OSSTR=mac
+    ;;
+    ("FreeBSD")
+        MK_OSSTR=freebsd
+    ;;
+    ("HPUX")
+        MK_OSSTR=hpux
+    ;;
+    ("Linux"|"linux-gnu"|"GNU"*)
+        MK_OSSTR=linux
+        [ -e /etc/openwrt_release ] && MK_OSSTR=openwrt
+    ;;
+    ("NetBSD")
+        MK_OSSTR=netbsd
+    ;;
+    ("OpenBSD")
+        MK_OSSTR=openbsd
+    ;;
+    ("SunOS"|"solaris")
+        MK_OSSTR=solaris
+    ;;
+    (*)
+        printf -- '%s\n' "Unrecognized OS: $(uname -s)" >&2
+        exit 1
+    ;;
+esac
+readonly MK_OSSTR
+export MK_OSSTR
 
 # close standard input (for security reasons) and stderr
 if [ "$1" = -d ]; then

--- a/agents/check_mk_agent.openbsd
+++ b/agents/check_mk_agent.openbsd
@@ -32,6 +32,42 @@ PLUGINSDIR=$MK_LIBDIR/plugins
 # to online documentation for details.
 LOCALDIR=$MK_LIBDIR/local
 
+# Ensure that the MK_OSSTR environment variable is set.
+# This imitates the 'OSTYPE' variable from bash
+# We use this variable later on for OS specific behaviour
+case $(uname -s) in
+    ("AIX")
+        MK_OSSTR=aix
+    ;;
+    ("Darwin")
+        MK_OSSTR=mac
+    ;;
+    ("FreeBSD")
+        MK_OSSTR=freebsd
+    ;;
+    ("HPUX")
+        MK_OSSTR=hpux
+    ;;
+    ("Linux"|"linux-gnu"|"GNU"*)
+        MK_OSSTR=linux
+        [ -e /etc/openwrt_release ] && MK_OSSTR=openwrt
+    ;;
+    ("NetBSD")
+        MK_OSSTR=netbsd
+    ;;
+    ("OpenBSD")
+        MK_OSSTR=openbsd
+    ;;
+    ("SunOS"|"solaris")
+        MK_OSSTR=solaris
+    ;;
+    (*)
+        printf -- '%s\n' "Unrecognized OS: $(uname -s)" >&2
+        exit 1
+    ;;
+esac
+readonly MK_OSSTR
+export MK_OSSTR
 
 # close standard input (for security reasons) and stderr
 if [ "$1" = -d ]; then

--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -80,6 +80,43 @@ set_variable_defaults() {
     : "${MK_VARDIR:=/var/lib/check_mk_agent}"
     : "${MK_LOGDIR:=/var/log/check_mk_agent}"
 
+    # Ensure that the MK_OSSTR environment variable is set.
+    # This imitates the 'OSTYPE' variable from bash
+    # We use this variable later on for OS specific behaviour
+    case $(uname -s) in
+        ("AIX")
+            MK_OSSTR=aix
+        ;;
+        ("Darwin")
+            MK_OSSTR=mac
+        ;;
+        ("FreeBSD")
+            MK_OSSTR=freebsd
+        ;;
+        ("HPUX")
+            MK_OSSTR=hpux
+        ;;
+        ("Linux"|"linux-gnu"|"GNU"*)
+            MK_OSSTR=linux
+            [ -e /etc/openwrt_release ] && MK_OSSTR=openwrt
+        ;;
+        ("NetBSD")
+            MK_OSSTR=netbsd
+        ;;
+        ("OpenBSD")
+            MK_OSSTR=openbsd
+        ;;
+        ("SunOS"|"solaris")
+            MK_OSSTR=solaris
+        ;;
+        (*)
+            printf -- '%s\n' "Unrecognized OS: $(uname -s)" >&2
+            exit 1
+        ;;
+    esac
+    readonly MK_OSSTR
+    export MK_OSSTR
+
     # some 'booleans'
     [ "${MK_RUN_SYNC_PARTS}" = "false" ] || MK_RUN_SYNC_PARTS=true
     [ "${MK_RUN_ASYNC_PARTS}" = "false" ] || MK_RUN_ASYNC_PARTS=true

--- a/agents/check_mk_agent.solaris
+++ b/agents/check_mk_agent.solaris
@@ -80,6 +80,43 @@ set_variable_defaults() {
     : "${MK_VARDIR:=/var/lib/check_mk_agent}"
     : "${MK_LOGDIR:=/var/log/check_mk_agent}"
 
+    # Ensure that the MK_OSSTR environment variable is set.
+    # This imitates the 'OSTYPE' variable from bash
+    # We use this variable later on for OS specific behaviour
+    case $(uname -s) in
+        ("AIX")
+            MK_OSSTR=aix
+        ;;
+        ("Darwin")
+            MK_OSSTR=mac
+        ;;
+        ("FreeBSD")
+            MK_OSSTR=freebsd
+        ;;
+        ("HPUX")
+            MK_OSSTR=hpux
+        ;;
+        ("Linux"|"linux-gnu"|"GNU"*)
+            MK_OSSTR=linux
+            [ -e /etc/openwrt_release ] && MK_OSSTR=openwrt
+        ;;
+        ("NetBSD")
+            MK_OSSTR=netbsd
+        ;;
+        ("OpenBSD")
+            MK_OSSTR=openbsd
+        ;;
+        ("SunOS"|"solaris")
+            MK_OSSTR=solaris
+        ;;
+        (*)
+            printf -- '%s\n' "Unrecognized OS: $(uname -s)" >&2
+            exit 1
+        ;;
+    esac
+    readonly MK_OSSTR
+    export MK_OSSTR
+
     # some 'booleans'
     [ "${MK_RUN_SYNC_PARTS}" = "false" ] || MK_RUN_SYNC_PARTS=true
     [ "${MK_RUN_ASYNC_PARTS}" = "false" ] || MK_RUN_ASYNC_PARTS=true


### PR DESCRIPTION
Hi,
this PR adds a new env var (or constant, really) `MK_OSSTR` to all *nix agent scripts.  This is a simple foundational step towards converging the *nix scripts together.

**MK_OSSTR**
Rationale: In order to get the same or similar information from different *nix variants, different tools sometimes need to be used, or the same tool but with different args (see: e.g. `df`).  This variable makes it easy to select the appropriate behaviour when such a selection is required e.g.
 
```
case "${MK_OSSTR}" in
    (aix)     some_aix_tool -with -aix -specific -args ;;
    (linux)   generic_tool --linux --args ;;
    (freebsd) generic_tool -f -r -e -e -b -s -d -a -r -g -s ;;
    (solaris) die_oracle_die | grep something | sed 's/silly baroque/solaris/g' ;;
esac
```

This var can also be integrated into section headers e.g. `<<<ps:${MK_OSSTR}>>>` or into JSON output whenever that journey finally gets underway, if ever.

This var allows the agent information block (usually within `section_checkmk()`) to be standardised i.e. `echo "AgentOS: ${MK_OSSTR}"`

This is not the only method to figure out the best way to glean information from different OSes and in some cases may actually be a naïve approach.  Regardless, this variable is still an important enabler for converging the agent scripts together.

Bug fix required?  The AIX agent defines `set_variable_defaults()` but never calls it.  This PR fixes that. :)

Cheers

Rawiri