### PR TITLE
BUG: Kaspersky AV Client - the age is no int but a float.

### DIFF
--- a/cmk/base/plugins/agent_based/kaspersky_av_client.py
+++ b/cmk/base/plugins/agent_based/kaspersky_av_client.py
@@ -103,8 +103,8 @@ register.check_plugin(
     discovery_function=discover_kaspersky_av_client,
     check_function=check_kaspersky_av_client,
     check_default_parameters={
-        "signature_age": (86400.0, 7 * 86400.0),
-        "fullscan_age": (86400.0, 7 * 86400.0),
+        "signature_age": (86400, 7 * 86400),
+        "fullscan_age": (86400, 7 * 86400),
     },
     check_ruleset_name="kaspersky_av_client",
 )

--- a/cmk/base/plugins/agent_based/kaspersky_av_client.py
+++ b/cmk/base/plugins/agent_based/kaspersky_av_client.py
@@ -71,8 +71,8 @@ def check_kaspersky_av_client(
     params: Dict[str, Tuple[float, float]], section: Section
 ) -> Generator[Result, None, None]:
     """
-    >>> test_params = dict(signature_age=(2, 3), fullscan_age=(2, 3))
-    >>> test_section = dict(fullscan_age=1, signature_age=1)
+    >>> test_params = dict(signature_age=(2.0, 3.3), fullscan_age=(2.0, 3.0))
+    >>> test_section = dict(fullscan_age=1.123, signature_age=1.123)
     >>> for result in check_kaspersky_av_client(test_params, test_section):
     ...     result
     Result(state=<State.OK: 0>, summary='Last update of signatures: 1 second ago')

--- a/cmk/base/plugins/agent_based/kaspersky_av_client.py
+++ b/cmk/base/plugins/agent_based/kaspersky_av_client.py
@@ -85,7 +85,7 @@ def check_kaspersky_av_client(
         age = section.get(key)
         if age is None:
             yield Result(state=State.UNKNOWN, summary=f"{what} unkown")
-        elif isinstance(age, int):  # needed to make mypy happy
+        elif isinstance(age, float):  # needed to make mypy happy
             yield from check_levels(
                 value=age,
                 levels_upper=params[key],

--- a/cmk/base/plugins/agent_based/kaspersky_av_client.py
+++ b/cmk/base/plugins/agent_based/kaspersky_av_client.py
@@ -103,8 +103,8 @@ register.check_plugin(
     discovery_function=discover_kaspersky_av_client,
     check_function=check_kaspersky_av_client,
     check_default_parameters={
-        "signature_age": (86400, 7 * 86400),
-        "fullscan_age": (86400, 7 * 86400),
+        "signature_age": (86400.0, 7 * 86400.0),
+        "fullscan_age": (86400.0, 7 * 86400.0),
     },
     check_ruleset_name="kaspersky_av_client",
 )

--- a/tests/unit/cmk/base/plugins/agent_based/test_kaspersky_av_client.py
+++ b/tests/unit/cmk/base/plugins/agent_based/test_kaspersky_av_client.py
@@ -39,7 +39,7 @@ def test_parse_kaspersky_av_client(string_table, now, expected_section):
     "section,results",
     [
         (
-            dict(fullscan_age=2, signature_age=2),
+            dict(fullscan_age=2.3549888134, signature_age=2.3549888134),
             [
                 Result(
                     state=State.WARN,
@@ -52,7 +52,7 @@ def test_parse_kaspersky_av_client(string_table, now, expected_section):
             ],
         ),
         (
-            dict(fullscan_age=3, signature_age=3),
+            dict(fullscan_age=3.35498881343, signature_age=3.3549888134),
             [
                 Result(
                     state=State.CRIT,
@@ -65,7 +65,7 @@ def test_parse_kaspersky_av_client(string_table, now, expected_section):
             ],
         ),
         (
-            dict(fullscan_failed=True, fullscan_age=1, signature_age=1),
+            dict(fullscan_failed=True, fullscan_age=1.3549888134, signature_age=1.3549888134),
             [
                 Result(state=State.OK, summary="Last update of signatures: 1 second ago"),
                 Result(state=State.OK, summary="Last fullscan: 1 second ago"),


### PR DESCRIPTION
Also inside the section definition it is shown as float.
!!! This check was not tested after migration to the new Check-API. !!!

Thank you for your interest in contributing to Checkmk!
Unfortunately, due to our current work load, we only consider pure bug fixes as stated in our [Readme](https://github.com/tribe29/checkmk#want-to-contribute).
This means any new pull request that is not a pure bug fix will be closed.
Instead of creating a PR, please consider sharing new check plugins, agent plugins, special agents or notification plugins via the [Checkmk Exchange](https://exchange.checkmk.com/).

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
