### PR TITLE
Tracking Media_and_Data_Integrity_Errors

### DIFF
--- a/cmk/base/plugins/agent_based/smart.py
+++ b/cmk/base/plugins/agent_based/smart.py
@@ -164,6 +164,7 @@ DISCOVERED_PARAMETERS: Final = (
     'Uncorrectable_Error_Cnt',
     'UDMA_CRC_Error_Count',
     'CRC_Error_Count',
+    'Media_and_Data_Integrity_Errors',
     #nvme
     'Critical_Warning',
 )


### PR DESCRIPTION
## General information
We had issues with a nvme-SSD resutlting in a filesystem which became read-only and was not repairable because of broken SSD. The Smart-Check unfortunately  did not notice any issue. Reason is that it does not track the 2 values which had shown the problem:
- Media and Data Integrity Errors
- Error Information Log Entries

## Bug reports
- OS: Debian GNU Linux Buster
- Any details about your local setup that might be helpful in troubleshooting
- You can test it with something like
```cat >/usr/lib/check_mk_agent/plugins/smart <<EOF
#!/bin/bash
echo "<<<smart>>>"
echo "/dev/nvme0n1 NVME TESTDISK"
echo "Critical Warning:                   0x00"
echo "Temperature:                        31 Celsius"
echo "Available Spare:                    100%"
echo "Available Spare Threshold:          10%"
echo "Percentage Used:                    2%"
echo "Data Units Read:                    2,050,260 [1.04 TB]"
echo "Data Units Written:                 78,657,503 [40.2 TB]"
echo "Host Read Commands:                 35,535,473"
echo "Host Write Commands:                1,589,783,331"
echo "Controller Busy Time:               12,147"
echo "Power Cycles:                       4"
echo "Power On Hours:                     3,674"
echo "Unsafe Shutdowns:                   1"
echo "Media and Data Integrity Errors:    $( date +%s )"
echo "Error Information Log Entries:      $( date +%s )"
echo "Warning  Comp. Temperature Time:    0"
echo "Critical Comp. Temperature Time:    0"
echo "Temperature Sensor 1:               31 Celsius"
echo "Temperature Sensor 2:               40 Celsius"
EOF```

## Proposed changes
Track one the Media_and_Data_Integrity_Errors (see git commit)