### PR TITLE
Update pyghmi dependency to 1.5.30

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -93,7 +93,7 @@ chardet = "==4.0.0"  # needed by requests
 urllib3 = "==1.26.5"  # needed by requests
 pyOpenSSL = "==19.1.0"  # needed by requests with extras = ["security"]
 pbr = "==5.4.4"  # needed by jira
-pyghmi = "==1.5.13"  # needed by base for IPMI
+pyghmi = "==1.5.30"  # needed by base for IPMI
 requests = {version = "==2.25.1",extras = ["security"]}  # needed by DCD, connexion
 pykerberos = "==1.2.1"  # needed by check_bi_aggr
 requests-kerberos = "==0.12.0"  # needed by check_bi_aggr

--- a/cmk/core_helpers/ipmi.py
+++ b/cmk/core_helpers/ipmi.py
@@ -172,7 +172,7 @@ class IPMIFetcher(AgentFetcher):
             if "error" in rsp:
                 continue
 
-            reading = sensor.decode_sensor_reading(rsp["data"])
+            reading = sensor.decode_sensor_reading(self._command, rsp["data"])
             if reading is not None:
                 # sometimes (wrong) data for GPU sensors is reported, even if
                 # not installed


### PR DESCRIPTION
This version fixes a [bug][1] that caused a TypeError to be raised during monitoring of some management boards.

Tested briefly in our CRE instance with a couple of HP and Dell servers monitored via IPMI.

[1]: https://review.opendev.org/c/x/pyghmi/+/819139