### PR TITLE
Update core_nagios.py

### DIFF
--- a/cmk/base/core_nagios.py
+++ b/cmk/base/core_nagios.py
@@ -998,9 +998,11 @@ def _extra_service_conf_of(
     # Add contact groups to the config only if the user has defined them.
     # Otherwise inherit the contact groups from the host.
     # "check-mk-notify" is always returned for rulebased notifications and
-    # the Nagios core and not defined by the user.
+    # the Nagios core and not defined by the user.  "check-mk-notify" will not exist
+    # when rulebased notifications is disabled so we shouldn't add contact groups
+    # if sercgr evaluates as false.
     sercgr = config_cache.contactgroups_of_service(hostname, description)
-    if sercgr != ["check-mk-notify"]:
+    if sercgr and sercgr != ["check-mk-notify"]:
         service_spec["contact_groups"] = ",".join(sercgr)
         cfg.contactgroups_to_define.update(sercgr)
 


### PR DESCRIPTION
FIX Host contact groups are not inherited to services

When rulebased notifications are disabled, "check-mk-notify" is not returned for all services. For compatibility with having rulebased notifications, we can also check that sercgr exists.

This way should allow Nagios inheritance whether rulebased notifications is enabled or disabled.

Thank you for your interest in contributing to Checkmk!
Consider looking into [Readme](https://github.com/tribe29/checkmk#want-to-contribute) regarding process details.

## General information

We have a checkmk 2.1.0p17 RAW (nagios engine) server running on Centos 7 with rulebased notifications disabled.  We observed that contactgroups for services were not inherited from the host when we did not define a service contactgroup.   Instead, we were getting an empty list of service_contactgroups for these services.   After examining the code, we determined that the fix for werks/8786 only works for instances with rulebased notifications enabled.

## Bug reports

Please include:

+ Centos 7.2
+ rulebased notifications is not defined in our configuration, so is disabled.
+ Steps to Reproduce

1. Configure global setting, "Rule Based notifications" as off.   
2. Assign a contactgroup to a host but do not assign a contactgroup to the services for that host
3. Observe that service contactgroups are empty, and not inherited from the host contactgroup.

+ An agent output or SNMP walk
+ The ID of a submitted crash report for reference (if applicable)

## Proposed changes

Sometimes it is hard for us to assess the quality of a fix.
While it may work for you, it is our job to ensure that it works for everybody.
These are some ways to help us:

+ What is the expected behavior?   Service_contactgroups are inherited from the host whether rule-based notifications are enabled or disabled.
+ What is the observed behavior?  when rule-based notifications are disabled, contactgroup inheritance is broken.
+ If it's not obvious from the above: In what way does your patch change the current behavior?  The above change skips the conditional when sercgr(list) evaluates as false as well as when sercgr(list)  !=  ['check-mk-notify']
+ Consider writing a unit test that would have failed without your fix.
+ Is this a new problem? What made you submit this PR (new firmware, new device, changed device behavior)?
We recently upgraded from a very old version of check-mk which was before rulebased notifications were available.


