### PR TITLE
check_mk-zpool_status: fixed check crash in case of zfs pools with sp…

### DIFF
--- a/cmk/base/plugins/agent_based/zpool_status.py
+++ b/cmk/base/plugins/agent_based/zpool_status.py
@@ -80,7 +80,7 @@ def parse_zpool_status(string_table: type_defs.StringTable) -> Optional[Section]
             if msg != "No known data errors":
                 pool_messages[last_pool].append(msg)
 
-        elif line[0] in ["spares", "logs", "cache"]:
+        elif line[0] in ["spares", "logs", "cache", "special"]:
             start_pool = False
             continue
 


### PR DESCRIPTION
…ecial devices and errors

## General information

the current zpool_status check crashes for the following zpool:

```
  pool: storage
 state: ONLINE
status: One or more devices has experienced an unrecoverable error.  An
        attempt was made to correct the error.  Applications are unaffected.
action: Determine if the device needs to be replaced, and clear the errors
        using 'zpool clear' or replace the device with 'zpool replace'.
   see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-9P
  scan: scrub repaired 0B in 00:54:14 with 0 errors on Mon May 30 22:52:10 2022
config:

        NAME                                                   STATE     READ WRITE CKSUM
        storage                                                ONLINE       0     0     0
          mirror-0                                             ONLINE       0     0     0
            ata-ST2000VM003-1CT164_W1H3SR9H                    ONLINE       0     0     0
            ata-TOSHIBA_DT01ACA200_94RRPEVAS                   ONLINE       0     0     0
        special 
          mirror-2                                             ONLINE       0     0     0
            ata-Samsung_SSD_860_QVO_1TB_S4CZNF0N459001M-part3  ONLINE       0     5     0
            ata-Samsung_SSD_860_QVO_1TB_S4CZNF0N458919M-part3  ONLINE       0     0     0
        logs
          mirror-1                                             ONLINE       0     0     0
            ata-Samsung_SSD_860_QVO_1TB_S4CZNF0N459001M-part1  ONLINE       0     0     0
            ata-Samsung_SSD_860_QVO_1TB_S4CZNF0N458919M-part1  ONLINE       0     0     0
        cache
          ata-Samsung_SSD_860_QVO_1TB_S4CZNF0N459001M-part2    ONLINE       0     0     0
          ata-Samsung_SSD_860_QVO_1TB_S4CZNF0N458919M-part2    ONLINE       0     0     0

errors: No known data errors
```
**OS**: Debian GNU/Linux 11 (bullseye)
**ZFS**: 2.1.4

## Proposed changes

Add the "special" top level device, which was introduced with zfs 0.8.x (https://github.com/openzfs/zfs/pull/5182), to the parsing logic.