### PR TITLE
Added new hardware models to cisco_stack.py

### DIFF
--- a/cmk/base/plugins/agent_based/cisco_stack.py
+++ b/cmk/base/plugins/agent_based/cisco_stack.py
@@ -69,9 +69,11 @@ register.snmp_section(
         ],
     ),
     detect=any_of(
-        startswith(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.9.1.1208"),
-        startswith(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.9.1.1745"),
-        startswith(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.9.1.516"),
+        startswith(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.9.1.1208"),  # cat29xxStack
+        startswith(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.9.1.1745"),  # cat38xxstack
+        startswith(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.9.1.516"),   # catalyst37xxStack
+        startswith(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.9.1.2694"),  # ciscoCat9200LFixedSwitchStack
+        startswith(".1.3.6.1.2.1.1.2.0", ".1.3.6.1.4.1.9.1.2695"),  # ciscoCat9200FixedSwitchStack
     ),
 )
 


### PR DESCRIPTION
## General information

Added new hardware models 9200 and 9200L
Added comments for better understanding which models are supported.

Manufacturer: Cisco
Model: C9200 and C9200L
Software: IOS-XE

## Example of a 9200L switch stack

OMD[xxx]:~/local/share/check_mk/checks$ snmpwalk -v 2c -c xxx 10.x.x.x 1.3.6.1.2.1.1.2.0
SNMPv2-MIB::sysObjectID.0 = OID: SNMPv2-SMI::enterprises.9.1.2694

Thank you for your interest in contributing to Checkmk!
Unfortunately, due to our current work load, we only consider pure bug fixes as stated in our [Readme](https://github.com/tribe29/checkmk#want-to-contribute).
This means any new pull request that is not a pure bug fix will be closed.
Instead of creating a PR, please consider sharing new check plugins, agent plugins, special agents or notification plugins via the [Checkmk Exchange](https://exchange.checkmk.com/).

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
