### PR TITLE
Improve detection of OMD whether it is running in a containerized environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,10 @@ ENV CMK_PASSWORD=""
 ARG MAIL_RELAY_HOST
 ENV MAIL_RELAY_HOST=""
 
+# Add helper variable to better detect when running inside container.
+# Used e.g. for omd update
+ENV CMK_CONTAINERIZED="yes"
+
 # Make the list of required packages available to the following command
 COPY needed-packages /needed-packages
 

--- a/omd/packages/omd/omdlib/main.py
+++ b/omd/packages/omd/omdlib/main.py
@@ -1651,8 +1651,10 @@ def getenv(key: str, default: Optional[str] = None) -> Optional[str]:
 
 
 def clear_environment() -> None:
-    # first remove *all* current environment variables
-    keep = ["TERM"]
+    # first remove *all* current environment variables, except:
+    # TERM
+    # CMK_CONTAINERIZED: To better detect when running inside container (e.g. used for omd update)
+    keep = ["TERM", "CMK_CONTAINERIZED"]
     for key in os.environ:
         if key not in keep:
             del os.environ[key]

--- a/omd/packages/omd/omdlib/utils.py
+++ b/omd/packages/omd/omdlib/utils.py
@@ -30,7 +30,11 @@ from typing import Iterator
 
 
 def is_dockerized() -> bool:
-    return os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+    return (
+        os.path.exists("/.dockerenv")
+        or os.path.exists("/run/.containerenv")
+        or os.environ.get("CMK_CONTAINERIZED") == "yes"
+    )
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Issue

When running Checkmk as a K3s Pod and also mounting a tmpfs, a site update will fail with repeated error messages `umount: /opt/omd/sites/SITE/tmp: umount failed: Operation not permitted.`.

This has been discovered trying to update from 2.0.0p27 to 2.1.0p9 on a RKE2 cluster (v1.21.8+rke2r1).

## Reason

The reason lies within OMD omdlib.utils `is_dockerized` function. This function tries detecting whether it is running in a container by checking the two files `/.dockerenv` and `/run/.containerenv`. Depending on its output, the function `_tmpfs_is_managed_by_node` in `omdlib.tmpfs` decides, how to handle the tmpfs (u)mount. 
As neither of the aforementioned files is present inside the checkmk container running on RKE2, `is_dockerized` returns `False`. This results in OMD expecting to being able to unmount the tmpfs, thus failing the update.

## Possible workarounds

- Unmounting the tmpfs and redeploying checkmk, then doing the update without tmpfs mount. Afterwards, the tmpfs may be mounted again. This involves in a total of three deployments, though.
- Manually creating a file `/.dockerenv` or `/run/.containerenv` inside the container or the image. This either requires a custom image build or doing it on every update (or by mounting a dummy file to one of the locations, that would be quite hacky, though)

## Proposed solution

Since the docker image is under control of Tribe29, adding a custom environment variable `CMK_CONTAINERIZED` is an easy solution to discovering when running inside a container.
This is done by:
- Adding the aforementioned variable to the docker image's Dockerfile
- Updating the `is_dockerized` logic with a check for this environment variable
- Updating `set_environment` in omdlib.main to keep `CMK_CONTAINERIZED` when the omd command switches to the site user

## OLD Proposed solution (for reference)

> Instead of just looking at those two files, it would be possible to check for certain cgroups' existence in `/proc/1/cgroup`. This is the change that this pull request proposes.
> I updated `is_dockerized` with logic to read `/proc/1/cgroup` and look for specific cgroups:
> - `/kubepods` -> Kubernetes-like deployments
> - `/docker` -> Docker deployments
> - `/lxc` LXC deployments
> 
> I am not sure, whether there is a better way to achieve this, or whether there are other cgroups that should be added.
> Also, I do not know whether this strictly is a bug or not. That's for you to decide ;)