### PR TITLE
Add missing support for Cisco C9800-CL WLC to SSID clients

### DIFF
--- a/cmk/base/plugins/agent_based/cisco_wlc_clients.py
+++ b/cmk/base/plugins/agent_based/cisco_wlc_clients.py
@@ -63,6 +63,7 @@ register.snmp_section(
     name="cisco_wlc_9800_clients",
     parsed_section_name="wlc_clients",
     detect=any_of(
+        equals(OID_sysObjectID, ".1.3.6.1.4.1.9.1.2391"),
         equals(OID_sysObjectID, ".1.3.6.1.4.1.9.1.2530"),
         equals(OID_sysObjectID, ".1.3.6.1.4.1.9.1.2861"),
     ),


### PR DESCRIPTION
Add support for Cisco C9800-CL WLC to SSID clients (cisco_wlc_clients).

## General information

The Cisco C9800-CL is supported by the latest CheckMK versions (oid .1.3.6.1.4.1.9.1.2391) and is available in the 'cisco_wlc'(.py) check but is not in the 'cisco_wlc_clients' which I think is a bug/missed step of the previous implementation.

By adding the '.1.3.6.1.4.1.9.1.2391' in the 'matches' of this file, the service 'Clients [SSID] | [Summary]' are added for this device (Cisco C9800-CL).

This change is simple and should not impact any other functionality. Has been tested on CheckMK 2.1.0p14.

## Proposed changes

Add this single line to the cisco_wlc_clients to support specific SSID related services (Clients <ssid>) just like with some other 9800 systems.
