### PR TITLE
BUG: dell_compellent_folder has missing perfdata tag

### DIFF
--- a/checks/dell_compellent_folder
+++ b/checks/dell_compellent_folder
@@ -42,5 +42,6 @@ check_info["dell_compellent_folder"] = {
     ),
     "snmp_scan_function": dell_compellent.scan,
     "group": "filesystem",
+    "has_perfdata": True,
     "default_levels_variable": "filesystem_default_levels",
 }


### PR DESCRIPTION
Error message inside CMK
-----------------
No historic metrics recorded but performance data is available. Maybe performance data processing is disabled.
-----------------

Thank you for your interest in contributing to Checkmk!
Unfortunately, due to our current work load, we only consider pure bug fixes as stated in our [Readme](https://github.com/tribe29/checkmk#want-to-contribute).
This means any new pull request that is not a pure bug fix will be closed.
Instead of creating a PR, please consider sharing new check plugins, agent plugins, special agents or notification plugins via the [Checkmk Exchange](https://exchange.checkmk.com/).

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
