### PR TITLE
Fix fs_size graph unit for lvm_vgs 

### DIFF
--- a/cmk/gui/plugins/metrics/translation.py
+++ b/cmk/gui/plugins/metrics/translation.py
@@ -770,6 +770,7 @@ check_metrics["check_mk-fjdarye200_pools"] = df_translation
 check_metrics["check_mk-dell_compellent_folder"] = df_translation
 check_metrics["check_mk-nimble_volumes"] = df_translation
 check_metrics["check_mk-ceph_df"] = df_translation
+check_metrics["check_mk-lvm_vgs"] = df_translation
 
 check_metrics["check_mk-netapp_api_volumes"] = {
     "fs_used": {


### PR DESCRIPTION
This commit fixes the unit displayed in the fs_size graph metric for the lvm_vgs check by adding the missing translation.

