### PR TITLE
postfix: correct detection of path to master.pid

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -998,8 +998,8 @@ section_mailqueue() {
             for queue_dir in ${multi_instances_dirs}; do
                 if [ -n "${queue_dir}" ]; then
                     postfix_queue_dir=$(postconf -c "${queue_dir}" 2>/dev/null | grep ^queue_directory | sed 's/.*=[[:space:]]*//g')
+                    read_postfix_queue_dirs "${postfix_queue_dir}" "${queue_dir}"
                     postfix_instance_name=$(postconf -c "${queue_dir}" -h multi_instance_name 2>/dev/null)
-                    read_postfix_queue_dirs "${postfix_queue_dir}" "${postfix_instance_name}"
                     read_postfix_master_pid "${postfix_queue_dir}" "${postfix_instance_name}"
                 fi
             done

--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -966,6 +966,27 @@ read_postfix_queue_dirs() {
     fi
 }
 
+## Postfix status monitoring
+read_postfix_master_pid() {
+    postfix_queue_dir=${1}
+    postfix_instance_name=${2:-postfix}
+    echo "<<<postfix_mailq_status:sep(58)>>>"
+    if [ -e "${postfix_queue_dir}/pid/master.pid" ]; then
+        if [ -r "${postfix_queue_dir}/pid/master.pid" ]; then
+            postfix_pid=$(sed 's/ //g' <"${postfix_queue_dir}/pid/master.pid") # handle possible spaces in output
+            if readlink -- "/proc/${postfix_pid}/exe" | grep -q ".*postfix/\(s\?bin/\)\?master.*"; then
+                echo "${postfix_instance_name}:the Postfix mail system is running:PID:${postfix_pid}"
+            else
+                echo "${postfix_instance_name}:PID file exists but instance is not running!"
+            fi
+        else
+            echo "${postfix_instance_name}:PID file exists but is not readable"
+        fi
+    else
+        echo "${postfix_instance_name}:the Postfix mail system is not running"
+    fi
+}
+
 ## Postfix mailqueue monitoring
 ## Determine the number of mails and their size in several postfix mail queue
 section_mailqueue() {
@@ -977,37 +998,19 @@ section_mailqueue() {
             for queue_dir in ${multi_instances_dirs}; do
                 if [ -n "${queue_dir}" ]; then
                     postfix_queue_dir=$(postconf -c "${queue_dir}" 2>/dev/null | grep ^queue_directory | sed 's/.*=[[:space:]]*//g')
-                    read_postfix_queue_dirs "${postfix_queue_dir}" "${queue_dir}"
+                    postfix_instance_name=$(postconf -c "${queue_dir}" -h multi_instance_name 2>/dev/null)
+                    read_postfix_queue_dirs "${postfix_queue_dir}" "${postfix_instance_name}"
+                    read_postfix_master_pid "${postfix_queue_dir}" "${postfix_instance_name}"
                 fi
             done
         fi
         # Always check for the default queue. It can exist even if multiple instances are configured
         read_postfix_queue_dirs "$(postconf -h queue_directory 2>/dev/null)"
+        read_postfix_master_pid "$(postconf -h queue_directory 2>/dev/null)"
 
     elif [ -x /usr/sbin/ssmtp ]; then
         echo '<<<postfix_mailq>>>'
         mailq 2>&1 | sed 's/^[^:]*: \(.*\)/\1/' | tail -n 6
-    fi
-
-    # Postfix status monitoring. Can handle multiple instances.
-    if inpath postfix; then
-        echo "<<<postfix_mailq_status:sep(58)>>>"
-        for i in /var/spool/postfix*/; do
-            if [ -e "${i}/pid/master.pid" ]; then
-                if [ -r "${i}/pid/master.pid" ]; then
-                    postfix_pid=$(sed 's/ //g' <"${i}/pid/master.pid") # handle possible spaces in output
-                    if readlink -- "/proc/${postfix_pid}/exe" | grep -q ".*postfix/\(s\?bin/\)\?master.*"; then
-                        echo "${i}:the Postfix mail system is running:PID:${postfix_pid}" | sed 's/\/var\/spool\///g'
-                    else
-                        echo "${i}:PID file exists but instance is not running!" | sed 's/\/var\/spool\///g'
-                    fi
-                else
-                    echo "${i}:PID file exists but is not readable"
-                fi
-            else
-                echo "${i}:the Postfix mail system is not running" | sed 's/\/var\/spool\///g'
-            fi
-        done
     fi
 
     # Check status of qmail mailqueue


### PR DESCRIPTION
## General information

The patch changes affects the linux agents postfix sections
 "postfix_mailq" and "postfix_mailq_status".

## Bug reports

Please include:

+ Your operating system name and version
  SLES 11.X to SLES 12
  Ubuntu 18.04 & 20.04
+ Any details about your local setup that might be helpful in troubleshooting
  We have a Multi-Instance Setup of postfix, where the queue_directories are not in the usual place
  usual is /var/spool/postix* but we choose other directory

## Proposed changes

+ What is the expected behavior?
  The Agent should use the in configuration defined queue_directories, to determine the master,pid
+ What is the observed behavior?
  The Agent only looks in /var/spool/postfix*
+ If it's not obvious from the above: In what way does your patch change the current behavior?
 The patch uses the queue_directories defined in configurations, it reuses the loop for queue size.
  Because the name of the directories is not always different (the check only uses first part of path), i implement to use the multi_instance_name of the postfix instance. The multi_instance_name is always uniqe to a postfix configuration.
  This may lead to some changing service names, depends on the configuration of the postfix (if instance_name and dir_name differ) 
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
  We do a roleout of the agent to some of our devices and saw that some of our postfix instances are not properly detected.
