### PR TITLE
Linux agent: ignore QEMU Emulator as shell (when on ARM)

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1520,7 +1520,7 @@ run_real_time_checks_for_remote() {
 }
 
 _this_shell() {
-    ps -o args= -p $$ | sed -e 's/^-//' -e 's/\ .*//'
+    ps -o args= -p $$ | sed -e 's/^-//' -e 's/^.*qemu-x86_64 //' -e 's/\ .*//'
 }
 
 #

--- a/tests/unit-shell/agents/test_run_cached.sh
+++ b/tests/unit-shell/agents/test_run_cached.sh
@@ -117,6 +117,15 @@ test_run_cached_get_shell() {
         assertEquals "bash" "$(_this_shell)"
     )
 
+    (# docker on ARM
+        ps() {
+            if [ "$1" = "-o" ] && [ "$2" = "args=" ] && [ "$3" = "-p" ]; then
+                echo /usr/bin/qemu-x86_64 /bin/bash bash /usr/bin/check_mk_agent
+            fi
+        }
+        assertEquals "/bin/bash" "$(_this_shell)"
+    )
+
 }
 # shellcheck disable=SC1090
 . "$UNIT_SH_SHUNIT2"


### PR DESCRIPTION
## General information

This bug probably only occurs when developing, and only when the checkmk container is running on Rosetta/QEMU (Mac M1/ARM), as I am doing. 

I wondered why the agent (also installed in the container) does silently ignore any execution of asynchronous plugins (robotmk). 

Seen on CMK image 2.1.0p4, fixed for 2.1.0.p9 (Debian 10).

## Proposed changes

+ Expected behaviour: execution of robotmk-runner.py in `/usr/lib/check_mk_agent/plugins/180`
+ Observed: no execution
+ The patch removes the shell `/usr/bin/qemu-x86_64` from the ps comand output and takes the command which was executed by the QEMU emulator as shell (here: `/bin/bash`)

```shell
# the line being parsed by sed
root@e055ddab3af8:/cmk_plugins# ps -o args= -p $$
/usr/bin/qemu-x86_64 /bin/bash bash
# Wrong result: 
root@e055ddab3af8:/cmk_plugins# ps -o args= -p $$ | sed -e 's/^-//' -e 's/\ .*//'
/usr/bin/qemu-x86_64
# Patched: 
root@e055ddab3af8:/cmk_plugins# ps -o args= -p $$ | sed -e 's/^-//' -e 's/^.*qemu-x86_64 //' -e 's/\ .*//'
/bin/bash
```