### PR TITLE
Fix keyerror in heartbeat_crm when param not defined in setup/wato

### DIFF
--- a/cmk/base/plugins/agent_based/heartbeat_crm.py
+++ b/cmk/base/plugins/agent_based/heartbeat_crm.py
@@ -341,7 +341,7 @@ def check_heartbeat_crm(params: Mapping[str, Any], section: Section) -> CheckRes
         return
 
     # Check for correct DC when enabled
-    if (p_dc := params["dc"]) is None or dc == p_dc:
+    if (p_dc := params.get("dc")) is None or dc == p_dc:
         yield Result(state=State.OK, summary=f"DC: {dc}")
     else:
         yield Result(state=State.CRIT, summary=f"DC: {dc} (Expected {p_dc})")


### PR DESCRIPTION
This fixes a key-error-exception occuring in the new heartbeat_crm