### PR TITLE
Fix error during update from 2.0.0p28.cee to 2.1.0p14.cee

### DIFF
--- a/cmk/gui/plugins/wato/check_parameters/heartbeat_rscstatus.py
+++ b/cmk/gui/plugins/wato/check_parameters/heartbeat_rscstatus.py
@@ -38,6 +38,7 @@ def _parameter_valuespec_heartbeat_rscstatus():
                 ),
             ),
         ],
+        ignored_keys=["discovered_state",],
     )
 
 

--- a/cmk/gui/plugins/wato/check_parameters/heartbeat_rscstatus.py
+++ b/cmk/gui/plugins/wato/check_parameters/heartbeat_rscstatus.py
@@ -38,7 +38,9 @@ def _parameter_valuespec_heartbeat_rscstatus():
                 ),
             ),
         ],
-        ignored_keys=["discovered_state",],
+        ignored_keys=[
+            "discovered_state",
+        ],
     )
 
 


### PR DESCRIPTION
Signed-off-by: Sven Rueß <github@sven-ruess.de>

## General information

During update from  2.0.0p28.cee to 2.1.0p14.cee following errors occur:
-|  8/27 Rewriting autochecks...
-| Transform failed: host='host1', plugin='heartbeat_rscstatus', ruleset='heartbeat_rscstatus', params={'discovered_state': 'none'}, error=AssertionError('non-empty params vanished')
-| Transform failed: host='host2', plugin='heartbeat_rscstatus', ruleset='heartbeat_rscstatus', params={'discovered_state': 'all'}, error=AssertionError('non-empty params vanished')
-| Transform failed: host='host3', plugin='heartbeat_rscstatus', ruleset='heartbeat_rscstatus', params={'discovered_state': 'all'}, error=AssertionError('non-empty params vanished')
-| Transform failed: host='host4', plugin='heartbeat_rscstatus', ruleset='heartbeat_rscstatus', params={'discovered_state': 'none'}, error=AssertionError('non-empty params vanished')

## Bug reports

Checkmk is used on Debian 10 in CEE Edition in mentioned versions above.

## Proposed changes

WATO rule is missing parameter, which is defined during discovery. This is checked now and adding the missing definition will fix it.