### PR TITLE
Update check_mk_agent.linux

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -439,7 +439,7 @@ section_mem() {
 }
 
 section_cpu() {
-    if [ "$(uname -m)" = "armv7l" ] || [ "$(uname -m)" = "armv6l" ]; then
+    if [ "$(uname -m)" = "armv7l" ] || [ "$(uname -m)" = "armv6l" ] || [ "$(uname -m)" = "aarch64" ]; then
         CPU_REGEX='^processor'
     else
         CPU_REGEX='^CPU|^processor'


### PR DESCRIPTION
fix the cpu count check for aarch64

With the new 64bit OS for example on the Raspberrypi, the cpu count is wrong:

```
root@raspberry:~# uname -m
aarch64
root@raspberry:~# grep -c -E '^processor' </proc/cpuinfo
4
root@raspberry:~# grep -c -E '^CPU|^processor' </proc/cpuinfo
24
```

