### PR TITLE
Fix bad interaction between chrony and systemd-timesyncd

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1300,7 +1300,7 @@ section_timesyncd() {
     systemctl is-enabled systemd-timesyncd.service >/dev/null 2>&1 || return 1
     # debian 10.8 uses ConditionFileIsExecutable to "disable" systemd-timedatectl when ntp is installed.
     # The service is still enabled, but does not start timesyncd as the condition is not met.
-    (inpath ntpd || inpath openntpd) && return 1 # we check the same condition as the systemd condition
+    (inpath ntpd || inpath openntpd || inpath chronyd || inpath VBoxService) && return 1 # we check the same condition as the systemd condition
     timedatectl timesync-status >/dev/null 2>&1 || return 1
 
     ${MK_RUN_SYNC_PARTS} || return 0


### PR DESCRIPTION
Actually calling `timedatectl timesync-status` otherwise leads to the chronyd service being stopped...

The real systemd condition list can be seen here:
https://sources.debian.org/src/systemd/241-7%7Edeb10u8/debian/extra/units/systemd-timesyncd.service.d/disable-with-time-daemon.conf/