### PR TITLE
Infoblox Services: add missing items to list of Service IDs

### DIFF
--- a/cmk/base/plugins/agent_based/infoblox_services.py
+++ b/cmk/base/plugins/agent_based/infoblox_services.py
@@ -78,6 +78,8 @@ SERVICE_ID = {
     "57": "cloud-api",
     "58": "threat-analytics",
     "59": "taxii",
+    "60": "bfd",
+    "61": "outbound"
 }
 STATUS_ID = {
     "1": "working",


### PR DESCRIPTION
**General information**

Add missing items "bfd" and "outbound" to list of Service IDs

See copy of official Infoblox SNMP Platform MIB https://git.furworks.de/opensourcemirror/LibreNMS/src/branch/master/mibs/infoblox/IB-PLATFORMONE-MIB for me details.

___

REVISION  "201606120000Z"  -- Jun 12, 2016

- DESCRIPTION "Add BFD service status"
 
 
REVISION  "201606070000Z"  -- June 07, 2016

- DESCRIPTION "Add Outbound traps"

___
**Bug reports**
CheckMK is missing Infoblox service IDs. The Service Parser crashes when those currently missing services are enabled on the Infoblox Appliance.

Please include:

**Your operating system name and version**
Ubuntu 18.04
Checkmk 2.0.0p19




**What is the expected behavior?**
monitor all running infoblox node services

**What is the observed behavior?**
... crash_type:section | exc_type:keyerror | exc_value:60 ...
...parse_infoblox_services ->return
... dictcomp .. ["60", "1",""]