### PR TITLE
add Documentation URL

### DIFF
--- a/agents/scripts/super-server/0_systemd/check-mk-agent@.service
+++ b/agents/scripts/super-server/0_systemd/check-mk-agent@.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Checkmk agent
+Documentation=https://docs.checkmk.com/latest/en/agent_linux.html
 
 [Service]
 # "-" path prefix makes systemd record the exit code,


### PR DESCRIPTION
Hello,

I'm working on https://salsa.debian.org/check_mk_agent-team/check-mk-agent
to integrate it into upcoming debian relese bookworm.
This PR would fix a lintian warning about documentation in systemd unit.

Best Regards,
Juri Grabowski