### PR TITLE
Added new hardware models

### DIFF
--- a/checks/cisco_stack
+++ b/checks/cisco_stack
@@ -103,8 +103,10 @@ check_info["cisco_stack"] = {
         ],
     ),
     "snmp_scan_function": lambda oid: (
-        oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.9.1.1208")
-        or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.9.1.1745")
+        oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.9.1.1208")  # cat29xxStack
+        or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.9.1.1745")  # cat38xxstack
+        or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.9.1.2694")  # ciscoCat9200LFixedSwitchStack
+        or oid(".1.3.6.1.2.1.1.2.0").startswith(".1.3.6.1.4.1.9.1.2695")  # ciscoCat9200FixedSwitchStack
     ),
     "group": "cisco_stack",
 }


### PR DESCRIPTION
## General information

Added new hardware models 9200 and 9200L
Added comments to snmp_scan_function for better understanding which models are supported.

Manufacturer: Cisco
Model: C9200 amd C9200L
Software: IOS-XE

## Example of a 9200L switch stack

OMD[xxx]:~/local/share/check_mk/checks$ snmpwalk -v 2c -c xxx 10.x.x.x 1.3.6.1.2.1.1.2.0
SNMPv2-MIB::sysObjectID.0 = OID: SNMPv2-SMI::enterprises.9.1.2694
