### PR TITLE
BUG: NagVis gadgets are broken after werk 13322

### DIFF
--- a/omd/packages/nagvis/skel/etc/nagvis/apache.conf
+++ b/omd/packages/nagvis/skel/etc/nagvis/apache.conf
@@ -5,7 +5,7 @@ Alias /###SITE###/nagvis/local "###ROOT###/local/share/nagvis/htdocs"
 Alias /###SITE###/nagvis/var "###ROOT###/tmp/nagvis/share"
 Alias /###SITE###/nagvis "###ROOT###/share/nagvis/htdocs"
 
-<Location ~ "/###SITE###/nagvis/(index\.php|frontend/nagvis-js/index\.php|server/core/ajax_handler\.php)$">
+<Location ~ "/###SITE###/nagvis/(index\.php|frontend/nagvis-js/index\.php|server/core/ajax_handler\.php|userfiles/gadgets/.*\.php)$">
   Options +ExecCGI
 </Location>
 


### PR DESCRIPTION
The title says nearly all needed. :)
You get an access denied for all gadgets after it is added to the map.

Thank you for your interest in contributing to Checkmk!
Unfortunately, due to our current work load, we only consider pure bug fixes as stated in our [Readme](https://github.com/tribe29/checkmk#want-to-contribute).
This means any new pull request that is not a pure bug fix will be closed.
Instead of creating a PR, please consider sharing new check plugins, agent plugins, special agents or notification plugins via the [Checkmk Exchange](https://exchange.checkmk.com/).

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
