### PR TITLE
agent_prometheus: fixed promql mode (init, query quoting), API prefix…

### DIFF
--- a/cmk/special_agents/agent_prometheus.py
+++ b/cmk/special_agents/agent_prometheus.py
@@ -1529,7 +1529,10 @@ class PrometheusAPI:
 
     def __init__(self, session) -> None:  # type:ignore[no-untyped-def]
         self.session = session
-        self.scrape_targets_dict = self._connected_scrape_targets()
+
+    @property
+    def scrape_targets_dict(self) -> Dict[str, Any]:
+        return self._connected_scrape_targets()
 
     def scrape_targets_attributes(self) -> Iterator[Tuple[str, Dict[str, Any]]]:
         """Format the scrape_targets_dict for information processing
@@ -1622,7 +1625,7 @@ class PrometheusAPI:
             return []
 
     def _perform_promql_query(self, promql: str) -> List[Dict[str, Any]]:
-        api_query_expression = "query?query=%s" % quote(promql)
+        api_query_expression = "query?query=%s" % promql
         result = self._process_json_request(api_query_expression)["data"]["result"]
         return result
 

--- a/cmk/special_agents/utils/prometheus.py
+++ b/cmk/special_agents/utils/prometheus.py
@@ -43,10 +43,13 @@ def extract_connection_args(config):
 
     address = config["host_address"] if connect_type == "ip_address" else config["host_name"]
 
-    if "path-prefix" in connect_settings:
-        address = f"{connect_settings['path-prefix']}{address}"
+    path_prefix = connect_settings.get("path-prefix", "")
+    if path_prefix:
+        path_prefix = path_prefix + "/"
 
-    connection_args.update({"address": address, "port": connect_settings.get("port")})
+    connection_args.update(
+        {"address": address, "path-prefix": path_prefix, "port": connect_settings.get("port")}
+    )
     return connection_args
 
 
@@ -60,7 +63,7 @@ def generate_api_session(connection_options):
     else:
         api_url = parse_api_url(
             server_address=connection_options["address"],
-            api_path="api/v1/",
+            api_path=connection_options["path-prefix"] + "api/v1/",
             protocol=connection_options["protocol"],
             port=connection_options["port"],
         )


### PR DESCRIPTION
- Handling of Prometheus API prefix was broken. (`https://customprefix192.33.22.11:443/api/v1` - should be `https://192.33.22.11:443/customprefix/api/v1` ) Related forum post: https://forum.checkmk.com/t/prometheus-with-custom-url/28679/2
- The special agent runs into a timeout if you only specify a custom PromQL query (=without setting any other scrape target). It directly tries to scrape connected targets even if they are not needed. This fails for PromQL-only rules. I made this a property so that the associated method gets only called when needed. 
- The Prometheus API is not happy with quoted query strings (e.g. `query?query=notifications_sent_out_total%7Binstance%3Dweb-push%3A8080%2C%20job%3Dweb-push%2C%20notification_type%3DPushNotification%`). Without quoting, it runs fine. 

Best regards,
Simon