### PR TITLE
Honor elphase state map in raritan_px_outlets check

### DIFF
--- a/checks/raritan_px_outlets
+++ b/checks/raritan_px_outlets
@@ -41,9 +41,10 @@ def parse_raritan_px_outlets(info):
         "2": (0, "cycling"),
     }
     parsed = {}
-    for index, state, current_str, voltage_str, power_str, appower_str, energy_str in info:
+    for index, label, state, current_str, voltage_str, power_str, appower_str, energy_str in info:
         parsed[index] = {
             "device_state": map_state.get(state, (3, "unknown")),
+            "label": label,
             "current": float(current_str) / 1000,
             "voltage": float(voltage_str) / 1000,
             "power": float(power_str),
@@ -60,6 +61,8 @@ def inventory_raritan_px_outlets(parsed):
 
 def check_raritan_px_outlets(item, params, parsed):
     if item in parsed:
+        if parsed[item]["label"]:
+            yield 0, "[%s]" % parsed[item]["label"]
         yield from check_elphase(item, params, parsed)
 
 
@@ -73,6 +76,7 @@ check_info["raritan_px_outlets"] = {
         ".1.3.6.1.4.1.13742.4.1.2.2.1",
         [
             "1",  # outletIndex
+            "2",  # outletLabel
             "3",  # outletOperationalState
             "4",  # outletCurrent
             "6",  # outletVoltage

--- a/checks/raritan_px_outlets
+++ b/checks/raritan_px_outlets
@@ -43,7 +43,7 @@ def parse_raritan_px_outlets(info):
     parsed = {}
     for index, state, current_str, voltage_str, power_str, appower_str, energy_str in info:
         parsed[index] = {
-            "state": map_state.get(state, (3, "unknown")),
+            "device_state": map_state.get(state, (3, "unknown")),
             "current": float(current_str) / 1000,
             "voltage": float(voltage_str) / 1000,
             "power": float(power_str),
@@ -55,15 +55,12 @@ def parse_raritan_px_outlets(info):
 
 
 def inventory_raritan_px_outlets(parsed):
-    return [(index, {}) for index, values in parsed.items() if values["state"][1] == "on"]
+    return [(index, {}) for index, values in parsed.items() if values["device_state"][1] == "on"]
 
 
 def check_raritan_px_outlets(item, params, parsed):
     if item in parsed:
-        state, state_readable = parsed[item]["state"]
-        yield state, "Operational status: %s" % state_readable
-        for result in check_elphase(item, params, parsed):
-            yield result
+        yield from check_elphase(item, params, parsed)
 
 
 check_info["raritan_px_outlets"] = {


### PR DESCRIPTION
## General information

The check for monitoring Raritan PX outlets currently ignores the "Map device state" parameter of the "Parameters for input phases of UPSs and PDUs" ruleset.

## Proposed changes

This simple renaming keeps the old behaviour if this parameter is unset (albeit changing output slightly).