### PR TITLE
ignore passive checks in the scheduled_rate for the speedometer

### DIFF
--- a/cmk/gui/plugins/sidebar/speedometer.py
+++ b/cmk/gui/plugins/sidebar/speedometer.py
@@ -28,7 +28,8 @@ class Speedometer(SidebarSnapin):
     def description(cls):
         return _(
             "A gadget that shows your current service check rate in relation to "
-            "the scheduled check rate. If the Speed-O-Meter shows a speed "
+            "the scheduled check rate, ignoring passive checks. If the "
+            "Speed-O-Meter shows a speed "
             "of 100 percent, all service checks are being executed in exactly "
             "the rate that is desired."
         )
@@ -82,7 +83,11 @@ class Speedometer(SidebarSnapin):
                 # Manually added services without check_interval could be a problem, but
                 # we have no control there.
                 scheduled_rate = (
-                    sites.live().query_summed_stats("GET services\nStats: suminv check_interval\n")[
+                    sites.live().query_summed_stats(
+                        "GET services\n"
+                        "Filter: check_command !~ check-mk-custom!$\n"
+                        "Stats: suminv check_interval\n"
+                    )[
                         0
                     ]
                     / 60.0


### PR DESCRIPTION
## General information

The Service Speed-O-Meter is intended to show the actual_check_rate
divided by the scheduled_check_rate as a percentage.  Perfect performance
is 100%.  Slow performance is indicated by numbers below 100%.

The problem we have is that scheduled_rate is artificially inflated
by the legacy nsca passive checks.

The live status query used for each site is a sum of the
1/check_interval for each check.  Check_interval is specified in minutes.

    lq "GET services\nStats: suminv check_interval"

A check that runs every two hours (like Check_MK Discovery) has a
check_interval of 120.  The passive checks have a check_interval of 1.

This means that every passive check is creating an expectation of
1 check per minute, but that rarely happens.

This patch removes passive checks from the scheduled_rate.

## Proposed changes

This patch removes passive checks from the scheduled_rate.
