### PR TITLE
Use GetAllBackupSyncAndTape inplace of Get-VBRTapeJob

### DIFF
--- a/agents/windows/plugins/veeam_backup_status.ps1
+++ b/agents/windows/plugins/veeam_backup_status.ps1
@@ -37,7 +37,7 @@ catch {
 
 try
 {
-$tapeJobs = Get-VBRTapeJob
+$tapeJobs = [Veeam.Backup.Core.CBackupJob]::GetAllBackupSyncAndTape()
 write-host "<<<veeam_tapejobs:sep(124)>>>"
 write-host "JobName|JobID|LastResult|LastState"
 foreach ($tapeJob in $tapeJobs)


### PR DESCRIPTION
## General information

Get-VBRTapeJob is known[1] to be slow as it reports all tape jobs with *all* state and result informations. GetAllBackupSyncAndTape only returns the latest state and result ans is much quicker on busy environment.

[1] https://forums.veeam.com/powershell-f26/get-vbrtapejob-slow-t41784.html

## Bug reports

 * Windows 2019
 * Veeam 11

## Proposed changes

 * Use GetAllBackupSyncAndTape inplace of Get-VBRTapeJob
 
