### PR TITLE
agent_proxmox_ve: allow nodes/time to be empty

### DIFF
--- a/cmk/special_agents/agent_proxmox_ve.py
+++ b/cmk/special_agents/agent_proxmox_ve.py
@@ -526,7 +526,8 @@ def agent_proxmox_ve_main(args: Args) -> None:
     snapshot_data = {}
 
     for node in data["nodes"]:
-        node_timezones[node["node"]] = node["time"]["timezone"]
+        if (timezone := node["time"].get("timezone")) is not None:
+            node_timezones[node["node"]] = timezone
         # only lxc and qemu can have snapshots
         for vm in node.get("lxc", []) + node.get("qemu", []):
             snapshot_data[str(vm["vmid"])] = {


### PR DESCRIPTION
## General information

Bugfix: Proxmox VE nodes that are shutdown have nodes -> time as empty json object. agent_proxmox_ve expects nodes -> time -> timezone to always be present, and thus crashes when a node is shut down.

Observed with Proxmox VE 7.2 and cmk 2.1.0p15.cre

## Proposed changes

+ What is the expected behavior?

agent_proxmox_ve should ignore or at least not crash if one PVE node in the cluster is down.

+ What is the observed behavior?

```
[agent] Success, [special_proxmox_ve] Agent exited with code 1: WARNING 2022-11-06 17:35:46 cmk.special_agents.utils.misc: Cache: could not find file - start a new one
```
Plus: `KeyError` at accessing unknown `timezone` key

+ If it's not obvious from the above: In what way does your patch change the current behavior?

Patch now falls back to "None" for timezone of the unavailable PVE node. This seems to work just fine.

+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?

No. In 2.1.0p14 another agent_proxmox_ve crash shadowed this problem.
