### PR TITLE
REST API: Fix showing single downtimes on read-only sites

### DIFF
--- a/cmk/gui/plugins/openapi/endpoints/downtime.py
+++ b/cmk/gui/plugins/openapi/endpoints/downtime.py
@@ -283,6 +283,7 @@ def show_downtimes(param):
     constructors.object_href("downtime", "{downtime_id}"),
     "cmk/show",
     method="get",
+    tag_group="Monitoring",
     path_params=[
         {
             "downtime_id": fields.Integer(

--- a/tests/unit/cmk/gui/plugins/openapi/test_openapi_downtime.py
+++ b/tests/unit/cmk/gui/plugins/openapi/test_openapi_downtime.py
@@ -892,9 +892,9 @@ def test_openapi_downtime_non_existing_groups(aut_user_auth_wsgi_app: WebTestApp
 
 
 @pytest.mark.usefixtures("suppress_remote_automation_calls")
+@pytest.mark.parametrize("wato_enabled", [True, False])
 def test_openapi_downtime_get_single(
-    aut_user_auth_wsgi_app: WebTestAppForCMK,
-    mock_livestatus,
+    aut_user_auth_wsgi_app: WebTestAppForCMK, mock_livestatus, wato_enabled: bool
 ):
     live: MockLiveStatusConnection = mock_livestatus
 
@@ -937,13 +937,14 @@ def test_openapi_downtime_get_single(
     )
 
     with live:
-        resp = aut_user_auth_wsgi_app.call_method(
-            "get",
-            base + "/objects/downtime/123",
-            headers={"Accept": "application/json"},
-            status=200,
-        )
-        assert resp.json_body["title"] == "Downtime for service: CPU load"
+        with aut_user_auth_wsgi_app.set_config(wato_enabled=wato_enabled):
+            resp = aut_user_auth_wsgi_app.call_method(
+                "get",
+                base + "/objects/downtime/123",
+                headers={"Accept": "application/json"},
+                status=200,
+            )
+            assert resp.json_body["title"] == "Downtime for service: CPU load"
 
 
 @pytest.mark.usefixtures("suppress_remote_automation_calls")


### PR DESCRIPTION
Currently, when one tries to GET a downtime on a read-only site by ID, they will be denied with "Forbidden: WATO is disabled".
As getting downtimes does not require WATO (at least as far as I am aware 😉), one would expect to simply get the queried downtime's information back.

The reason for this behaviour is the missing parameter `tag_group` on the `Endpoint` decorator of `cmk.gui.plugins.openapi.endpoints.downtime.show_downtime()`, which defaults to `Setup`.

This PR adds the missing parameter to the `Endpoint` decorator of `show_downtime` with a value of `Monitoring`. This fixes showing single downtimes on read-only sites.

There is also a new unit test to assess the correct functionality in the future.
To differentiate the new test from the existing one that did not disable WATO, i renamed the existing test to include `_wato_enabled`. I hope this is alright.

Just let me know, when there is anything I should change 🙂