### PR TITLE
fix handling of decimal values in ibm_svc_nodestats

### DIFF
--- a/checks/ibm_svc_nodestats
+++ b/checks/ibm_svc_nodestats
@@ -15,7 +15,48 @@ from cmk.base.plugins.agent_based.agent_based_api.v1 import render
 # Note: This file is almost identical with ibm_svc_nodestats. We should
 # create an include file for sharing common code!
 
-# Example output from agent:
+# newer Firmware versions may return decimal values, not just integer
+# <<<ibm_svc_nodestats:sep(58)>>>
+# node_id:node_name:stat_name:stat_current:stat_peak:stat_peak_time
+# 6:BLUBBSVC01:compression_cpu_pc:0:0:230119164649
+# 6:BLUBBSVC01:cpu_pc:16:18:230119164614
+# 6:BLUBBSVC01:fc_mb:572:598:230119164619
+# 6:BLUBBSVC01:fc_io:48940:75775:230119164614
+# 6:BLUBBSVC01:sas_mb:0:0:230119164649
+# 6:BLUBBSVC01:sas_io:0:0:230119164649
+# 6:BLUBBSVC01:iscsi_mb:0:0:230119164649
+# 6:BLUBBSVC01:iscsi_io:0:0:230119164649
+# 6:BLUBBSVC01:write_cache_pc:34:34:230119164649
+# 6:BLUBBSVC01:total_cache_pc:79:80:230119164444
+# 6:BLUBBSVC01:vdisk_mb:391:394:230119164619
+# 6:BLUBBSVC01:vdisk_io:23885:25737:230119164619
+# 6:BLUBBSVC01:vdisk_ms:0.216:0.278:230119164229
+# 6:BLUBBSVC01:mdisk_mb:172:220:230119164154
+# 6:BLUBBSVC01:mdisk_io:9832:9832:230119164649
+# 6:BLUBBSVC01:mdisk_ms:0.324:0.440:230119164634
+# 6:BLUBBSVC01:drive_mb:0:0:230119164649
+# 6:BLUBBSVC01:drive_io:0:0:230119164649
+# 6:BLUBBSVC01:drive_ms:0.000:0.000:230119164649
+# 6:BLUBBSVC01:vdisk_r_mb:388:388:230119164649
+# 6:BLUBBSVC01:vdisk_r_io:23401:24944:230119164619
+# 6:BLUBBSVC01:vdisk_r_ms:0.217:0.280:230119164229
+# 6:BLUBBSVC01:vdisk_w_mb:2:27:230119164539
+# 6:BLUBBSVC01:vdisk_w_io:482:2660:230119164334
+# 6:BLUBBSVC01:vdisk_w_ms:0.191:0.455:230119164309
+# 6:BLUBBSVC01:mdisk_r_mb:168:194:230119164154
+# 6:BLUBBSVC01:mdisk_r_io:9700:9700:230119164649
+# 6:BLUBBSVC01:mdisk_r_ms:0.323:0.453:230119164634
+# 6:BLUBBSVC01:mdisk_w_mb:3:51:230119164334
+# 6:BLUBBSVC01:mdisk_w_io:132:1715:230119164334
+# 6:BLUBBSVC01:mdisk_w_ms:0.393:0.446:230119164204
+# 6:BLUBBSVC01:drive_r_mb:0:0:230119164649
+# 6:BLUBBSVC01:drive_r_io:0:0:230119164649
+# 6:BLUBBSVC01:drive_r_ms:0.000:0.000:230119164649
+# 6:BLUBBSVC01:drive_w_mb:0:0:230119164649
+# 6:BLUBBSVC01:drive_w_io:0:0:230119164649
+# 6:BLUBBSVC01:drive_w_ms:0.000:0.000:230119164649
+
+# Old Example output from agent (only integer values):
 # <<<ibm_svc_nodestats:sep(58)>>>
 # 1:BLUBBSVC01:compression_cpu_pc:0:0:140325134931
 # 1:BLUBBSVC01:cpu_pc:1:3:140325134526
@@ -112,7 +153,7 @@ def parse_ibm_svc_nodestats(info):
             else:
                 continue
             try:
-                stat_current = int(data["stat_current"])
+                stat_current = float(data["stat_current"])
             except ValueError:
                 continue
             parsed.setdefault(item_name, {}).setdefault(stat_name, stat_current)

--- a/tests/unit/checks/generictests/datasets/ibm_svc_nodestats_regression.py
+++ b/tests/unit/checks/generictests/datasets/ibm_svc_nodestats_regression.py
@@ -105,10 +105,10 @@ checks = {
             [
                 (
                     0,
-                    "Latency is 0 ms for read, 0 ms for write",
+                    "Latency is 0.0 ms for read, 0.0 ms for write",
                     [
-                        ("read_latency", 0, None, None, None, None),
-                        ("write_latency", 0, None, None, None, None),
+                        ("read_latency", 0.0, None, None, None, None),
+                        ("write_latency", 0.0, None, None, None, None),
                     ],
                 )
             ],
@@ -119,10 +119,10 @@ checks = {
             [
                 (
                     0,
-                    "Latency is 5 ms for read, 1 ms for write",
+                    "Latency is 5.0 ms for read, 1.0 ms for write",
                     [
-                        ("read_latency", 5, None, None, None, None),
-                        ("write_latency", 1, None, None, None, None),
+                        ("read_latency", 5.0, None, None, None, None),
+                        ("write_latency", 1.0, None, None, None, None),
                     ],
                 )
             ],
@@ -133,10 +133,10 @@ checks = {
             [
                 (
                     0,
-                    "Latency is 2 ms for read, 0 ms for write",
+                    "Latency is 2.0 ms for read, 0.0 ms for write",
                     [
-                        ("read_latency", 2, None, None, None, None),
-                        ("write_latency", 0, None, None, None, None),
+                        ("read_latency", 2.0, None, None, None, None),
+                        ("write_latency", 0.0, None, None, None, None),
                     ],
                 )
             ],
@@ -150,7 +150,10 @@ checks = {
                 (
                     0,
                     "0.00 B/s read, 0.00 B/s write",
-                    [("read", 0, None, None, None, None), ("write", 0, None, None, None, None)],
+                    [
+                        ("read", 0.0, None, None, None, None),
+                        ("write", 0.0, None, None, None, None),
+                    ],
                 )
             ],
         ),
@@ -162,8 +165,8 @@ checks = {
                     0,
                     "1.05 MB/s read, 16.8 MB/s write",
                     [
-                        ("read", 1048576, None, None, None, None),
-                        ("write", 16777216, None, None, None, None),
+                        ("read", 1048576.0, None, None, None, None),
+                        ("write", 16777216.0, None, None, None, None),
                     ],
                 )
             ],
@@ -175,7 +178,10 @@ checks = {
                 (
                     0,
                     "0.00 B/s read, 0.00 B/s write",
-                    [("read", 0, None, None, None, None), ("write", 0, None, None, None, None)],
+                    [
+                        ("read", 0.0, None, None, None, None),
+                        ("write", 0.0, None, None, None, None),
+                    ],
                 )
             ],
         ),
@@ -187,8 +193,11 @@ checks = {
             [
                 (
                     0,
-                    "0 IO/s read, 0 IO/s write",
-                    [("read", 0, None, None, None, None), ("write", 0, None, None, None, None)],
+                    "0.0 IO/s read, 0.0 IO/s write",
+                    [
+                        ("read", 0.0, None, None, None, None),
+                        ("write", 0.0, None, None, None, None),
+                    ],
                 )
             ],
         ),
@@ -198,8 +207,11 @@ checks = {
             [
                 (
                     0,
-                    "15 IO/s read, 865 IO/s write",
-                    [("read", 15, None, None, None, None), ("write", 865, None, None, None, None)],
+                    "15.0 IO/s read, 865.0 IO/s write",
+                    [
+                      ("read", 15.0, None, None, None, None),
+                      ("write", 865.0, None, None, None, None),
+                    ],
                 )
             ],
         ),
@@ -209,8 +221,11 @@ checks = {
             [
                 (
                     0,
-                    "19 IO/s read, 110 IO/s write",
-                    [("read", 19, None, None, None, None), ("write", 110, None, None, None, None)],
+                    "19.0 IO/s read, 110.0 IO/s write",
+                    [
+                      ("read", 19.0, None, None, None, None),
+                      ("write", 110.0, None, None, None, None),
+                    ],
                 )
             ],
         ),


### PR DESCRIPTION
Similar to Werks 14061 and 14063 for ibm_svc_systemstats, newer SVC firmware versions can also report decimal values for ibm_svc_nodestats. Fixed by casting to float and adapted regression test.