### PR TITLE
f5_bigip_fans: Fixed Fan Status on newer Models

### DIFF
--- a/checks/f5_bigip_fans
+++ b/checks/f5_bigip_fans
@@ -41,9 +41,12 @@ def parse_f5_bigip_fans(info):
             if fanchoice >= len(fantyp):
                 continue
             if fanchoice == 0:
-                parsed[("%s %d" % (fantyp[fanchoice], int(fanentry[0])))] = int(fanentry[1])
+                parsed[("%s %d" % (fantyp[fanchoice], int(fanentry[0])))] = (
+                    int(fanentry[2]),
+                    fanentry[1],
+                )
             else:
-                parsed[("%s %s" % (fantyp[fanchoice], fanentry[0]))] = int(fanentry[1])
+                parsed[("%s %s" % (fantyp[fanchoice], fanentry[0]))] = (int(fanentry[1]), None)
         fanchoice += 1
 
     return parsed
@@ -55,7 +58,16 @@ def inventory_f5_bigip_fans(parsed):
 
 
 def check_f5_bigip_fans(item, params, parsed):
-    fanspeed = parsed.get(item)
+    fanspeed, fanstatus = parsed.get(item)
+
+    # Status Map:
+    # 0: Bad
+    # 1: Good
+    # 2: Not Present
+    if fanspeed == 0 and fanstatus == "1":
+        yield 0, "Fan Status: good"
+        return
+
     if fanspeed is None:
         # do not change this to if not fanspeed! fanspeed could be 0.
         yield 3, "Could not detect speed"
@@ -73,7 +85,7 @@ check_info["f5_bigip_fans"] = {
     "service_description": "FAN %s",
     "group": "hw_fans",
     "snmp_info": [
-        (".1.3.6.1.4.1.3375.2.1.3.2.1.2.1", [1, 3]),
+        (".1.3.6.1.4.1.3375.2.1.3.2.1.2.1", [1, 2, 3]),
         (".1.3.6.1.4.1.3375.2.1.3.6.2.1", [4, 3]),
     ],
     "snmp_scan_function": scan_f5_bigip,

--- a/tests/unit/checks/generictests/datasets/f5_bigip_fans.py
+++ b/tests/unit/checks/generictests/datasets/f5_bigip_fans.py
@@ -8,7 +8,13 @@
 # type: ignore
 checkname = 'f5_bigip_fans'
 
-info = [[['1', '15574'], ['2', '16266'], ['3', '15913'], ['4', '16266'], ['5', '0']], []]
+info = [[['1', '1', '15574'],
+         ['2', '1', '16266'],
+         ['3', '1', '15913'],
+         ['4', '1', '16266'],
+         ['5', '0', '0'],
+         ['6', '1', '0']],
+        []]
 
 discovery = {
     '': [
@@ -16,7 +22,8 @@ discovery = {
         ('Chassis 2', 'f5_bigip_fans_default_levels'),
         ('Chassis 3', 'f5_bigip_fans_default_levels'),
         ('Chassis 4', 'f5_bigip_fans_default_levels'),
-        ('Chassis 5', 'f5_bigip_fans_default_levels')
+        ('Chassis 5', 'f5_bigip_fans_default_levels'),
+        ('Chassis 6', 'f5_bigip_fans_default_levels')
     ]
 }
 
@@ -26,6 +33,7 @@ checks = {
         ('Chassis 2', (2000, 500), [(0, 'Speed: 16266 RPM', [])]),
         ('Chassis 3', (2000, 500), [(0, 'Speed: 15913 RPM', [])]),
         ('Chassis 4', (2000, 500), [(0, 'Speed: 16266 RPM', [])]),
-        ('Chassis 5', (2000, 500), [(2, 'Speed: 0 RPM (warn/crit below 2000 RPM/500 RPM)', [])])
+        ('Chassis 5', (2000, 500), [(2, 'Speed: 0 RPM (warn/crit below 2000 RPM/500 RPM)', [])]),
+        ('Chassis 6', (2000, 500), [(0, 'Fan Status: good', [])])
     ]
 }


### PR DESCRIPTION
Newer Models like the Bigip i5600 don't have their fans running. So they report just '0' as fan speed.
But they deliver the actual status of this fan also in another OID.

This Fix reads this second OID and uses it just in case of a fan speed of 0.

From SNMP Walk:
.1.3.6.1.2.1.1.1.0 BIG-IP i5600 : Linux 3.10.0-862.14.4.el7.x86_64 : BIG-IP software release 16.1.2.2, build 0.0.28
.1.3.6.1.2.1.1.2.0 .1.3.6.1.4.1.3375.2.1.3.4.108

.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.1.1 1
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.1.2 2
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.1.3 3
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.1.4 4
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.1.5 5
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.1.6 6
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.1.7 7
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.1.8 8
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.2.1 1
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.2.2 1
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.2.3 1
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.2.4 1
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.2.5 1
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.2.6 1
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.2.7 1
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.2.8 1
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.3.1 0
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.3.2 0
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.3.3 0
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.3.4 0
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.3.5 0
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.3.6 0
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.3.7 0
.1.3.6.1.4.1.3375.2.1.3.2.1.2.1.3.8 0

