### PR TITLE
megaraid_ldisks: Fix variable expansion in item label

### DIFF
--- a/cmk/base/plugins/agent_based/megaraid_ldisks.py
+++ b/cmk/base/plugins/agent_based/megaraid_ldisks.py
@@ -38,7 +38,7 @@ def parse_megaraid_ldisks(string_table: StringTable) -> megaraid.SectionLDisks:
             adapter = line[1]
         elif megaraid_ldisks_is_new_drive(l) and adapter is not None:
             disk = l.split(": ")[1].split(" ")[0]
-            item = "/c{adapter}/v{disk}"
+            item = f"/c{adapter}/v{disk}"
             parsed[item] = {}
 
             # Add it under the old item name. Not discovered, but can be used when checking


### PR DESCRIPTION
## General information

Every linux server with MegaRAID controller reports only one service for logical disks, independent of the actual number of configured logical disks, which is named "RAID Adapter/LDisk /c{adapter}/v{disk}" (sic, without replacement of the variables).
This was introduced by [Werk #13850](https://checkmk.com/werk/13850)

## Proposed changes

Simply make the string an f-string, like in the other megaraid checks.