### PR TITLE
BUG: PoweredOff VM has stale Memory Check forever

### DIFF
--- a/checks/esx_vsphere_vm
+++ b/checks/esx_vsphere_vm
@@ -28,31 +28,21 @@ def check_esx_vsphere_vm_mem(_no_item, params, section):
         try:
             # consumed host memory
             host_memory_usage = (
-                savefloat(section["summary.quickStats.hostMemoryUsage"][0])
-                * 1024
-                * 1024
+                savefloat(section["summary.quickStats.hostMemoryUsage"][0]) * 1024 * 1024
             )
             # active guest memory
             guest_memory_usage = (
-                savefloat(section["summary.quickStats.guestMemoryUsage"][0])
-                * 1024
-                * 1024
+                savefloat(section["summary.quickStats.guestMemoryUsage"][0]) * 1024 * 1024
             )
             # size of the balloon driver in the VM
             ballooned_memory = (
-                savefloat(section["summary.quickStats.balloonedMemory"][0])
-                * 1024
-                * 1024
+                savefloat(section["summary.quickStats.balloonedMemory"][0]) * 1024 * 1024
             )
             # The portion of memory, in MB, that is granted to this VM from non-shared host memor(musst not be set)
-            shared_memory = (
-                savefloat(section["summary.quickStats.sharedMemory"][0]) * 1024 * 1024
-            )
+            shared_memory = savefloat(section["summary.quickStats.sharedMemory"][0]) * 1024 * 1024
             # The portion of memory, in MB, that is granted to this VM from host memory that is shared between VMs.
             private_memory = (
-                savefloat(section.get("summary.quickStats.privateMemory", [0])[0])
-                * 1024
-                * 1024
+                savefloat(section.get("summary.quickStats.privateMemory", [0])[0]) * 1024 * 1024
             )
         except:
             raise MKCounterWrapped(

--- a/checks/esx_vsphere_vm
+++ b/checks/esx_vsphere_vm
@@ -23,44 +23,56 @@ def check_esx_vsphere_vm_mem(_no_item, params, section):
     # If the machine is powered of, we do not get data
     powerstate = section["runtime.powerState"][0]
     if powerstate != "poweredOn":
-        raise MKCounterWrapped("VM is %s, skipping this check" % powerstate)
+        yield 0, "VM is %s, skipping this check" % powerstate
+    else:
+        try:
+            # consumed host memory
+            host_memory_usage = (
+                savefloat(section["summary.quickStats.hostMemoryUsage"][0])
+                * 1024
+                * 1024
+            )
+            # active guest memory
+            guest_memory_usage = (
+                savefloat(section["summary.quickStats.guestMemoryUsage"][0])
+                * 1024
+                * 1024
+            )
+            # size of the balloon driver in the VM
+            ballooned_memory = (
+                savefloat(section["summary.quickStats.balloonedMemory"][0])
+                * 1024
+                * 1024
+            )
+            # The portion of memory, in MB, that is granted to this VM from non-shared host memor(musst not be set)
+            shared_memory = (
+                savefloat(section["summary.quickStats.sharedMemory"][0]) * 1024 * 1024
+            )
+            # The portion of memory, in MB, that is granted to this VM from host memory that is shared between VMs.
+            private_memory = (
+                savefloat(section.get("summary.quickStats.privateMemory", [0])[0])
+                * 1024
+                * 1024
+            )
+        except:
+            raise MKCounterWrapped(
+                "Hostsystem did not provide memory information (reason may be high load)"
+            )
 
-    try:
-        # consumed host memory
-        host_memory_usage = (
-            savefloat(section["summary.quickStats.hostMemoryUsage"][0]) * 1024 * 1024
-        )
-        # active guest memory
-        guest_memory_usage = (
-            savefloat(section["summary.quickStats.guestMemoryUsage"][0]) * 1024 * 1024
-        )
-        # size of the balloon driver in the VM
-        ballooned_memory = savefloat(section["summary.quickStats.balloonedMemory"][0]) * 1024 * 1024
-        # The portion of memory, in MB, that is granted to this VM from non-shared host memor(musst not be set)
-        shared_memory = savefloat(section["summary.quickStats.sharedMemory"][0]) * 1024 * 1024
-        # The portion of memory, in MB, that is granted to this VM from host memory that is shared between VMs.
-        private_memory = (
-            savefloat(section.get("summary.quickStats.privateMemory", [0])[0]) * 1024 * 1024
-        )
-    except:
-        raise MKCounterWrapped(
-            "Hostsystem did not provide memory information (reason may be high load)"
-        )
-
-    for perfname, value in [
-        ("host", host_memory_usage),
-        ("guest", guest_memory_usage),
-        ("ballooned", ballooned_memory),
-        ("private", private_memory),
-        ("shared", shared_memory),
-    ]:
-        yield check_levels(
-            value,
-            perfname,
-            params=params.get(perfname),
-            infoname=perfname.title(),
-            human_readable_func=get_bytes_human_readable,
-        )
+        for perfname, value in [
+            ("host", host_memory_usage),
+            ("guest", guest_memory_usage),
+            ("ballooned", ballooned_memory),
+            ("private", private_memory),
+            ("shared", shared_memory),
+        ]:
+            yield check_levels(
+                value,
+                perfname,
+                params=params.get(perfname),
+                infoname=perfname.title(),
+                human_readable_func=get_bytes_human_readable,
+            )
 
 
 check_info["esx_vsphere_vm.mem_usage"] = {

--- a/checks/esx_vsphere_vm
+++ b/checks/esx_vsphere_vm
@@ -24,45 +24,44 @@ def check_esx_vsphere_vm_mem(_no_item, params, section):
     powerstate = section["runtime.powerState"][0]
     if powerstate != "poweredOn":
         yield 0, "VM is %s, skipping this check" % powerstate
-    else:
-        try:
-            # consumed host memory
-            host_memory_usage = (
-                savefloat(section["summary.quickStats.hostMemoryUsage"][0]) * 1024 * 1024
-            )
-            # active guest memory
-            guest_memory_usage = (
-                savefloat(section["summary.quickStats.guestMemoryUsage"][0]) * 1024 * 1024
-            )
-            # size of the balloon driver in the VM
-            ballooned_memory = (
-                savefloat(section["summary.quickStats.balloonedMemory"][0]) * 1024 * 1024
-            )
-            # The portion of memory, in MB, that is granted to this VM from non-shared host memor(musst not be set)
-            shared_memory = savefloat(section["summary.quickStats.sharedMemory"][0]) * 1024 * 1024
-            # The portion of memory, in MB, that is granted to this VM from host memory that is shared between VMs.
-            private_memory = (
-                savefloat(section.get("summary.quickStats.privateMemory", [0])[0]) * 1024 * 1024
-            )
-        except:
-            raise MKCounterWrapped(
-                "Hostsystem did not provide memory information (reason may be high load)"
-            )
+        return
 
-        for perfname, value in [
-            ("host", host_memory_usage),
-            ("guest", guest_memory_usage),
-            ("ballooned", ballooned_memory),
-            ("private", private_memory),
-            ("shared", shared_memory),
-        ]:
-            yield check_levels(
-                value,
-                perfname,
-                params=params.get(perfname),
-                infoname=perfname.title(),
-                human_readable_func=get_bytes_human_readable,
-            )
+    try:
+        # consumed host memory
+        host_memory_usage = (
+            savefloat(section["summary.quickStats.hostMemoryUsage"][0]) * 1024 * 1024
+        )
+        # active guest memory
+        guest_memory_usage = (
+            savefloat(section["summary.quickStats.guestMemoryUsage"][0]) * 1024 * 1024
+        )
+        # size of the balloon driver in the VM
+        ballooned_memory = savefloat(section["summary.quickStats.balloonedMemory"][0]) * 1024 * 1024
+        # The portion of memory, in MB, that is granted to this VM from non-shared host memor(musst not be set)
+        shared_memory = savefloat(section["summary.quickStats.sharedMemory"][0]) * 1024 * 1024
+        # The portion of memory, in MB, that is granted to this VM from host memory that is shared between VMs.
+        private_memory = (
+            savefloat(section.get("summary.quickStats.privateMemory", [0])[0]) * 1024 * 1024
+        )
+    except:
+        raise MKCounterWrapped(
+            "Hostsystem did not provide memory information (reason may be high load)"
+        )
+
+    for perfname, value in [
+        ("host", host_memory_usage),
+        ("guest", guest_memory_usage),
+        ("ballooned", ballooned_memory),
+        ("private", private_memory),
+        ("shared", shared_memory),
+    ]:
+        yield check_levels(
+            value,
+            perfname,
+            params=params.get(perfname),
+            infoname=perfname.title(),
+            human_readable_func=get_bytes_human_readable,
+        )
 
 
 check_info["esx_vsphere_vm.mem_usage"] = {


### PR DESCRIPTION
If you have a powerOff VM inside the monitoring then you have a stale service from the memory check forever.
At discovery time you see the message already but at check time the counter wrap is not shown.

Thank you for your interest in contributing to Checkmk!
Unfortunately, due to our current work load, we only consider pure bug fixes as stated in our [Readme](https://github.com/tribe29/checkmk#want-to-contribute).
This means any new pull request that is not a pure bug fix will be closed.
Instead of creating a PR, please consider sharing new check plugins, agent plugins, special agents or notification plugins via the [Checkmk Exchange](https://exchange.checkmk.com/).

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
