### PR TITLE
agents/plugins/mk_postgres: remove shared object stats

### DIFF
--- a/agents/plugins/mk_postgres.py
+++ b/agents/plugins/mk_postgres.py
@@ -247,7 +247,7 @@ class PostgresBase:
         sql_cmd = (
             "SELECT datid, datname, numbackends, xact_commit, xact_rollback, blks_read, "
             "blks_hit, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, "
-            "pg_database_size(datname) AS datsize FROM pg_stat_database;"
+            "pg_database_size(datname) AS datsize FROM pg_stat_database WHERE datname IS NOT NULL;"
         )
         return self.run_sql_as_db_user(sql_cmd, rows_only=False, extra_args="-P footer=off")
 


### PR DESCRIPTION
Signed-off-by: morph027 <stefan.heitmueller@gmx.com>

Thank you for your interest in contributing to Checkmk!
Unfortunately, due to our current work load, we only consider pure bug fixes as stated in our [Readme](https://github.com/tribe29/checkmk#want-to-contribute).
This means any new pull request that is not a pure bug fix will be closed.
Instead of creating a PR, please consider sharing new check plugins, agent plugins, special agents or notification plugins via the [Checkmk Exchange](https://exchange.checkmk.com/).

## General information

`PostgreSQL DB MAIN/access_to_shared_objects Size | check failed - please submit a crash report!`

Stack trace says that `abs()` is not working on `str`. Value is `str` as it's an empty string for shared objects (see https://stackoverflow.com/a/68649722)

## Bug reports

- Ubuntu 22.04
- Postgresql 15
- Agent output:

```
<<<postgres_stat_database:sep(59)>>>
[[[main]]]
datid;datname;numbackends;xact_commit;xact_rollback;blks_read;blks_hit;tup_returned;tup_fetched;tup_inserted;tup_updated;tup_deleted;datsize
0;;0;4892;0;516;235823;111036;63568;885;18;1;
5;postgres;1;2753;9;2487;575988;1440595;323172;23;408;13;7787311
1;template1;0;2230;0;2745;150164;587296;44020;17515;1158;47;7803695
4;template0;0;0;0;0;0;0;0;0;0;0;7479811
16391;drone;0;2434;0;4178;636262;1686263;324222;1554;2397;53;9183747
16588;gitea;0;6006;0;9599;1859369;3396993;756579;36226;3282;77;19784195
17663;homeassistant;1;15605;4;551078;94046266;20048725;924228;5131610;2128;105;2094945071
17777;nextcloud;0;203995;65;723103;30704523;58772486;9527053;885700;32108;3804;441786883
20704;sogo;0;2247;0;4253;547566;1481009;275878;488;1795;52;8135171
20766;zammad;0;25340;0;32687;3473437;8463671;1045510;182579;10147;347;97649155
```


## Proposed changes

Exclude columns without `datname` record from being parsed.