### PR TITLE
FIX check_icmp: Fix indexed address variable names

### DIFF
--- a/checks/check_icmp
+++ b/checks/check_icmp
@@ -52,10 +52,10 @@ def check_icmp_arguments(params):
         args += ["-6", "$_HOSTADDRESSES_6$"]
 
     elif target[0] == "indexed_ipv4address":
-        args.append("$_HOSTADDRESS_4_%s$" % target[1])
+        args.append("$_HOSTADDRESSES_4_%s$" % target[1])
 
     elif target[0] == "indexed_ipv6address":
-        args.append("$_HOSTADDRESS_6_%s$" % target[1])
+        args.append("$_HOSTADDRESSES_6_%s$" % target[1])
 
     else:  # custom
         args.append(str(target[1]))

--- a/tests/unit/checks/test_check_icmp.py
+++ b/tests/unit/checks/test_check_icmp.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.checks
         ),
         pytest.param(
             {"address": ("indexed_ipv4address", 1)},
-            "-w 200.00,80% -c 500.00,100% $_HOSTADDRESS_4_1$",
+            "-w 200.00,80% -c 500.00,100% $_HOSTADDRESSES_4_1$",
             id="indexed ipv4 address",
         ),
         pytest.param(


### PR DESCRIPTION
## General information

Change-ID I3223494869d563cff0f6cb56795237c2825f3bd0 / commit d2c0a5ee610f49f476d2acbb7f57509a5117034c changed the name of the host macros for individual additional addresses without adapting check_icmp.

At least Check_MK Raw since 2.0.0p23 is affected. Don't know about CEE.

## Bug reports

When adding an ICMP Ping Check for a single indexed additional address, it always comes back with "UNKN: Failed to resolve $: Name or service not known".

## Proposed changes

This renames the host macros in the check_icmp as well.