### PR TITLE
Bug: All df checks don't respect the trend_perfdata setting

### DIFF
--- a/cmk/base/plugins/agent_based/utils/df.py
+++ b/cmk/base/plugins/agent_based/utils/df.py
@@ -606,15 +606,16 @@ def df_check_filesystem_single(  # type:ignore[no-untyped-def]
     if subtract_reserved:
         yield Metric("reserved", reserved_space)
 
-    yield from size_trend(
-        value_store=value_store,
-        value_store_key=mountpoint,
-        resource="disk",
-        levels=params,
-        used_mb=used_space,
-        size_mb=filesystem_size,
-        timestamp=this_time,
-    )
+    if params.get("trend_perfdata"):
+        yield from size_trend(
+            value_store=value_store,
+            value_store_key=mountpoint,
+            resource="disk",
+            levels=params,
+            used_mb=used_space,
+            size_mb=filesystem_size,
+            timestamp=this_time,
+        )
 
     if inodes_total and inodes_avail is not None:
         yield from check_inodes(params, inodes_total, inodes_avail)


### PR DESCRIPTION
One bug was encountered where the rule setting to not compute trend data is not respected.
Better said it is ignored and trend data is computed every time.

As the default setting for this param is True i only check if it is set.

Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/tribe29/checkmk#want-to-contribute) regarding process details.

## General information

Please give a brief summary of the affected device, software or appliance.
Keep in mind that we are experts in monitoring, but we cannot be experts on all supported devices.
A little context will help us assess your proposed change.

## Bug reports

Please include:

+ Your operating system name and version
+ Any details about your local setup that might be helpful in troubleshooting
+ Detailed steps to reproduce the bug
+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?
+ What is the observed behavior?
+ If it's not obvious from the above: In what way does your patch change the current behavior?
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
