### PR TITLE
check_mk_agent.openbsd: Fix network parsing bug

### DIFF
--- a/agents/check_mk_agent.openbsd
+++ b/agents/check_mk_agent.openbsd
@@ -180,7 +180,7 @@ section_misc_sections() {
     # adjust internal field separator to get lines from netstat and backup it before
     OFS=$IFS
     IFS='
-    '
+'
     # collect netstat values and interface number
     for NS in $NETSTAT_OUTPUT; do
         NI=$((NI + 1))


### PR DESCRIPTION
With the restructure of the agent for openbsd to use functions it introduced a parsing bug where it fails to correctly separate network interfaces. This fixes that.