### PR TITLE
Prevent backscatter

### DIFF
--- a/cmk/notification_plugins/utils.py
+++ b/cmk/notification_plugins/utils.py
@@ -192,6 +192,8 @@ def set_mail_headers(
     elif len(target.split(",")) > 1:
         mail["Reply-To"] = target
 
+    mail["Auto-Submitted"] = "auto-generated"
+
     return mail
 
 

--- a/cmk/notification_plugins/utils.py
+++ b/cmk/notification_plugins/utils.py
@@ -193,6 +193,7 @@ def set_mail_headers(
         mail["Reply-To"] = target
 
     mail["Auto-Submitted"] = "auto-generated"
+    mail["X-Auto-Response-Suppress"] = "DR,RN,NRN,OOF,AutoReply"
 
     return mail
 


### PR DESCRIPTION
## General information

The patch prevents email backscatter (out of office-replies or other auto-responses)
for the notification plugins "mail" and "asciimail"

## Bug reports

Please include:

+ Detailed steps to reproduce the bug
Everytime a notification is send via mail and the recipient has set an out of office-reply or any other automatic response.
Another email is generated and send to the sender address of the notification. In larger environments this is results in daily useless mails.

## Proposed changes

+ What is the expected behavior?
The auto-response Mails are not longer generated by the MDA (Mail Delivery System) or MUA (Mail User Agent)

+ In what way does your patch change the current behavior?
The patch added two additional mail-headers. First 'Auto-Submitted' (see RFC3834) it indicates that the mail is auto generated and not initiated by a natural person, so no response is necessary. Second 'X-Auto-Response-Suppress' (see Microsoft Exchange Description) it indicates which auto responses are desired (all except non-delivery reports are suppressed)
