### PR TITLE
timesyncd: Fix parsing arbitrary systemd time spans

### DIFF
--- a/tests/unit/cmk/base/plugins/agent_based/test_timesyncd.py
+++ b/tests/unit/cmk/base/plugins/agent_based/test_timesyncd.py
@@ -26,7 +26,7 @@ DATA1 = [
     ["Reference:", "C0248F97"],
     ["Precision:", "1us", "(-24)"],
     ["Root", "distance:", "87.096ms", "(max:", "5s)"],
-    ["Offset:", "-53.991ms"],
+    ["Offset:", "-1min 53.991ms"],
     ["Delay:", "208.839ms"],
     ["Jitter:", "0"],
     ["Packet", "count:", "1"],
@@ -65,11 +65,14 @@ def test_discover_timesyncd(
             DATA1,
             timesyncd.default_check_parameters,
             [
-                Result(state=state.OK, summary="Offset: 54 milliseconds"),
-                Metric("time_offset", 0.053991, levels=(0.2, 0.5)),
                 Result(
                     state=state.CRIT,
-                    summary="Time since last sync: 22 hours 1 minute (warn/crit at 2 hours 5 minutes/3 hours 0 minutes)",
+                    summary="Offset: 1 minute 0 seconds (warn/crit at 200 milliseconds/500 milliseconds)",
+                ),
+                Metric("time_offset", 60.053991, levels=(0.2, 0.5)),
+                Result(
+                    state=state.CRIT,
+                    summary="Time since last sync: 22 hours 0 minutes (warn/crit at 2 hours 5 minutes/3 hours 0 minutes)",
                 ),
                 Result(state=state.OK, summary="Stratum: 2.00"),
                 Result(state=state.OK, summary="Jitter: Jan 01 1970 00:00:00"),
@@ -83,7 +86,7 @@ def test_discover_timesyncd(
             [
                 Result(
                     state=state.CRIT,
-                    summary="Time since last sync: 22 hours 1 minute (warn/crit at 2 hours 5 minutes/3 hours 0 minutes)",
+                    summary="Time since last sync: 22 hours 0 minutes (warn/crit at 2 hours 5 minutes/3 hours 0 minutes)",
                 ),
                 Result(state=state.OK, summary="Found no time server"),
             ],
@@ -95,7 +98,7 @@ def test_check_timesyncd_freeze(
     params: timesyncd.CheckParams,
     result: CheckResult,
 ):
-    server_time = 1569922392.37 + 60 * 60 * 22 + 60, "UTC"
+    server_time = 1569922332.37 + 60 * 60 * 22 + 60, "UTC"
     section = timesyncd.parse_timesyncd(string_table)
     with on_time(*server_time):
         assert list(timesyncd.check_timesyncd(params, section)) == result


### PR DESCRIPTION
## General information

This is about the parsing of the "timesyncd" section sent by the Linux agent.

## Bug reports

The Linux Agent sends a section like the following when systemd-timesyncd is in use:
```
<<<timesyncd>>>
       Server: 192.2.0.1 (ntp.example.org)
Poll interval: 34min 8s (min: 32s; max 34min 8s) 
         Leap: normal                            
      Version: 4                                 
      Stratum: 2                                 
    Reference: CD2EB2A9                          
    Precision: 1us (-20)                         
Root distance: 36.627ms (max: 5s)                
       Offset: +18min 28.477161s                         
        Delay: 869us                             
       Jitter: 221us                             
 Packet count: 18                                
    Frequency: +5.957ppm                         
```
While the offset is usually <1s, it may become larger (for whatever reason, but for reproduction you can probably set it manually using `date`). It's then composed of multiple components (as above) with different units (min + s), as described in the man page systemd.time(7).

This raises a `MKGeneralException("invalid data value from time server")`.

I submitted this crash with ID `bd1dc314-d0ca-11ec-b409-1b5efafc6090`.

## Proposed changes

This patch implements the full extent of the format specified in the systemd.time(7) man page. In particular:

* Support for multiple time units concatenated
* No need for spaces between them
* Support for all aliases of the units (s, sec, second, seconds)
  * Although one version of systemd probably always uses only one of the strings per unit for output, that could change between versions!

I also updated the unit tests to include this case.