### PR TITLE
Ibm svc eventlog 2.0.0 bugfix:  ValueError: too many values to unpack (expected 11)

### DIFF
--- a/checks/ibm_svc_eventlog
+++ b/checks/ibm_svc_eventlog
@@ -24,7 +24,7 @@ def check_ibm_svc_eventlog(item, _no_params, info):
     messagecount = 0
     last_err = ""
 
-    for _sequence_number, _last_timestamp, _object_type, _object_id, _object_name, _copy_id, _status, _fixed, _event_id, _error_code, description in info:
+    for _sequence_number, _last_timestamp, _object_type, _object_id, _object_name, _copy_id, _status, _fixed, _event_id, _error_code, description, *_ in info:
         messagecount += 1
         last_err = description
 


### PR DESCRIPTION
## General information

product_name IBM FlashSystem 900

This new IBM Storage Flash System now emits two extra (empty) fields.
See the last two colons:

```
OMD[prod]:~$ cmk -d <storagesystem>  | grep -A1 ibm_svc_eventlog 
<<<ibm_svc_eventlog:sep(58)>>>
164:220522214408:enclosure:1:::alert:no:085044:1114:Enclosure Battery fault type 1::
```

This causes an **ValueError: too many values to unpack (expected 11)**
because it now gets 13 values and only 11 are expected.

This fix just adds *_  (multiple placeholders)  to catch the (unneeded) extra fields  index 12 and 13.

This is the info dict:

[['164',
  '220522214408',
  'enclosure',
  '1',
  '',
  '',
  'alert',
  'no',
  '085044',
  '1114',
  'Enclosure Battery fault type 1',
  '',
  '']]

I noticed that in the master branch the formatting was changed, I did this fix on 2.0.0p26 therefore I am sending a diff for 2.0.0 branch, but the master branch also needs such an *_  catch all variable.

Thank you
Jodok