### PR TITLE
Fix file group crash

### DIFF
--- a/cmk/base/plugins/agent_based/utils/fileinfo.py
+++ b/cmk/base/plugins/agent_based/utils/fileinfo.py
@@ -540,7 +540,7 @@ def check_fileinfo_groups_data(
                 file_stat.size, files_matching["size_minmax"]
             )
 
-            age = reftime - file_stat.time
+            age = max(reftime - file_stat.time, 0)
             files_matching["age_minmax"] = _update_minmax(age, files_matching["age_minmax"])
 
             yield from _check_individual_files(


### PR DESCRIPTION
Since we upgraded to 2.1.0, we encounter check crashes ("check failed - please submit a crash report!") from time to time on the File Group check. By reading the crash logs it turned out that a ValueError "Cannot render negative timespan" is thrown in `cmk/base/api/agent_based/render.py` when trying to render the file age which is calculated in `cmk/base/api/agent_based/fileinfo.py`:

```
age = reftime - file_stat.time
```

So, when the monitored host returns a file time newer than the time on the CheckMK server, it will crash.

This fix prevents that the age given to the renderer can be negative.