### PR TITLE
winperf_if.ps1 wrong line continuation

### DIFF
--- a/agents/windows/plugins/windows_if.ps1
+++ b/agents/windows/plugins/windows_if.ps1
@@ -44,7 +44,7 @@ if ([Environment]::OSVersion.Version.Major -ge "5"){
 	try {
 		Write-Host "<<<winperf_if_get_netadapter:sep(124)>>>"
 		foreach ($net in Get-NetAdapter -IncludeHidden){
-			$description = $($net.InterfaceDescription).replace('|', '/')`
+			$description = $($net.InterfaceDescription).replace('|', '/')
 			$alias = $($net.InterfaceAlias).replace('|', '/')
 			Write-Host ("$description|" +
 			            "$alias|" +


### PR DESCRIPTION
## Bug reports

winperf_if.ps1 crashes as there is a line continuation symbol that should not be there.
Error message is "unknown symbol $alias"
