### PR TITLE
Apply Werk #13431: Fix async checks blocked by realtime checks in version 2.0.0

### DIFF
--- a/agents/check_mk_agent.linux
+++ b/agents/check_mk_agent.linux
@@ -1120,7 +1120,7 @@ run_liveupdate() {
         else
             for trigger in "${MK_VARDIR}/rtc_remotes/"?*; do
                 # no such file => no expansion of ?* => nothing to do
-                [ -e "${trigger}" ] && run_real_time_checks_for_remote "${trigger}" >/dev/null &
+                [ -e "${trigger}" ] && { run_real_time_checks_for_remote "${trigger}" >/dev/null & }
             done
         fi
     fi


### PR DESCRIPTION
Apply Werk #13431: Fix async checks blocked by realtime checks in version 2.0.0

Signed-off-by: Sven Rueß <github@sven-ruess.de>

## General information

https://checkmk.com/de/werk/13431
Is missing in current supported version. This should be also added to fix this issue in this version.

## Bug reports

Real-Time checks are not working on Linux based systems.

## Proposed changes

Added the same changes which you did in version 2.1.0 and master.