### PR TITLE
Translate $HOSTNAME$ and $HOSTADDRESS$ in aggregation name

### DIFF
--- a/cmk/gui/plugins/views/icons/builtin.py
+++ b/cmk/gui/plugins/views/icons/builtin.py
@@ -1183,6 +1183,8 @@ class AggregationIcon(Icon):
             start = args.find("-a' '") + 5
             end = args.find("' ", start)
             aggr_name = args[start:end]
+            aggr_name = aggr_name.replace("$HOSTADDRESS$", row["host_address"])
+            aggr_name = aggr_name.replace("$HOSTNAME$", row["host_name"])
 
             url = "%s/check_mk/view.py?view_name=aggr_single&aggr_name=%s" % (
                 base_url,


### PR DESCRIPTION
Signed-off-by: Sven Rueß <github@sven-ruess.de>

## General information

Inline help is providing information, that both variables $HOSTADDRESS$ and $HOSTNAME$ can be used in aggregation name.
But those variables are never replaced during processing and link in action menu (Open this aggregation) is not working.

## Bug reports

Setup a rule for checking dynamic BIs with $HOSTNAME$ in aggregation name. 
Link in action menu "Open this aggregation" is not working because $HOSTNAME$ is not replaced by hostname.

## Proposed changes

Variables should be replaced in aggregation name, that links are working.
This is now added. All current supported versions (1.6.0, 2.0.0, 2.1.0) are affected.