### PR TITLE
cisco_ip_sla: Fixed detection of some cisco models

### DIFF
--- a/checks/cisco_ip_sla
+++ b/checks/cisco_ip_sla
@@ -162,18 +162,19 @@ def check_cisco_ip_sla(_item, params, data):
         yield state, infotext, perfdata
 
 
-check_info["cisco_ip_sla"] = {
-    "parse_function": parse_cisco_ip_sla,
-    "inventory_function": inventory_cisco_ip_sla,
-    "check_function": check_cisco_ip_sla,
-    "service_description": "Cisco IP SLA %s",
-    "group": "cisco_ip_sla",
-    "default_levels_variable": "cisco_ip_sla_default_levels",
-    "has_perfdata": True,
-    "snmp_scan_function": lambda oid: oid(".1.3.6.1.2.1.1.2.0")
-    in [
-        ".1.3.6.1.4.1.9.1.2068",
-        ".1.3.6.1.4.1.9.1.1858",
+check_info['cisco_ip_sla'] = {
+    'parse_function': parse_cisco_ip_sla,
+    'inventory_function': inventory_cisco_ip_sla,
+    'check_function': check_cisco_ip_sla,
+    'service_description': 'Cisco IP SLA %s',
+    'group': 'cisco_ip_sla',
+    'default_levels_variable': 'cisco_ip_sla_default_levels',
+    'has_perfdata': True,
+    'snmp_scan_function': lambda oid: oid('.1.3.6.1.2.1.1.2.0') in [
+        '.1.3.6.1.4.1.9.1.2068',
+        '.1.3.6.1.4.1.9.1.1858',
+        '.1.3.6.1.4.1.9.1.1861',
+        '.1.3.6.1.4.1.9.1.2348',
     ],
     "snmp_info": [
         (

--- a/checks/cisco_ip_sla
+++ b/checks/cisco_ip_sla
@@ -170,12 +170,9 @@ check_info['cisco_ip_sla'] = {
     'group': 'cisco_ip_sla',
     'default_levels_variable': 'cisco_ip_sla_default_levels',
     'has_perfdata': True,
-    'snmp_scan_function': lambda oid: oid('.1.3.6.1.2.1.1.2.0') in [
-        '.1.3.6.1.4.1.9.1.2068',
-        '.1.3.6.1.4.1.9.1.1858',
-        '.1.3.6.1.4.1.9.1.1861',
-        '.1.3.6.1.4.1.9.1.2348',
-    ],
+    "snmp_scan_function": lambda oid: "cisco" in oid(".1.3.6.1.2.1.1.1.0").lower()
+                                      and "ios" in oid(".1.3.6.1.2.1.1.1.0").lower()
+                                      and oid(".1.3.6.1.4.1.9.9.42.1.2.2.1.37.*"),
     "snmp_info": [
         (
             ".1.3.6.1.4.1.9.9.42.1.2.2.1",


### PR DESCRIPTION
With this fix, the following Models will be supported:
 - Cisco ASR1001-X
 - Cisco ASR1001-HX