### PR TITLE
Preserve perfvalues of 0 instead of setting them to ""

### DIFF
--- a/cmk/base/checking.py
+++ b/cmk/base/checking.py
@@ -941,6 +941,8 @@ def _convert_perf_data(p: Sequence[Union[None, str, float]]) -> str:
 def _convert_perf_value(x: Union[None, str, float]) -> str:
     if isinstance(x, float):
         return ("%.6f" % x).rstrip("0").rstrip(".")
+    if x == 0:
+       x = "0" # prevent 0 integers from being treated as False and set to "" below
     return str(x or "")
 
 


### PR DESCRIPTION
Hi tribe29-Team,

the following seems to affect only the RAW edition. When a check returns perfdata with a value of integer 0, the value gets dropped, leading to a perfdata string like this:

oracle_sga_streams_pool=;;;;

Example agent output to reproduce this is attached, 



When that gets passed to pnp4nagios, it fails to create the rrd file, which is only visible if process_perfdata.cfg sets the LOG_LEVEL = 2


2022-04-22 22:13:58 [9266] [1] Found Performance Data for oracle / ORA_ABC_DB_Performance (oracle_db_time=0;;;; oracle_db_cpu=0;;;; oracle_db_wait_time=0;;;; oracle_buffer_hit_ratio=99.991314;;;; oracle_library_cache_hit_ratio=99.94691;;;; oracle_buffer_busy_wait=0;;;; oracle_consistent_gets=0;;;; oracle_db_block_change=0;;;; oracle_db_block_gets=0;;;; oracle_free_buffer_wait=0;;;; oracle_physical_reads=0;;;; oracle_physical_writes=0;;;; oracle_pin_hits_sum=0;;;; oracle_pins_sum=0;;;; oracle_sga_buffer_cache=54223962112;;;; oracle_sga_java_pool=1073741824;;;; oracle_sga_large_pool=536870912;;;; oracle_sga_redo_buffer=128913408;;;; oracle_sga_shared_io_pool=536870912;;;; oracle_sga_shared_pool=8455716864;;;; oracle_sga_size=64424509440;;;; oracle_sga_streams_pool=;;;;)
2022-04-22 22:13:58 [9266] [2] No pattern match in function _parse(oracle_sga_streams_pool=;;;; )
2022-04-22 22:13:58 [9266] [1] Invalid Perfdata detected

In my tests, this only seemed to happen if the check was assigned to a cluster, which I don't quite understand to be honest. Then again, the fixed code makes sense I suppose.
I guess the bug stems from the fact that an integer of 0 evaluates to a boolean False in python.

[perfdata_example.txt](https://github.com/tribe29/checkmk/files/8544029/perfdata_example.txt)

