### PR TITLE
[parse_freeipmi] adds values when line has 7 elements

### DIFF
--- a/cmk/base/check_legacy_includes/ipmi_sensors.py
+++ b/cmk/base/check_legacy_includes/ipmi_sensors.py
@@ -158,6 +158,10 @@ def parse_freeipmi(info):
             _sid, _name, _sensortype, reading_str, unit = stripped_line[:-1]
             add_valid_values([("value", reading_str, float), ("unit", unit, str)])
 
+        elif len(stripped_line) == 7:
+            _sid, _name, _sensortype, _sensorstatus, reading_str, unit = stripped_line[:-1]
+            add_valid_values([("value", reading_str, float), ("unit", unit, str)])
+
         elif len(stripped_line) == 13:
             (
                 _sid,


### PR DESCRIPTION
we see IPMI devices with 7 elements when --output-sensor-thresholds is
not on.

This small fix adds the value in this case. Otherwise the temperature is not recorded as a metric.

[agent_data.txt](https://github.com/tribe29/checkmk/files/7756456/agent_data.txt)
