### PR TITLE
fixed postgres db discovery for db named with numbers only

### DIFF
--- a/checks/postgres_stat_database
+++ b/checks/postgres_stat_database
@@ -36,7 +36,7 @@ def parse_postgres_stat_database(info):
                 db_name = "%s/%s" % (instance_name, row["datname"])
             else:
                 db_name = row["datname"]
-            parsed[db_name] = row
+            parsed[str(db_name)] = row
 
     return parsed
 


### PR DESCRIPTION
In case PostgreSQL databases have names which contain only numbers, the discovery will fail, because the parsed data will be written out as an integer instead of a string. 
