### PR TITLE
ibm_svc_systemstats 2.0.0 bugfix metric value casting problem, float() instead of int() needed

### DIFF
--- a/checks/ibm_svc_systemstats
+++ b/checks/ibm_svc_systemstats
@@ -66,19 +66,19 @@ def ibm_svc_systemstats_parse(info):
             if "VDisks" not in parsed:
                 parsed["VDisks"] = {}
             stat_name = stat_name.replace("vdisk_", "")
-            parsed["VDisks"][stat_name] = int(stat_current)
+            parsed["VDisks"][stat_name] = float(stat_current)
         if stat_name in ("mdisk_r_mb", "mdisk_w_mb", "mdisk_r_io", "mdisk_w_io", "mdisk_r_ms",
                          "mdisk_w_ms"):
             if "MDisks" not in parsed:
                 parsed["MDisks"] = {}
             stat_name = stat_name.replace("mdisk_", "")
-            parsed["MDisks"][stat_name] = int(stat_current)
+            parsed["MDisks"][stat_name] = float(stat_current)
         if stat_name in ("drive_r_mb", "drive_w_mb", "drive_r_io", "drive_w_io", "drive_r_ms",
                          "drive_w_ms"):
             if "Drives" not in parsed:
                 parsed["Drives"] = {}
             stat_name = stat_name.replace("drive_", "")
-            parsed["Drives"][stat_name] = int(stat_current)
+            parsed["Drives"][stat_name] = float(stat_current)
     return parsed
 
 


### PR DESCRIPTION
Thank you for your interest in contributing to Checkmk!
Unfortunately, due to our current work load, we only consider pure bug fixes as stated in our [Readme](https://github.com/tribe29/checkmk#want-to-contribute).
This means any new pull request that is not a pure bug fix will be closed.
Instead of creating a PR, please consider sharing new check plugins, agent plugins, special agents or notification plugins via the [Checkmk Exchange](https://exchange.checkmk.com/).

## Bug reports
Running  `cmk -IIv <hostname>` returns:

```
  WARNING: Exception in discovery function of check plugin 'ibm_svc_systemstats_iops': invalid literal for int() with base 10: '0.338'
  WARNING: Exception in discovery function of check plugin 'ibm_svc_systemstats_disk_latency': invalid literal for int() with base 10: '0.338'
  WARNING: Exception in discovery function of check plugin 'ibm_svc_systemstats_diskio': invalid literal for int() with base 10: '0.338'
  1 ibm_svc_array
  1 ibm_svc_disks
  1 ibm_svc_enclosure
  1 ibm_svc_enclosurestats_power
  1 ibm_svc_enclosurestats_temp
  1 ibm_svc_eventlog
  1 ibm_svc_host
  1 ibm_svc_mdisk
  1 ibm_svc_mdiskgrp
  8 ibm_svc_portfc
  1 ibm_svc_system
  1 ibm_svc_systemstats_cache
  1 ibm_svc_systemstats_cpu_util
```

The agent output shows that it not only contains int values but also floats:

```
OMD[sap]:~/var/check_mk$ cmk -d <hostname> | grep -A 50 '<<<ibm_svc_systemstats'
<<<ibm_svc_systemstats:sep(58)>>>
stat_name:stat_current:stat_peak:stat_peak_time
compression_cpu_pc:0:0:220823104755
cpu_pc:17:25:220823104305
fc_mb:1771:2890:220823104300
fc_io:44820:54912:220823104620
sas_mb:0:0:220823104755
sas_io:0:0:220823104755
iscsi_mb:0:0:220823104755
iscsi_io:0:0:220823104755
write_cache_pc:34:53:220823104305
total_cache_pc:80:80:220823104755
vdisk_mb:1772:2890:220823104300
vdisk_io:44820:54911:220823104620
vdisk_ms:0.309:0.419:220823104330
mdisk_mb:1830:2964:220823104305
mdisk_io:41564:55615:220823104615
mdisk_ms:0.320:0.397:220823104305
drive_mb:4693:7113:220823104305
drive_io:90957:127705:220823104305
drive_ms:0.238:0.299:220823104400
vdisk_r_mb:1271:2111:220823104640
vdisk_r_io:33292:43974:220823104620
vdisk_r_ms:0.348:0.521:220823104330
vdisk_w_mb:499:1514:220823104305
vdisk_w_io:11529:19151:220823104510
vdisk_w_ms:0.196:0.354:220823104305
mdisk_r_mb:1354:2386:220823104640
mdisk_r_io:33097:46042:220823104620
mdisk_r_ms:0.284:0.349:220823104405
mdisk_w_mb:475:1451:220823104305
mdisk_w_io:8466:15661:220823104305
mdisk_w_ms:0.458:0.481:220823104305
drive_r_mb:3656:4931:220823104640
drive_r_io:63916:84330:220823104555
drive_r_ms:0.271:0.357:220823104400
drive_w_mb:1036:2636:220823104305
drive_w_io:27040:51764:220823104305
drive_w_ms:0.158:0.194:220823104305
power_w:867:869:220823104725
temp_c:21:21:220823104755
temp_f:69:69:220823104755
iplink_mb:0:0:220823104755
iplink_io:0:0:220823104755
iplink_comp_mb:0:0:220823104755
cloud_up_mb:0:0:220823104755
cloud_up_ms:0:0:220823104755
cloud_down_mb:0:0:220823104755
cloud_down_ms:0:0:220823104755
iser_mb:0:0:220823104755
iser_io:0:0:220823104755
```

While debugging this I added `from pprint import pprint` and added a pprint(info) in `def ibm_svc_systemstats_parse(info)` this is the info list of lists:

```
[['stat_name', 'stat_current', 'stat_peak', 'stat_peak_time'],
 ['compression_cpu_pc', '0', '0', '220823105008'],
 ['cpu_pc', '15', '23', '220823104913'],
 ['fc_mb', '1675', '2646', '220823104908'],
 ['fc_io', '40493', '56730', '220823104617'],
 ['sas_mb', '0', '0', '220823105008'],
 ['sas_io', '0', '0', '220823105008'],
 ['iscsi_mb', '0', '0', '220823105008'],
 ['iscsi_io', '0', '0', '220823105008'],
 ['write_cache_pc', '34', '43', '220823104908'],
 ['total_cache_pc', '80', '80', '220823105008'],
 ['vdisk_mb', '1675', '2646', '220823104908'],
 ['vdisk_io', '40491', '56729', '220823104617'],
 ['vdisk_ms', '0.309', '0.375', '220823104913'],
 ['mdisk_mb', '1857', '2924', '220823104913'],
 ['mdisk_io', '38876', '57265', '220823104617'],
 ['mdisk_ms', '0.326', '0.383', '220823104913'],
 ['drive_mb', '4462', '7305', '220823104913'],
 ['drive_io', '83200', '131877', '220823104642'],
 ['drive_ms', '0.263', '0.316', '220823104923'],
 ['vdisk_r_mb', '1339', '1942', '220823104637'],
 ['vdisk_r_io', '29892', '46306', '220823104617'],
 ['vdisk_r_ms', '0.353', '0.417', '220823104647'],
 ['vdisk_w_mb', '336', '1199', '220823104908'],
 ['vdisk_w_io', '10599', '16529', '220823104908'],
 ['vdisk_w_ms', '0.185', '0.295', '220823104913'],
 ['mdisk_r_mb', '1534', '2207', '220823104637'],
 ['mdisk_r_io', '31226', '49065', '220823104617'],
 ['mdisk_r_ms', '0.294', '0.334', '220823104913'],
 ['mdisk_w_mb', '321', '1304', '220823104913'],
 ['mdisk_w_io', '7650', '15009', '220823104908'],
 ['mdisk_w_ms', '0.459', '0.486', '220823104913'],
 ['drive_r_mb', '3630', '4834', '220823104642'],
 ['drive_r_io', '59155', '86604', '220823104642'],
 ['drive_r_ms', '0.306', '0.355', '220823104923'],
 ['drive_w_mb', '832', '2473', '220823104913'],
 ['drive_w_io', '24046', '48537', '220823104913'],
 ['drive_w_ms', '0.155', '0.189', '220823104913'],
 ['power_w', '867', '872', '220823104938'],
 ['temp_c', '21', '21', '220823105008'],
 ['temp_f', '69', '69', '220823105008'],
 ['iplink_mb', '0', '0', '220823105008'],
 ['iplink_io', '0', '0', '220823105008'],
 ['iplink_comp_mb', '0', '0', '220823105008'],
 ['cloud_up_mb', '0', '0', '220823105008'],
 ['cloud_up_ms', '0', '0', '220823105008'],
 ['cloud_down_mb', '0', '0', '220823105008'],
 ['cloud_down_ms', '0', '0', '220823105008'],
 ['iser_mb', '0', '0', '220823105008'],
 ['iser_io', '0', '0', '220823105008']]
```

I then just changed a few int() to float() casts.

Thank you.

 