### PR TITLE
BUG: ipmi checks ignores wato rules for status overwrite

### DIFF
--- a/cmk/base/plugins/agent_based/utils/ipmi.py
+++ b/cmk/base/plugins/agent_based/utils/ipmi.py
@@ -145,7 +145,7 @@ def check_ipmi_detailed(
             yield Result(state=overwrite_state, summary="User-defined state")
             break
 
-    # stay compatible with older versions
+    # stay compatible with older versions and compare with overwrite_state
     yield Result(
         state=State.best(status_txt_mapping(sensor.status_txt), overwrite_state),
         summary="Status: %s" % sensor.status_txt,

--- a/cmk/base/plugins/agent_based/utils/ipmi.py
+++ b/cmk/base/plugins/agent_based/utils/ipmi.py
@@ -137,7 +137,7 @@ def check_ipmi_detailed(
     status_txt_mapping: StatusTxtMapping,
 ) -> type_defs.CheckResult:
 
-    overwrite_state = State(2)
+    overwrite_state = State(3)
 
     for wato_status_txt, wato_status in params.get("sensor_states", []):
         if sensor.status_txt.startswith(wato_status_txt):

--- a/tests/unit/cmk/base/plugins/agent_based/test_ipmi_sensors.py
+++ b/tests/unit/cmk/base/plugins/agent_based/test_ipmi_sensors.py
@@ -480,8 +480,8 @@ def test_discover_ipmi_sensors(
             },
             _SECTIONS[1],
             [
-                Result(state=State.OK, summary="Status: Presence detected"),
                 Result(state=State.UNKNOWN, summary="User-defined state"),
+                Result(state=State.OK, summary="Status: Presence detected"),
             ],
         ),
         pytest.param(

--- a/tests/unit/cmk/base/plugins/agent_based/utils/test_ipmi_utils.py
+++ b/tests/unit/cmk/base/plugins/agent_based/utils/test_ipmi_utils.py
@@ -271,12 +271,12 @@ from cmk.base.plugins.agent_based.utils import ipmi
             False,
             lambda txt: State.OK,
             [
-                Result(state=State.OK, summary="Status: ok"),
-                Result(state=State.OK, summary="1.04 Volts"),
-                Metric("PCH_1.05V", 1.04, levels=(None, 1.13)),
                 Result(
                     state=State.UNKNOWN, summary="User-defined state", details="User-defined state"
                 ),
+                Result(state=State.OK, summary="Status: ok"),
+                Result(state=State.OK, summary="1.04 Volts"),
+                Metric("PCH_1.05V", 1.04, levels=(None, 1.13)),
             ],
         ),
     ],


### PR DESCRIPTION
The current ipmi check ignores WATO defined status overwrite strings.
It only shows this as text but the check status is not correctly represented.

Thank you for your interest in contributing to Checkmk!
Unfortunately, due to our current work load, we only consider pure bug fixes as stated in our [Readme](https://github.com/tribe29/checkmk#want-to-contribute).
This means any new pull request that is not a pure bug fix will be closed.
Instead of creating a PR, please consider sharing new check plugins, agent plugins, special agents or notification plugins via the [Checkmk Exchange](https://exchange.checkmk.com/).

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
