### PR TITLE
Fixing epoch service discovery

### DIFF
--- a/checks/ceph_status
+++ b/checks/ceph_status
@@ -252,7 +252,7 @@ factory_settings["ceph_mgrs_default_levels"] = {
 
 
 def inventory_ceph_status_mgrs(parsed):
-    if "mgrmap" in parsed:
+    if "epoch" in parsed.get("mgrmap", {})
         return [(None, {})]
 
 


### PR DESCRIPTION
Ceph 16.2.6 does not provide the `{"mgrmap": {"epoch": ...}}` value any more. See below for excerpt of `ceph -s -f json-pretty`.

```json
{
    "mgrmap": {
        "available": true,
        "num_standbys": 1,
        "modules": [
            "cephadm",
            "dashboard",
            "iostat",
            "nfs",
            "prometheus",
            "restful"
        ],
        "services": {
            "dashboard": "https://172.16.32.11:8443/",
            "prometheus": "http://172.16.32.11:9283/"
        }
    }
}
```

Thank you for your interest in contributing to Checkmk! Unfortunately, due to our current work load,
we can at the moment only consider pure bugfixes, as stated in our
[Readme](https://github.com/tribe29/checkmk#want-to-contribute). Thus, any new pull request which
is not a pure bugfix will be closed. Instead of creating a PR, please consider sharing new check
plugins, agent plugins, special agents or notification plugins via the
[Checkmk Exchange](https://exchange.checkmk.com/).
