### PR TITLE
Fix unexpected return value of bi_expansion_level

### DIFF
--- a/cmk/gui/logged_in.py
+++ b/cmk/gui/logged_in.py
@@ -204,7 +204,7 @@ class LoggedInUser:
 
     @property
     def bi_expansion_level(self) -> int:
-        return self.load_file("bi_treestate", (None,))[0]
+        return self.load_file("bi_treestate", (0,))[0]
 
     @bi_expansion_level.setter
     def bi_expansion_level(self, value: int) -> None:


### PR DESCRIPTION
Hi all

We had a few people report issues when trying to do timewarps from BI availabilities. Digging into the issue revealed TypeError crash reports informing about an illegal comparison from "int to None" using `<=`.

The issue occurs in the edge case where a user did not ever work with BI before, and thus is lacking the file `bi_treestates.mk` in their profile. Currently this leads to a default value of `(None,)` being used for the file contents, which in turn leads to `None` being returned by `bi_expansion_level`, instead of an integer value.
When determining whether a node is open in `FoldableTreeRendererTree._is_open`, this results in failure when trying to do `len(path) <= self._expansion_level`.

This commit changes this by updating the fallback value of `load_file` in the bi_expansion_level property of the class `LoggedInUser` to `(0,)`.

Note that this is also required in 2.1.0. The file to patch there is `cmk/gui/utils/logged_in.py `. If you choose to accept this PR, should I create a separate one for 2.1.0 or does this patch make its way there automatically 😉 ?

_Crash report from DEV attached for reference [crash-report.tar.gz](https://github.com/tribe29/checkmk/files/9920890/Checkmk_Crash_ucp_dev_master_51f2c142-5aaf-11ed-9cdf-0242ac120002_2022-11-02_14-46-07.tar.gz)_

Kind regards
Thierry