### PR TITLE
[kemp_loadmaster_realserver] changes item

### DIFF
--- a/checkman/kemp_loadmaster_realserver
+++ b/checkman/kemp_loadmaster_realserver
@@ -9,8 +9,8 @@ description:
  is 'out of service' or 'failed' the check's result will be CRIT.
 
 item:
- IP address of the realserver
+ Name of the virtual service and IP address of the realserver
 
 discovery:
  One service is created for each backend server if it is not disabled.
- Each one is defined by its ID.
+ Each one is defined by the name of its virtual service and IP address.

--- a/checks/kemp_loadmaster_realserver
+++ b/checks/kemp_loadmaster_realserver
@@ -4,48 +4,77 @@
 # This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
 # conditions defined in the file COPYING, which is part of this source code package.
 
-# example for contents of info:
-#   IP address     id  state
-# ['10.20.30.101', '1', '1'],
-# ['10.20.30.102', '2', '1'],
-# ['10.20.30.101', '3', '1'],
-# ['10.20.30.102', '4', '1'],
-# ['10.20.30.101', '5', '1'],
-# ['10.20.30.102', '6', '1']
-
-
-def inventory_kemp_loadmaster_realserver(info):
-    for line in info:
-        if line[2] not in ["4", ""]:  # Skip disabled servers
-            yield line[0], None
-
-
-def check_kemp_loadmaster_realserver(item, _no_params, info):
-    states = {
-        "1": (0, "in service"),
-        "2": (2, "out of service"),
-        "3": (2, "failed"),
-        "4": (2, "disabled"),
+def parse_kemp_loadmaster_realserver(info):
+    vs_states = {
+        "1": (0, 'in service'),
+        "2": (2, 'out of service'),
+        "3": (2, 'failed'),
+        "4": (1, 'disabled'),
+        "5": (1, 'sorry'),
+        "6": (0, 'redirect'),
+        "7": (2, 'error message'),
     }
 
-    for ipaddress, _server_id, state_id in info:
-        if item == ipaddress:
-            state, state_name = states[state_id]
-            return state, "State: %s" % state_name
+    rs_states = {
+        '1': (0, 'in service'),
+        '2': (2, 'out of service'),
+        '3': (2, 'failed'),
+        '4': (1, 'disabled'),
+    }
 
+        
+    section = {}
+
+    for vs in info[1]:
+        section[vs[0]] = {
+            'name': vs[1],
+            'state': vs_states.get(vs[2], (3, 'unknown state %s' % vs[2])),
+            'rs': [],
+        }
+
+    for rs in info[0]:
+        section[rs[1]]['rs'].append((rs[0], rs_states.get(rs[2], (3, 'unknown state %s' % rs[2]))))
+
+    return section
+
+def inventory_kemp_loadmaster_realserver(section):
+    for vsid, vsdata in section.items():
+        if vsdata['state'][1] not in ['disabled']:
+            for rsip, (state, state_name) in vsdata['rs']:
+                if state_name not in ['disabled']:
+                    yield '%s %s' % (vsdata['name'], rsip), None
+
+def check_kemp_loadmaster_realserver(item, _no_params, section):
+    comps = item.split()
+    vsname = " ".join(comps[:-1])
+    ip = comps[-1]
+    for vsid, vsdata in section.items():
+        if vsdata['name'] == vsname:
+            for rsip, (state, state_name) in vsdata['rs']:
+                if rsip == ip:
+                    yield state, "State: %s" % state_name
 
 check_info["kemp_loadmaster_realserver"] = {
+    "parse_function": parse_kemp_loadmaster_realserver,
     "inventory_function": inventory_kemp_loadmaster_realserver,
     "check_function": check_kemp_loadmaster_realserver,
     "service_description": "Real Server %s",
-    "snmp_info": (
+    "snmp_info": [(
         ".1.3.6.1.4.1.12196.13.2.1",
         [
             2,  # IP address: B100-MIB::rSip
-            5,  # ID: B100-MIB::rSidx
+            1,  # ID of virtual Service
             8,  # state: B100-MIB::rSstate
-        ],
-    ),
-    "snmp_scan_function": lambda oid: oid(".1.3.6.1.2.1.1.2.0")
-    in [".1.3.6.1.4.1.12196.250.10", ".1.3.6.1.4.1.2021.250.10"],
+        ]),
+                  (
+        ".1.3.6.1.4.1.12196.13.1.1",
+        [
+            OID_END,
+            13, # B100-MIB::vSname
+            14, # B100-MIB::vSstate
+        ]),
+    ],
+
+    "snmp_scan_function": lambda oid: oid(".1.3.6.1.2.1.1.2.0") in
+                          [".1.3.6.1.4.1.12196.250.10", ".1.3.6.1.4.1.2021.250.10"],
 }


### PR DESCRIPTION
The real servers of a Kemp load balancer are defined for each virtual
service separately. The old check did not honor this and created just
one service for each real server IP address.
