### PR TITLE
Added support for checking BBU & Cache-Vault for Storecli-Plugin, added Linux-Support

### DIFF
--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -79,14 +79,14 @@ storcli_info() {
         '"DID"'*)    #Device Id: 19
             LOG_DEV_ID=$( echo $line |  awk -F ': |,' '{print $2}')
         ;;
-        '                                "Intf" : '*) #                                 "Intf" : "SATA",
+        '"Intf" : '*) #                                 "Intf" : "SATA",
             VEND=$( echo "$line" | cut -d '"' -f4 )
         ;;
         # This is the last value, generate output here
         '"Model" : '*) #                                 "Model" : "INTEL SSDSC2BX200G4R",
          #Inquiry Data: WD-WCC1T1035197WDC WD20EZRX-00DC0B0 80.00A80
             # $4 seems to be better for some vendors... wont be possible to get this perfect.
-            MODEL=$( echo "$line" | cut -d '"' -f4 )
+            MODEL=$( echo "$line" | cut -d '"' -f4 | tr ' ' '-' )
 
             # /dev/sdc ATA SAMSUNG_SSD_830   5 Reallocated_Sector_Ct   0x0033   100   100   010    Pre-fail  Always       -
             smartctl -d megaraid,"${LOG_DEV_ID}" -v 9,raw48 -A /dev/sg${CONTROLLER} | \

--- a/agents/plugins/smart
+++ b/agents/plugins/smart
@@ -61,6 +61,42 @@ megaraid_info() {
         done
 }
 
+storcli_info() {
+    PDINFO=$($1 /cAll show nolog J)
+
+    echo "$PDINFO" | \
+    while read -r line ; do
+        case "$line" in
+        '"Controller"'*) #                 "Controller" : 0,
+           CONTROLLER=$( echo $line |  awk -F ': |,' '{print $2}')
+        ;;
+        '"EID:Slt"'*) #                                 "EID:Slt" : "32:0",
+           unset SLOT LOG_DEV_ID VEND MODEL
+            ENC=$( echo "$line" | cut -d '"' -f4 | cut -d ':' -f1 )
+            SLOT=$( echo "$line" | cut -d '"' -f4 | cut -d ':' -f2 )
+        ;;
+        # Identify the logical device ID. smartctl needs it to access the disk.
+        '"DID"'*)    #Device Id: 19
+            LOG_DEV_ID=$( echo $line |  awk -F ': |,' '{print $2}')
+        ;;
+        '                                "Intf" : '*) #                                 "Intf" : "SATA",
+            VEND=$( echo "$line" | cut -d '"' -f4 )
+        ;;
+        # This is the last value, generate output here
+        '"Model" : '*) #                                 "Model" : "INTEL SSDSC2BX200G4R",
+         #Inquiry Data: WD-WCC1T1035197WDC WD20EZRX-00DC0B0 80.00A80
+            # $4 seems to be better for some vendors... wont be possible to get this perfect.
+            MODEL=$( echo "$line" | cut -d '"' -f4 )
+
+            # /dev/sdc ATA SAMSUNG_SSD_830   5 Reallocated_Sector_Ct   0x0033   100   100   010    Pre-fail  Always       -
+            smartctl -d megaraid,"${LOG_DEV_ID}" -v 9,raw48 -A /dev/sg${CONTROLLER} | \
+              grep Always  | grep -E -v '^190(.*)Temperature(.*)'       | \
+              sed "s|^|Ctrl${CONTROLLER}/Enc${ENC}/Slot${SLOT} $VEND $MODEL |"
+            ;;
+            esac
+       done
+}
+
 # Only handle always updated values, add device path and vendor/model
 if inpath smartctl >/dev/null 2>&1; then
     #
@@ -168,8 +204,15 @@ if inpath smartctl >/dev/null 2>&1; then
         fi
     done 2>/dev/null
 
-    # Call MegaRaid submodule if conditions are met
-    if type MegaCli >/dev/null 2>&1; then
+    # storcli is the (newer) replacement of MegaCli
+    # perccli is a fork of storcli used for Dell-Hardware
+    # keep using MegaCli if non of them are present
+    storcli_bin=""
+    if [ -e /opt/MegaRAID/storcli/storcli64 ] ; then
+        storcli_bin="/opt/MegaRAID/storcli/storcli64"
+    elif [ -e /opt/MegaRAID/perccli/perccli64 ] ; then
+        storcli_bin="/opt/MegaRAID/perccli/perccli64"  # dell branded version of storcli
+    elif type MegaCli >/dev/null 2>&1; then
         MegaCli_bin="MegaCli"
     elif type MegaCli64 >/dev/null 2>&1; then
         MegaCli_bin="MegaCli64"
@@ -179,7 +222,9 @@ if inpath smartctl >/dev/null 2>&1; then
         MegaCli_bin="unknown"
     fi
 
-    if [ "$MegaCli_bin" != "unknown" ]; then
+    if [ -n "${storcli_bin}" ] ; then
+        storcli_info "${storcli_bin}"
+    elif [ "$MegaCli_bin" != "unknown" ]; then
         megaraid_info "$MegaCli_bin"
     fi
 else

--- a/agents/plugins/storcli
+++ b/agents/plugins/storcli
@@ -1,0 +1,17 @@
+#!/bin/bash
+storcli_bin=""
+if [ -e /opt/MegaRAID/storcli/storcli64 ] ; then
+    storcli_bin="/opt/MegaRAID/storcli/storcli64"
+elif [ -e /opt/MegaRAID/perccli/perccli64 ] ; then
+    storcli_bin="/opt/MegaRAID/perccli/perccli64"  # dell branded version of storcli
+fi
+
+if [ -n "${storcli_bin}" ] ; then
+    echo "<<<storcli_pdisks>>>"
+    ${storcli_bin} /call/eall/sall show nolog
+    echo "<<<storcli_vdrives>>>"
+    ${storcli_bin} /call/vall show nolog
+    echo "<<<storcli_bbu>>>"
+    ${storcli_bin} /call/bbu show all nolog
+    ${storcli_bin} /call/cv show all nolog
+fi

--- a/agents/windows/plugins/storcli.bat
+++ b/agents/windows/plugins/storcli.bat
@@ -13,5 +13,7 @@ ECHO ^<^<^<storcli_pdisks^>^>^>
 "!StorCli!" /call/eall/sall show
 ECHO ^<^<^<storcli_vdrives^>^>^>
 "!StorCli!" /call/vall show
-
+ECHO ^<^<^<storcli_bbu^>^>^>
+"!StorCli!" /call/bbu show all
+"!StorCli!" /call/cv show all
 :END

--- a/checks/storcli_bbu
+++ b/checks/storcli_bbu
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# License: GNU General Public License v2
+
+# Currently I do not have that mutch hardware of that kind,
+# but notify all other states which are not "Optimal" as Critical should be
+# a good idea most of the time.
+factory_settings["storcli_bbu_default_levels"] = {
+    "Optimal": 0,
+}
+
+
+def parse_storcli_bbu(info):
+
+    parsed = {}
+
+    controller_num = -1
+    bbu_type = ""
+    bbu_state = ""
+    bbu_temperature = -1
+    bbu_replacement = ""
+    bbu_capacitance = -1
+    for line in info:
+        if line[0].startswith("Controller"):
+            # Next Controller, reset Values
+            bbu_state = ""
+            bbu_temperature = -1
+
+            controller_num = line[2]
+        if line[0].startswith("Temperature"):
+            bbu_temperature = line[1]
+        if line[0].startswith("Replacement"):
+            bbu_replacement = line[2]
+        if line[0].startswith("Type"):
+            bbu_type = line[1]
+        if line[0].startswith("State"):
+            bbu_state = line[1]
+        if line[0].startswith("Battery") and bbu_type == "BBU" and line[1].startswith("State"):
+            bbu_state = line[2]
+        if line[0].startswith("Relative"):
+            bbu_capacitance = line[4]
+        if line[0].startswith("Capacitance"):
+            bbu_capacitance = line[1]
+        if line[0].startswith("Properties") or line[0].startswith("BBU_Properties"):
+            # not interested in properties...stop parsing this controller
+            parsed["Controller %s Type %s" % (controller_num, bbu_type)] = {
+                "type": bbu_type,
+                "state": bbu_state,
+                "temperature": bbu_temperature,
+                "replacement_required": bbu_replacement,
+                "capacitance": bbu_capacitance
+            }
+            bbu_state = ""
+            bbu_type = ""
+            bbu_temperature = -1
+            bbu_replacement = ""
+            bbu_capacitance = -1
+
+
+    return parsed
+
+
+def inventory_storcli_bbu(parsed):
+    for item in parsed:
+        yield (item, {})
+
+
+def check_storcli_bbu(item, params, parsed):
+    yield 0, "Type is %s" % parsed[item]["type"]
+    yield 0, "Capacitance is %s" % parsed[item]["capacitance"]
+    yield 0, "Temperature is %s C" % parsed[item]["temperature"]
+    yield 0, "Replacement Required is %s" % parsed[item]["replacement_required"]
+
+    device_state = parsed[item]["state"]
+    infotext = "State is %s" % device_state
+
+    if device_state in params:
+        status = params[device_state]
+    else:
+        status = 2
+        infotext += " (unknown[%s])" % device_state
+
+    if parsed[item]["replacement_required"] != "No":
+        status = 2
+        infotext += " (Replacement Required: %s)" % parsed[item]["replacement_required"]
+
+    yield status, infotext
+
+
+check_info["storcli_bbu"] = {
+    "default_levels_variable": "storcli_bbu_default_levels",
+    "parse_function": parse_storcli_bbu,
+    "inventory_function": inventory_storcli_bbu,
+    "check_function": check_storcli_bbu,
+    "service_description": "RAID BBU %s",
+    "group": "storcli_bbu",
+}


### PR DESCRIPTION
Hi all,

- the storecli Plugin is not checking the state of the BBU / Cache-Vault at the moment, so I added this
- the Plugin on Client-Side was only available for Windows, I added a little bash-script for use on Linux too
- the Linux Version also supports perccli (Dell-Branded Version of storcli)

There is also a check for storcli in check-mk-agent, but this does not work because the check is using MegaCli-Syntax not supported anymore by storcli or perccli. So in my opinion the "old" check without plugin could be moved out from check-mk agent (but this is not part of this PR).
