### PR TITLE
replace_macros_in_str: repeat replacement for nested macros

### DIFF
--- a/cmk/utils/macros.py
+++ b/cmk/utils/macros.py
@@ -5,6 +5,7 @@
 # conditions defined in the file COPYING, which is part of this source code package.
 
 from typing import MutableMapping
+import re
 
 MacroMapping = MutableMapping[str, str]
 
@@ -16,6 +17,8 @@ def replace_macros_in_str(string: str, macro_mapping: MacroMapping) -> str:
     >>> replace_macros_in_str("abc $MACRO$ 123", {"$MACRO2$": "replacement2"})
     'abc $MACRO$ 123'
     """
+    for macro, replacement in macro_mapping.items():
+        string = string.replace(macro, replacement)
     for macro, replacement in macro_mapping.items():
         string = string.replace(macro, replacement)
     return string

--- a/cmk/utils/macros.py
+++ b/cmk/utils/macros.py
@@ -5,7 +5,6 @@
 # conditions defined in the file COPYING, which is part of this source code package.
 
 from typing import MutableMapping
-import re
 
 MacroMapping = MutableMapping[str, str]
 


### PR DESCRIPTION
In notification mails, it can happen that e.g. $SERVICECHECKCOMMAND$ contains other template parameters, e.g. $HOSTNAME$ as a parameter to the external command.

Without this change, that nested parameter would not be shown in notification mails.