### PR TITLE
Update cisco_stack

### DIFF
--- a/checks/cisco_stack
+++ b/checks/cisco_stack
@@ -39,6 +39,7 @@ def parse_cisco_stack(info):
         "1": "master",
         "2": "member",
         "3": "notMember",
+        "4": "standby",
     }
 
     parsed = {}


### PR DESCRIPTION
## General information

Added switch role name "standby" which is new in IOS-XE.

Manufacturer: Cisco
Model: C9200L-24P-4G
Software: IOS-XE 16.12.4

## Bug reports

Output of "show switch" command:
Switch#   Role    Mac Address     Priority Version  State 
*1       Active   xxxx.xxxx.xxxx     15     V01     Ready                
 2       **Standby**  xxxx.xxxx.xxxx     10     V01     Ready                
 3       Member   xxxx.xxxx.xxxx     9      V01     Ready                
 4       Member   xxxx.xxxx.xxxx     8      V01     Ready

Output of SNMP walk:
SNMP v2c
Walk 1.3.6.1.4.1.9.9.500.1.2.1.1.3
1.3.6.1.4.1.9.9.500.1.2.1.1.3.1000 = "1" [ASN_INTEGER]
1.3.6.1.4.1.9.9.500.1.2.1.1.3.2000 = "4" [ASN_INTEGER]
1.3.6.1.4.1.9.9.500.1.2.1.1.3.3000 = "2" [ASN_INTEGER]
1.3.6.1.4.1.9.9.500.1.2.1.1.3.4000 = "2" [ASN_INTEGER]

## Proposed changes

As porposed.