### PR TITLE
Fix mk logwatch

### DIFF
--- a/agents/plugins/mk_logwatch.py
+++ b/agents/plugins/mk_logwatch.py
@@ -1191,7 +1191,9 @@ def _is_outdated_batch(batch_file, retention_period, now):
 
 def write_batch_file(lines, batch_id, batch_dir):
     # type: (Iterable[str], str, str) -> None
-    with io.open(os.path.join(batch_dir, "logwatch-batch-file-%s" % batch_id), "w", encoding="utf-8") as handle:
+    with io.open(
+        os.path.join(batch_dir, "logwatch-batch-file-%s" % batch_id), "w", encoding="utf-8"
+    ) as handle:
         handle.writelines([ensure_text_type(l, errors="replace") for l in lines])
 
 


### PR DESCRIPTION
Fix mk_logwatch for UTF-8
- function write_batch_file should wirte UTF-8 to batch files
- add exception for writing state file

Signed-off-by: Sven Rueß <github@sven-ruess.de>

## General information

With usage of mk_logwatch.py or mk_logwatch_2.py there are rare exceptions during writing batch files.
Logfiles could have UTF-8 symbols included and those symbols and text is not written to batch file.
State file is updated, but services are vanished and data is missing for logwatch. I had a short
mail conversation with @kain88-de and he should be directly informed about this PR.

## Bug reports

Bug will be occur on every operating system with log files using UTF-8 symbols.
Batch file will not be written and nothing is reported to Checkmk server. Exception
is not catched and user is not informed about this issue. I have attached a small test script
for demonstration.
[test.txt](https://github.com/tribe29/checkmk/files/10674058/test.txt)

Affected versions 2.0.0+

## Proposed changes

Changes were tested on customer environment and are working correctly. No exception will
occur and data is reported to monitoring server.

Logwatch should write UTF-8 to batch file to handle it correctly and should not produce exceptions.
