### PR TITLE
Improve when mk_zypper is run

### DIFF
--- a/agents/plugins/mk_zypper
+++ b/agents/plugins/mk_zypper
@@ -9,11 +9,13 @@
 
 # Disable unused variable error (needed to keep track of version)
 # shellcheck disable=SC2034
-CMK_VERSION="2.1.0i1"
+CMK_VERSION="2.0.0p17"
 
 #SuSE-release is deprecated and was removed with SLE 15. os-release should be used for the new versions.
 
 RELEASEFILE="/etc/SuSE-release"
+STATEFILE="/var/lib/check_mk_agent/zypper.state"
+SPOOLFILE="/var/lib/check_mk_agent/spool/90000_mk_zypper"
 
 if [ -f "/etc/os-release" ]
     then
@@ -21,27 +23,44 @@ if [ -f "/etc/os-release" ]
 fi
 
 if type zypper > /dev/null ; then
-    echo '<<<zypper:sep(124)>>>'
+    LASTUPDATE=$(grep -v '^#' /var/log/zypp/history | tail -1 | awk 'BEGIN {FS="|"};{print $1}' | xargs -i date -d "{}" +%s)
+    NOW=$(date +%s)
+
+    if [ -f $STATEFILE ]
+    then
+        STATE=$(cat $STATEFILE)
+		
+        if (( $LASTUPDATE < $STATE && $NOW-$STATE < 86400 ))
+        then
+			# it has been less than 24 hours AND there has been no system update since last time we checked
+            exit
+        fi
+    fi
+	
+    echo '<<<zypper:sep(124)>>>' > "$SPOOLFILE"
+
     if egrep -q 'VERSION = 10|VERSION_ID="10' < $RELEASEFILE
     then
         ZYPPER='waitmax 50 zypper --no-gpg-checks --non-interactive --terse'
         REFRESH=`$ZYPPER refresh 2>&1`
         if  [ "$REFRESH" ]
         then
-	    echo "ERROR: $REFRESH"
+            echo "ERROR: $REFRESH" >> "$SPOOLFILE"
         else
             { $ZYPPER pchk || [ $? = 100 -o $? = 101 ] && $ZYPPER lu ; } \
-    	      | egrep '(patches needed|\|)' | egrep -v '^(#|Repository |Catalog )'
+              | egrep '(patches needed|\|)' | egrep -v '^(#|Repository |Catalog )' >> "$SPOOLFILE"
         fi
     else
         ZYPPER='waitmax 50 zypper --no-gpg-checks --non-interactive --quiet'
         REFRESH=`$ZYPPER refresh 2>&1`
         if  [ "$REFRESH" ]
         then
-            echo "ERROR: $REFRESH"
+            echo "ERROR: $REFRESH" >> "$SPOOLFILE"
         else
             { { $ZYPPER pchk || [ $? = 100 -o $? = 101 ] && $ZYPPER lp ; } ; $ZYPPER ll ; } \
-    	      | egrep '(patches needed|\|)' | egrep -v '^(#|Repository)'
+              | egrep '(patches needed|\|)' | egrep -v '^(#|Repository)' >> "$SPOOLFILE"
         fi
     fi
+
+	date +%s > "$STATEFILE"
 fi


### PR DESCRIPTION
mk_zypper takes a long time to run, so most people will set it up to run asynchronously every X hour. The problem with this is the alert stays in cache until the plugin is executed again, which can take a long time. Instead of this, it would be better to detect whether there has been any update on the system (with /var/log/zypp/history) and to then run the check again. If there has been no change, we still want to check at least once a day if there is anything new. There are probably better ways to implement this (I'm using a cache file and a spool file) but this is working fine on OpenSUSE Leap 15.3.

Thank you for your interest in contributing to Checkmk!
Unfortunately, due to our current work load, we only consider pure bug fixes as stated in our [Readme](https://github.com/tribe29/checkmk#want-to-contribute).
This means any new pull request that is not a pure bug fix will be closed.
Instead of creating a PR, please consider sharing new check plugins, agent plugins, special agents or notification plugins via the [Checkmk Exchange](https://exchange.checkmk.com/).

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
