### PR TITLE
Add checking mountoptions for fuse filesystems

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -624,7 +624,7 @@ section_nfs_mounts() {
 
 section_mounts() {
     echo '<<<mounts>>>'
-    grep ^/dev </proc/mounts | grep -v " squashfs "
+    grep -E "^/dev|fuse\." </proc/mounts | grep -v " squashfs "
 }
 
 section_ps() {


### PR DESCRIPTION
check mountoptions for fuse filesystems e.g. glusterfs mountpoints. I understand that remote filesystems are excluded in DF section with -l option to avoid hanging agent. But it would be nice if the agent could at least check mountpoint and options out of the box without custom local check.

Thank you for your interest in contributing to Checkmk!
Unfortunately, due to our current work load, we only consider pure bug fixes as stated in our [Readme](https://github.com/tribe29/checkmk#want-to-contribute).
This means any new pull request that is not a pure bug fix will be closed.
Instead of creating a PR, please consider sharing new check plugins, agent plugins, special agents or notification plugins via the [Checkmk Exchange](https://exchange.checkmk.com/).

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
