### PR TITLE
Don't stack virtual size per process

### DIFF
--- a/cmk/gui/plugins/metrics/ps.py
+++ b/cmk/gui/plugins/metrics/ps.py
@@ -90,6 +90,6 @@ graph_info["size_per_process"] = {
     "title": _("Size per process"),
     "metrics": [
         ("process_resident_size,processes,/", "area", _("Average resident size per process")),
-        ("process_virtual_size,processes,/", "stack", _("Average virtual size per process")),
+        ("process_virtual_size,processes,/", "area", _("Average virtual size per process")),
     ],
 }


### PR DESCRIPTION
I configured Check_MK to monitor java processes with one check_mk service per user.

Stacking virtual size per process on top of resident size per process generates a confusing graph where number of processes, total virtual size and virtual size per process don't match:
![image](https://user-images.githubusercontent.com/963797/183060010-b4d112ef-46ca-4288-a929-81ea944ea468.png)

See also: Werk 11275

## Environment

- Docker container v2.1.0p8, running on Kubernetes, Agent 2.1.0p8 running on SLES12SP5

## Detailed steps to reproduce the bug

1. Create process monitoring rule that matches only a single process per service. Make sure it has a lot of VIRT and RES in htop.
2. Compare the "VIRT" column in htop matches the value at which the line for the virtual size per process can be seen
    - Expected: Matches
    - Actual: line is at VIRT+RES

## Proposed changes

Change stack -> area. The surrounding code looks like this would work.