### PR TITLE
Fix executing local checks for openwrt agent

### DIFF
--- a/agents/check_mk_agent.openwrt
+++ b/agents/check_mk_agent.openwrt
@@ -1395,6 +1395,8 @@ main_setup() {
 
     set_variable_defaults
 
+    set_up_profiling
+
     unset_locale
 
     preamble_1


### PR DESCRIPTION
The problem can be easily reproduced by the following command:

```
  docker run --rm busybox ash -c "
     mkdir -p /usr/lib/check_mk_agent/local;
     echo "date" > /usr/lib/check_mk_agent/local/test.sh;
     chmod +x /usr/lib/check_mk_agent/local/test.sh;
     wget -O /tmp/cmka https://raw.githubusercontent.com/tribe29/checkmk/master/agents/check_mk_agent.openwrt;
     ash /tmp/cmka -d"
```

The following line will be visible:

```
  /tmp/cmka: line 1129: _log_section_time: not found
```

After this change, the current date will be printed instead of this
error.