### PR TITLE
fsc_sc2_temp: Replace wrong metric name in manpage

### DIFF
--- a/checkman/fsc_sc2_temp
+++ b/checkman/fsc_sc2_temp
@@ -9,7 +9,7 @@ description:
  FSC-SERVERCONTROL2-MIB.
 
  The check goes WARN or CRIT if the
- power consumption is higher or lower than the
+ temperature is higher or lower than the
  configurable levels or if it exceeds critical
  levels defined on the device.
 


### PR DESCRIPTION
Small improvement: The manpage for fsc_sc2_temp falsely mentioned power consumption instead of
temperature in the description.
