### PR TITLE
Permit setting an alternate cache directory

### DIFF
--- a/agents/check_mk_caching_agent.linux
+++ b/agents/check_mk_caching_agent.linux
@@ -27,7 +27,7 @@
 #   ip address, which is absolutely needed here.                     #
 # ------------------------------------------------------------------ #
 
-export MK_CACHEDIR="/var/cache/check_mk"
+export MK_CACHEDIR=${MK_CACHEDIR:-/var/cache/check_mk}
 
 # Determine the IP address of the remote Nagios server.
 # xinetd sends us the IP address of the remote host via


### PR DESCRIPTION
## General information

The caching agent has a fixed directory set for the cache.

## Bug reports

Please include:

+ Your operating system name and version
RHEL 7

+ Any details about your local setup that might be helpful in troubleshooting
/var/cache is on a very slow disk

+ Detailed steps to reproduce the bug
Try to relocate the cache used by the agent

+ An agent output or SNMP walk
N/A

+ The ID of a submitted crash report for reference (if applicable)
N/A

## Proposed changes

+ What is the expected behavior?

When MK_CACHEDIR is set, use that cache instead.

+ What is the observed behavior?

The directory is hard coded and cannot be swapped out via env vars.