### PR TITLE
add levels for disk-io queue length

### DIFF
--- a/cmk/gui/plugins/wato/check_parameters/diskstat.py
+++ b/cmk/gui/plugins/wato/check_parameters/diskstat.py
@@ -174,6 +174,14 @@ def _parameter_valuespec_diskstat():
                 "write_ios",
                 Levels(title=_("Write operations"), unit=_("1/s"), default_levels=(300.0, 400.0)),
             ),
+            (
+                "read_ql",
+                Levels(title=_("Read queue length"), unit=_(""), default_levels=(80.0, 90.0)),
+            ),
+            (
+                "write_ql",
+                Levels(title=_("Write queue length"), unit=_(""), default_levels=(80.0, 90.0)),
+            ),
         ],
     )
 


### PR DESCRIPTION
add missing levels for queue length

this level is included in the actual plugin and metrics file but the check_parameters are missing
in old-style check this level was existent with the same default levels

tested on OS Ubuntu 20.04