### PR TITLE
Apply werk 15034 also to 2.1 releases

### DIFF
--- a/cmk/gui/plugins/wato/check_mk_configuration.py
+++ b/cmk/gui/plugins/wato/check_mk_configuration.py
@@ -5752,7 +5752,7 @@ def _valuespec_snmpv3_contexts():
         elements=[
             DropdownChoice(
                 title=_("Section name"),
-                choices=get_snmp_section_names,
+                choices=lambda: [(None, _("All SNMP sections"))] + get_snmp_section_names(),
             ),
             ListOfStrings(
                 title=_("SNMP Context IDs"),


### PR DESCRIPTION
"All SNMP sections" is currently missing in the dropdown choices

![grafik](https://user-images.githubusercontent.com/17898967/210589310-542e5264-e2cd-4a33-a3bf-8598e164e275.png)

