### PR TITLE
Bug in Example for Combining Nodes (REST API Doc)

### DIFF
--- a/cmk/gui/plugins/openapi/restful_objects/specification.py
+++ b/cmk/gui/plugins/openapi/restful_objects/specification.py
@@ -224,7 +224,7 @@ This example filters for the host "example.com" only when the `state` column is 
 means the state is OK.
 
     {'op': 'and', 'expr': [{'op': '=', 'left': 'host_name', 'right': 'example.com'},
-                            {'op': '=', 'left': 'state', 'right': 0}}
+                            {'op': '=', 'left': 'state', 'right': 0}]}
 
 # Table definitions
 


### PR DESCRIPTION
There is a small bug in the online documentation example for Combining Nodes (Querying Status Data)

We have this small documentation bug in Version 2.0.0p26 and 2.1.0p5

