### PR TITLE
Fix KeyError timerange in Migrate dashlets during update 2.0.0p28 to …

### DIFF
--- a/cmk/gui/plugins/dashboard/utils.py
+++ b/cmk/gui/plugins/dashboard/utils.py
@@ -935,13 +935,16 @@ def transform_stats_dashlet(dashlet_spec: DashletConfig) -> DashletConfig:
 
 
 def transform_timerange_dashlet(dashlet_spec: DashletConfig) -> DashletConfig:
-    dashlet_spec["timerange"] = {
-        "0": "4h",
-        "1": "25h",
-        "2": "8d",
-        "3": "35d",
-        "4": "400d",
-    }.get(dashlet_spec["timerange"], dashlet_spec["timerange"])
+    if "timerange" in dashlet_spec:
+        dashlet_spec["timerange"] = {
+            "0": "4h",
+            "1": "25h",
+            "2": "8d",
+            "3": "35d",
+            "4": "400d",
+        }.get(dashlet_spec["timerange"], dashlet_spec["timerange"])
+    else:
+        dashlet_spec["timerange"] = "4h"
     return dashlet_spec
 
 


### PR DESCRIPTION
…2.1.0p14

Signed-off-by: Sven Rueß <github@sven-ruess.de>

## General information

During update from 2.0.0p28.cee to 2.1.0p14.cee in step
-|  12/27 Migrate dashlets...

following error occurred:
-|  + "Migrate dashlets" failed
-| Traceback (most recent call last):
-|   File "/omd/sites/intern/lib/python3/cmk/update_config.py", line 298, in run
-|     step_func()
-|   File "/omd/sites/intern/lib/python3/cmk/update_config.py", line 1341, in _migrate_dashlets
-|     transform_timerange_dashlet(dashlet)
-|   File "/omd/sites/intern/lib/python3/cmk/gui/plugins/dashboard/utils.py", line 944, in transform_timerange_dashlet
-|     }.get(dashlet_spec["timerange"], dashlet_spec["timerange"])
-| KeyError: 'timerange'

## Bug reports

Checkmk is running on Debian 10.

## Proposed changes

I verified the definitions of all user dashlets. There is the key timerange missing in some dashlet configs.
Update script is not checking if this key exists and tries hard to rewrite it.

So check is done, if key is existing and should be rewritten. Otherwise it adds a default definition for this key.

With this modification all dashlets can be migarted successful and have a timerange key defined. Further updates should be no problem.

In master this update is completely rewritten. I could not check, if this error still exists there.