### PR TITLE
Fix crashes of storcli_physical_disks plugin

### DIFF
--- a/cmk/base/plugins/agent_based/storcli_physical_disks.py
+++ b/cmk/base/plugins/agent_based/storcli_physical_disks.py
@@ -24,7 +24,7 @@ def parse_storcli_physical_disks(string_table: StringTable) -> megaraid.SectionP
             raw_disk["state"] = state
             continue
 
-        if words[:3] == ["Predictive", "Failure", "Count"]:
+        if words[:3] == ["Predictive", "Failure", "Count"] and words[4] != "N/A":
             raw_disk["failure_count"] = words[4]
 
     return {


### PR DESCRIPTION
## General information

We came across crashes parsing the storcli_physical_disks section, when the failure_count is 'N/A'.

## Bug reports

Please include:

Exception:      `ValueError (invalid literal for int() with base 10: 'N/A')`
Traceback:

      File "/omd/sites/zdf_smanz/lib/python3/cmk/base/agent_based/data_provider.py", line 122, in _parse_raw_data
        return section.parse_function(list(raw_data))
      File "/omd/sites/zdf_smanz/lib/python3/cmk/base/plugins/agent_based/storcli_physical_disks.py", line 30, in parse_storcli_physical_disks
        return {
      File "/omd/sites/zdf_smanz/lib/python3/cmk/base/plugins/agent_based/storcli_physical_disks.py", line 34, in <dictcomp>
        failures=None if (c := raw_disk.get("failure_count")) is None else int(c),

Local Variables:

    {'.0': <dict_itemiterator object at 0x7f3ba9c30040>,
     'c': 'N/A',
     'name': '/c1/e12/s0',
     'raw_disk': {'failure_count': 'N/A', 'name': '/c1/e12/s0', 'state': 'UGood'}}

## Proposed changes

Set failures to `None` if the value is set to 'N/A'

+ What is the expected behavior?
The parsing function is not expected to crash
+ What is the observed behavior?
The parsing crashes with the exception/traceback mentioned above
