### PR TITLE
MD: Fix parsing MD with single disk

### DIFF
--- a/checks/md
+++ b/checks/md
@@ -98,12 +98,24 @@
 # unused devices: <none>
 # ---------------------------------------------------------
 
+# Example of a raid with a single disk
+# ---------------------------------------------------------
+# md1 : active raid1 nvme4n1p2[1] nvme5n1p2[0] nvme2n1p2[2] nvme1n1p2[3] nvme3n1p2[5] nvme0n1p2[4]
+#       25977152 blocks super 1.2 [6/6] [UUUUUU]
+#
+# md0 : active raid1 nvme6n1[0]
+#       7501333824 blocks super 1.2 [1/1] [U]
+#       bitmap: 4/56 pages [16KB], 65536KB chunk
+#
+# unused devices: <none>
+# ---------------------------------------------------------
+
 
 def parse_md(info):  # pylint: disable=too-many-branches
     parsed = {}
     instance = {}
     for line in (l for l in info if l):
-        if len(line) >= 6 and line[0].startswith("md") and line[1] == ":":
+        if len(line) >= 5 and line[0].startswith("md") and line[1] == ":":
             if line[3].startswith("(") and line[3].endswith(")"):
                 raid_state = line[2] + line[3]
                 raid_name = line[4]


### PR DESCRIPTION
MD: Fix parsing single disk

We have a mdraid with a single disk, something like this (see md2)

```
cat /proc/mdstat     
Personalities : [raid1] [raid10] [linear] [multipath] [raid0] [raid6] [raid5] [raid4]
md1 : active raid10 nvme4n1p3[3] nvme5n1p3[5] nvme2n1p3[4] nvme1n1p3[0] nvme3n1p3[2] nvme0n1p3[1]
      9296776704 blocks super 1.2 512K chunks 2 near-copies [6/6] [UUUUUU]
      bitmap: 34/70 pages [136KB], 65536KB chunk

md0 : active raid1 nvme4n1p2[1] nvme5n1p2[0] nvme2n1p2[2] nvme1n1p2[3] nvme3n1p2[5] nvme0n1p2[4]
      25977152 blocks super 1.2 [6/6] [UUUUUU]

md2 : active raid1 nvme6n1[0]
      7501333824 blocks super 1.2 [1/1] [U]
      bitmap: 4/56 pages [16KB], 65536KB chunk
```

checkmk only detects 2 md raids and merges md0 + md2 to a single RAID.

```
MD Softraid md0      Status: active, Spare: 0, Failed: 0, Active: 6, Status: 1/1, U(!!)
MD Softraid md1      Status: active, Spare: 0, Failed: 0, Active: 6, Status: 6/6, UUUUUU
```
