### PR TITLE
Set look_for_keys=False on SFTP check without keys

### DIFF
--- a/active_checks/check_sftp
+++ b/active_checks/check_sftp
@@ -56,6 +56,7 @@ def connection(
             password=opt_pass,
             port=opt_port,
             timeout=opt_timeout,
+            look_for_keys=False,
         )
     else:
         client.connect(


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Unfortunately, due to our current work load, we only consider pure bug fixes as stated in our [Readme](https://github.com/tribe29/checkmk#want-to-contribute).
This means any new pull request that is not a pure bug fix will be closed.
Instead of creating a PR, please consider sharing new check plugins, agent plugins, special agents or notification plugins via the [Checkmk Exchange](https://exchange.checkmk.com/).

## General information

The SFTP check failes with username/password if an SSH key exists that doesn't allow access to the SFTP server.

The paramiko connect function that CheckMK uses to check SFTP servers is missing the look_for_keys=False option. The documentation says that this needs set to false so that paramiko doesn't look for a key to connect. 
https://docs.paramiko.org/en/stable/api/client.html

## Bug reports

Please include:

+ Your operating system name and version
Centos 7

+ Any details about your local setup that might be helpful in troubleshooting
We use git version control for wato, which is why we have SSH keys there.

+ Detailed steps to reproduce the bug
1. Create SSH keys in the /omd/sites/<SITE>/.ssh/ directory (create the directory if it doesn't exist. Important, do not add these keys to the authorized_keys file for the SFTP server
2. Create a SFTP check using username/password


## Proposed changes

+ What is the expected behavior?
SFTP checks using username/password work when SSH keys exist for the site user.

+ What is the observed behavior?
SFTP checks continue to try using the SSH key and do not attempt to use the username/password.

+ If it's not obvious from the above: In what way does your patch change the current behavior?
Adds the look_for_keys=False to the connect method as the paramiko documentation specifies

+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
This has existed since at least 1.6.0, but we've kept a local file of the changes needed. Trying to upstream those changes.
