### PR TITLE
API: Allow access to BI aggregation state with disabled WATO

### DIFF
--- a/cmk/gui/plugins/openapi/endpoints/bi.py
+++ b/cmk/gui/plugins/openapi/endpoints/bi.py
@@ -262,6 +262,7 @@ class BIAggregationStateResponseSchema(Schema):
     request_schema=BIAggregationStateRequestSchema,
     response_schema=BIAggregationStateResponseSchema,
     permissions_required=RO_PERMISSIONS,
+    tag_group="Monitoring",
 )
 def get_bi_aggregation_state(params: Mapping[str, Any]) -> Response:
     """Get the state of BI aggregations"""

--- a/tests/unit/cmk/gui/plugins/openapi/test_openapi_bi.py
+++ b/tests/unit/cmk/gui/plugins/openapi/test_openapi_bi.py
@@ -5,6 +5,8 @@
 
 import json
 
+import pytest
+
 from tests.unit.cmk.gui.conftest import WebTestAppForCMK
 
 from cmk.utils.livestatus_helpers.testing import MockLiveStatusConnection
@@ -390,8 +392,9 @@ def test_openapi_delete_pack_forbidden(aut_user_auth_wsgi_app: WebTestAppForCMK)
     )
 
 
+@pytest.mark.parametrize("wato_enabled", [True, False])
 def test_get_aggregation_state_empty(  # type:ignore[no-untyped-def]
-    aut_user_auth_wsgi_app, mock_livestatus
+    aut_user_auth_wsgi_app, mock_livestatus, wato_enabled
 ) -> None:
     base = "/NO_SITE/check_mk/api/1.0"
     postfix = "/domain-types/bi_aggregation/actions/aggregation_state/invoke"
@@ -406,16 +409,18 @@ def test_get_aggregation_state_empty(  # type:ignore[no-untyped-def]
     )
 
     with live():
-        _response = aut_user_auth_wsgi_app.post(
-            url,
-            headers={"Accept": "application/json", "Content-Type": "application/json"},
-            status=200,
-            params=json.dumps({}),
-        )
+        with aut_user_auth_wsgi_app.set_config(wato_enabled=wato_enabled):
+            _response = aut_user_auth_wsgi_app.post(
+                url,
+                headers={"Accept": "application/json", "Content-Type": "application/json"},
+                status=200,
+                params=json.dumps({}),
+            )
 
 
+@pytest.mark.parametrize("wato_enabled", [True, False])
 def test_get_aggregation_state_filter_names(  # type:ignore[no-untyped-def]
-    aut_user_auth_wsgi_app, mock_livestatus
+    aut_user_auth_wsgi_app, mock_livestatus, wato_enabled
 ) -> None:
     base = "/NO_SITE/check_mk/api/1.0"
     postfix = "/domain-types/bi_aggregation/actions/aggregation_state/invoke"
@@ -430,9 +435,10 @@ def test_get_aggregation_state_filter_names(  # type:ignore[no-untyped-def]
     )
 
     with live():
-        _response = aut_user_auth_wsgi_app.post(
-            url,
-            headers={"Accept": "application/json", "Content-Type": "application/json"},
-            status=200,
-            params=json.dumps({"filter_names": ["Host heute"]}),
-        )
+        with aut_user_auth_wsgi_app.set_config(wato_enabled=wato_enabled):
+            _response = aut_user_auth_wsgi_app.post(
+                url,
+                headers={"Accept": "application/json", "Content-Type": "application/json"},
+                status=200,
+                params=json.dumps({"filter_names": ["Host heute"]}),
+            )


### PR DESCRIPTION
## Issue

When using "Check state of BI aggregation" on a host that is running on a read-only remote site, the checks will fail with `ERROR: Exception while opening URL: <URL> - 403 Client Error: FORBIDDEN for url: <URL>`.

When calling the same URL on CLI you get:
```json
{
  "title": "Forbidden: WATO is disabled",
  "status": 403,
  "detail": "This endpoint is currently disabled via the 'Disable remote configuration' option in 'Distributed Monitoring'. You may be able to query the central site."
}
```

## Reason

This is caused by the `tag_group` parameter being left on its default value `Setup` for the Endpoint of  `cmk.gui.plugins.openapi.endpoints.bi.get_bi_aggregation_state()`. As far as I can tell, there is no reason for this endpoint to be only available with WATO enabled, though.

## Solution

The fix itself is rather simple. By setting the parameter `tag_group="Monitoring"` on the aforementioned Endpoint, access is allowed from read-only sites as well.
The relevant unit tests have been updated to check both cases of WATO being enabled or disabled.

(Maybe the other GET endpoints in the BI group can be opened up as well. However, I am not entirely sure whether this would serve any actual purpose?)