### PR TITLE
mk_oracle.ps1 use Oracle config in $MK_CONFDIR

### DIFF
--- a/agents/windows/plugins/mk_oracle.ps1
+++ b/agents/windows/plugins/mk_oracle.ps1
@@ -146,7 +146,11 @@ else {
      debug_echo "${CONFIG_FILE} not found"
 }
 
-
+# If sqlnet.ora or tnsnames.ora exist in MK_CONFDIR set it as %TNS_ADMIN%
+if ((test-path -path "${MK_CONFDIR}\sqlnet.ora") -or (test-path -path "${MK_CONFDIR}\tnsnames.ora")) {
+     $env:TNS_ADMIN = "${MK_CONFDIR}"
+}
+debug_echo "value of TNS_ADMIN = $env:TNS_ADMIN"
 
 if ($ORACLE_HOME) {
      # if the ORACLE_HOME is set in the config file then we
@@ -589,7 +593,7 @@ Function sql_performance {
                ||'|'|| b.pinhits
                ||'|'|| b.reloads
                ||'|'|| b.invalidations
-          from v$instance i, v$librarycache b;"
+          from v$instance i, v$librarycache b;
 
 '@
           echo $query_performance


### PR DESCRIPTION
The Windows Oracle Agent doesn't use the paths documented (https://docs.checkmk.com/latest/en/monitoring_oracle.html#_windows_4) like the Oracle Linux Agent.
The Windows Agent uses "%ORACLE_HOME%\network\admin". With the change it uses MK_CONFDIR, if Oracle config files exist.