### PR TITLE
Fix AttributeError in IPMI fetcher on ThinkSystem

### DIFF
--- a/cmk/core_helpers/ipmi.py
+++ b/cmk/core_helpers/ipmi.py
@@ -191,7 +191,9 @@ class IPMIFetcher(Fetcher[AgentRawData]):
         output = b"<<<ipmi_firmware:sep(124)>>>\n"
         for entity_name, attributes in firmware_entries:
             for attribute_name, value in attributes.items():
-                output += b"|".join(f.encode("utf8") for f in (entity_name, attribute_name, value))
+                output += b"|".join(
+                    str(f).encode("utf8") for f in (entity_name, attribute_name, value)
+                )
                 output += b"\n"
 
         return AgentRawData(output)


### PR DESCRIPTION
## General information

We added a Lenovo ThinkSystem's XClarity BMC to the list of monitored hosts.

## Bug reports

After a few patches to pyghmi (which are probably already upstream, but CMK's version is quite dated), `pyghmiutil 192.2.0.1 user sensors` printed everything just fine (and then hang, as it usually does).

However, `cmk --debug -vv -I` contained this output:
```
+ PARSE FETCHER RESULTS
  Source: SourceType.MANAGEMENT/FetcherType.IPMI
  -> Not adding sections: AttributeError("'datetime.datetime' object has no attribute 'encode'")
```
and did not add a single IPMI sensor.

While a bit hard to troubleshoot (since this exception does not seem to be available anywhere in detail), we determined that this must be the relevant line:
https://github.com/tribe29/checkmk/blob/63a84002ff2f66b214f2ef8031bed700617f5fd5/cmk/core_helpers/ipmi.py#L194
Indeed printing those three variables yielded:
```
XCC version 7.80                                                                                                                        
XCC build CDI388M                                                                                                                                                                                                                                                                
XCC date 2021-11-04 08:29:47                                                                                                            
```
...the last of which clearly is a datetime!

## Proposed changes

Simply convert everything to a string before it is encoded to UTF-8.