### PR TITLE
Fix Typo: Deamon -> Daemon

### DIFF
--- a/checkman/isc_dhcpd
+++ b/checkman/isc_dhcpd
@@ -1,4 +1,4 @@
-title: Linux ISC DHCP-Deamon DHCP Pools: Number of Free Addresses
+title: Linux ISC DHCP-Daemon DHCP Pools: Number of Free Addresses
 agents: linux
 catalog: os/services
 license: GPLv2

--- a/checkman/mysql
+++ b/checkman/mysql
@@ -4,7 +4,7 @@ catalog: app/mysql
 license: GPLv2
 distribution: check_mk
 description:
- This check only shows the Version of the runnin MySQL Deamon.
+ This check only shows the Version of the runnin MySQL Daemon.
 
  This check needs the agent plugin {mk_mysql} to be installed.
  Further details about this plugin and monitoring of MySQL can be

--- a/checkman/mysql_ping
+++ b/checkman/mysql_ping
@@ -1,11 +1,11 @@
-title: MySQL: Status of Deamon
+title: MySQL: Status of Daemon
 agents: linux
 catalog: app/mysql
 license: GPLv2
 distribution: check_mk
 description:
- This check checks if the MySQL deamon is alive and a connection is possible.
- Otherwiese it returns {CRIT}. This check can also be used to detect wrong or
+ This check checks if the MySQL daemon is alive and a connection is possible.
+ Otherwise it returns {CRIT}. This check can also be used to detect wrong or
  unconfigured mk_mysql plugins.
 
  This check needs the agent plugin {mk_mysql} to be installed.

--- a/checks/mysql_ping
+++ b/checks/mysql_ping
@@ -18,7 +18,7 @@ from cmk.base.check_legacy_includes.mysql import *  # pylint: disable=wildcard-i
 def check_mysql_ping(_no_item, _no_params, data):
     message = " ".join(data[0])
     if message == "mysqld is alive":
-        return 0, "MySQL Deamon is alive"
+        return 0, "MySQL Daemon is alive"
     return 2, message
 
 

--- a/locale/de/LC_MESSAGES/multisite.po
+++ b/locale/de/LC_MESSAGES/multisite.po
@@ -35712,7 +35712,7 @@ msgid ""
 "Better disable it."
 msgstr ""
 "Persistente Verbindungen sind nahezu nutzlos, wenn Sie den Livestaus-Proxy-"
-"Deamon einsetzen. Deaktivieren Sie diese besser."
+"Daemon einsetzen. Deaktivieren Sie diese besser."
 
 msgid ""
 "Persistent connections may be a configuration to improve the performance of "

--- a/tests/unit/checks/generictests/datasets/mysql_ping_1_regression.py
+++ b/tests/unit/checks/generictests/datasets/mysql_ping_1_regression.py
@@ -33,6 +33,6 @@ checks = {
     '': [
         ('mysql', {}, [(2, 'this line is no longer ignored', [])]),
         ('elephant', {}, [(2, "mysqladmin: connect to server at 'localhost' failed", [])]),
-        ('moth', {}, [(0, 'MySQL Deamon is alive', [])]),
+        ('moth', {}, [(0, 'MySQL Daemon is alive', [])]),
     ],
 }


### PR DESCRIPTION
This fixes a typo (`deamon` instead of `daemon`) in several places.

I only fixed the typo where it is visible (help pages, check output, translation). There's more of it in the codebase though: https://github.com/tribe29/checkmk/search?q=deamon