### PR TITLE
Add CUSTOM notification to Pagerduty notification plugin

### DIFF
--- a/cmk/notification_plugins/pagerduty.py
+++ b/cmk/notification_plugins/pagerduty.py
@@ -20,6 +20,7 @@ from cmk.notification_plugins.utils import (
 def pagerduty_event_type(event: str) -> str:
     return {
         "PROBLEM": "trigger",
+        "CUSTOM": "trigger",
         "ACKNOWLEDGEMENT": "acknowledge",
         "RECOVERY": "resolve",
         "FLAPPINGSTART": "trigger",


### PR DESCRIPTION
## General information

The CheckMK documentation suggests using a CUSTOM notification for testing but the Pagerduty plugin doesn't allow for CUSTOM notifications, throwing a dictionary error. 
https://docs.checkmk.com/latest/en/notifications_pagerduty.html


## Bug reports

Please include:

+ Your operating system name and version
Centos 7

+ Any details about your local setup that might be helpful in troubleshooting
We use Pagerduty for notifications

+ Detailed steps to reproduce the bug
1. Setup a notification rule for pagerduty
2. Fake a check result to critical
3. Force a custom notification

## Proposed changes
+ What is the expected behavior?
A pagerduty issue is created in Pagerduty

+ What is the observed behavior?
CheckMK throws an error in the notify log about CUSTOM not being a key

pagerduty_event_type(context.get('NOTIFICATIONTYPE')), -- File "/omd/sites/DFW/lib/python3/cmk/notification_plugins/pagerduty.py", line 17, in pagerduty_event_type -- return { -- KeyError: 'CUSTOM'


+ If it's not obvious from the above: In what way does your patch change the current behavior?
Adds a CUSTOM key that triggers an issue in pagerduty

+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
We've been using the old pagerduty methods of alerts and are now switching to the built in Pagerduty plugin
