### PR TITLE
Localconnect

### DIFF
--- a/agents/scripts/super-server/0_systemd/check-mk-agent.socket.fallback
+++ b/agents/scripts/super-server/0_systemd/check-mk-agent.socket.fallback
@@ -13,3 +13,4 @@ MaxConnectionsPerSource=3
 
 [Install]
 WantedBy=sockets.target
+IPAddressDeny=0.0.0.0/0 ::/0

--- a/agents/scripts/super-server/1_xinetd/check-mk-agent
+++ b/agents/scripts/super-server/1_xinetd/check-mk-agent
@@ -42,3 +42,4 @@ service check-mk-agent
 
     disable        = no
 }
+    only_from      = 127.0.0.1


### PR DESCRIPTION
Hello,

I'm working on https://salsa.debian.org/check_mk_agent-team/check-mk-agent
And with this PR I try to integrate following patches: 
https://salsa.debian.org/check_mk_agent-team/check-mk-agent/-/blob/debian/latest/debian/patches/0002-allow-xinetd-connect-only-from-127.0.0.1-per-default.patch
https://salsa.debian.org/check_mk_agent-team/check-mk-agent/-/blob/debian/latest/debian/patches/0003-allow-systemd-connect-only-from-127.0.0.1-per-default.patch

into upcoming debian release bookworm.
This PR would fix ftp-master reject about public connect.

Best Regards,
Juri Grabowski