### PR TITLE
Fix Solaris agent section header quoting

### DIFF
--- a/agents/check_mk_agent.solaris
+++ b/agents/check_mk_agent.solaris
@@ -498,7 +498,7 @@ section_cpu() {
 section_zpool() {
     # zpool status
     if [ -x /sbin/zpool ]; then
-        run_cached "zpool_status" 120 "echo <<<zpool_status>>>; /sbin/zpool status -x"
+        run_cached "zpool_status" 120 "echo '<<<zpool_status>>>'; /sbin/zpool status -x"
 
         ${MK_RUN_SYNC_PARTS} || return
 
@@ -534,7 +534,7 @@ section_solaris_prtg() {
         # prtdiag does not work in local zones
         if [ "${zonename}" == "global" ]; then
             run_cached "solaris_prtdiag_status" 300 \
-                'echo <<<solaris_prtdiag_status>>>; /usr/sbin/prtdiag 1>/dev/null 2>&1; echo $?'
+                'echo "<<<solaris_prtdiag_status>>>"; /usr/sbin/prtdiag 1>/dev/null 2>&1; echo $?'
         fi
     fi
 }


### PR DESCRIPTION
Fix the necessary bash quoting to print the `<<<zpool_status>>>` and `<<<solaris_prtdiag_status>>>` headers correctly. Otherwise these sections are missing in the current Solaris agent output.

> Your operating system name and version

SunOS 5.11, Kernel 11.4.43.113.3

> Detailed steps to reproduce the bug

1. Copy the current Solaris `check_mk_agent.solaris` to a Solaris global zone with a zpool.
2. Run the agent manually.
3. Observe (grep) the missing `zpool_status` and `solaris_prtdiag_status` sections.

> What is the expected behavior?

Mentioned sections are present.

> What is the observed behavior?

Mentioned sections are missing.

> Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?

We ran into problems with cached local checks on Solaris at a customer site after upgrading to CMK EE 2.1.0p11. After troubleshooting a bit, we decided to try the current master's version of `check_mk_agent.solaris`. With that, the cached local checks work again, but the `zpool_status` and `solaris_prtdiag_status` were still missing. Root cause seems to be Werk 12906's commit abf9c44b56b039d8929882cb9495a297fb2c7fba.