### PR TITLE
mk_apt

### DIFF
--- a/agents/plugins/mk_apt
+++ b/agents/plugins/mk_apt
@@ -37,7 +37,7 @@ check_apt_update() {
         # 1397BC53640DB551
         apt-get update -qq 2>/dev/null
     fi
-    apt-get -o 'Debug::NoLocking=true' -o 'APT::Get::Show-User-Simulation-Note=false' -s -qq "$UPGRADE" | grep -v '^Conf'
+    apt-get -o 'Debug::NoLocking=true' -o 'APT::Get::Show-User-Simulation-Note=false' -s -qq "$UPGRADE" | grep -E -v '^(Conf|Try|Learn)'
 }
 
 if type apt-get >/dev/null; then

--- a/agents/plugins/mk_apt
+++ b/agents/plugins/mk_apt
@@ -37,7 +37,7 @@ check_apt_update() {
         # 1397BC53640DB551
         apt-get update -qq 2>/dev/null
     fi
-    apt-get -o 'Debug::NoLocking=true' -o 'APT::Get::Show-User-Simulation-Note=false' -s -qq "$UPGRADE" | grep -E -v '^(Conf|Try|Learn)'
+    apt-get -o 'Debug::NoLocking=true' -o 'APT::Get::Show-User-Simulation-Note=false' -s -qq "$UPGRADE" | grep -v '^Conf'
 }
 
 if type apt-get >/dev/null; then


### PR DESCRIPTION

## General information

With the new Ubuntu upgrades the mk_apt check does not work anymore.

## Bug reports

mk_apt of Ubuntu 20.04.5 LTS writes two new lines into output which must not be in the agent output:
![Ubuntu 20 04 5 LTS-mk_apt](https://user-images.githubusercontent.com/3239736/194834144-31b21eaa-fde0-4ef9-9586-4c32661200a0.png)

## Proposed changes

So I enhanced the filtering grep command to "grep -E -v '^(Conf|Try|Learn)"