### PR TITLE
check_mk_agent.linux / systemctl: properly handle units marked with bullet circles

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -535,11 +535,11 @@ section_systemd() {
     if inpath systemctl; then
         echo '<<<systemd_units>>>'
         echo "[list-unit-files]"
-        systemctl list-unit-files --no-pager | tr -s ' '
+        systemctl list-unit-files --full --no-legend --no-pager --plain | tr -s ' '
         echo "[status]"
         systemctl status --all --type service --no-pager | tr -s ' '
         echo "[all]"
-        systemctl --all --no-pager | sed '/^$/q' | tr -s ' '
+        systemctl --all --full --no-legend --no-pager --plain | sed '/^$/q' | tr -s ' '
     fi
 }
 


### PR DESCRIPTION
systemd uses the so called bullet circle (SPECIAL_GLYPH_BLACK_CIRCLE) to mark units in special states (not-found, inactive, dead,... but also failed).

By default, and when running in a UTF-8 capable environment, systemd uses the "●" character for the bullet circle, only in ASCII fallback mode it uses "*" instead.

When C.UTF-8 is available, check_mk_agent uses it as its LC_ALL setting though, returning something like:

```
| % LC_ALL="C.utf8" systemctl --all --no-pager | sed '/^$/q' | tr -s ' ' | grep restic-backup
|  restic-backup-fileserver01-data-prune.service loaded inactive dead Restic backup prune of fileserver01-data
| ● restic-backup-mail01-data-prune.service loaded failed failed Restic backup prune of mail01-data
|  restic-backup-fileserver01-data-prune.timer loaded active waiting Weekly restic backup prune of fileserver01-data
|  restic-backup-mail01-data-prune.timer loaded active waiting Weekly restic backup prune of mail01-data
```

But such a failed unit isn't detected and handled by checkmk's systemd_units then (as observed with checkmk v2.0.0p22):

```
| OK    Systemd Service Summary         Total: 102, Disabled: 9, Failed: 0
```

But when using an environment *without* UTF-8 support, systemd's systemctl would behave as expected by checkmk. Corresponding output:

```
| % LC_ALL=C systemctl --all --no-pager | sed '/^$/q' | tr -s ' ' | grep restic-backup
|  restic-backup-fileserver01-data-prune.service loaded inactive dead Restic backup prune of fileserver01-data
| * restic-backup-mail01-data-prune.service loaded failed failed Restic backup prune of mail01-data
|  restic-backup-fileserver01-data-prune.timer loaded active waiting Weekly restic backup prune of fileserver01-data
|  restic-backup-mail01-data-prune.timer loaded active waiting Weekly restic backup prune of mail01-data
```

The proper solution though is to use the options `--no-legend --no-pager
--plain` instead, quoting from systemd upstream commit 1cabd2d0c56b7:

```
|   systemctl: hide first column with --plain instead of --no-legend
|
|   Hiding the first column, which may contain bullet circles, with --no-legend
|   is undocumented and potentially unexpected. On the other hand, not printing
|   bullet circles with --plain is documented so hiding the column with that
|   switch is sensible.
|
|   The combination "--full --no-legend --no-pager --plain" is appropriate for
|   automated processing of systemctl output.
```

And indeed, this behaves as expected then and also checkmk handles it properly then:

```
| synpromika@backup ~ % LC_ALL="C.utf8" systemctl --all --no-legend --no-pager --plain | sed '/^$/q' | tr -s ' ' | grep restic-backup
| restic-backup-fileserver01-data-prune.service loaded inactive dead Restic backup prune of fileserver01-data
| restic-backup-mail01-data-prune.service loaded failed failed Restic backup prune of mail01-data
| restic-backup-fileserver01-data-prune.timer loaded active waiting Weekly restic backup prune of fileserver01-data
| restic-backup-mail01-data-prune.timer loaded active waiting Weekly restic backup prune of mail01-data
```

And also checkmk handles it properly then:

```
| CRIT	Systemd Service Summary	Total: 125, Disabled: 9, Failed: 1, 1 static service failed (restic-backup-mail01-data-prune)
```

Verified systemctl behavior on systemd v232-25 (Debian/stretch), v241-7 (Debian/buster), v247.3 (Debian/bullseye) and v250.4 (Debian/unstable as of 2022-04-21).

FTR: the --plain option isn't relevant for the new `systemctl status` handling that got introduced in commit e5d0b1c852.  Quoting from systemctl(1) section about `status` unit command:

```
| This function is intended to generate human-readable output.
| If you are looking for computer-parsable output, use show instead.
```

**NOTE:** this failed backup run went unnoticed in checkmk monitoring and was caught only elsewhere. We digged into this issue and noticed that several units weren't monitoring as expected, so this bugfix seems to be quite important.