### PR TITLE
fix params detection in check_humidity

### DIFF
--- a/cmk/base/plugins/agent_based/utils/humidity.py
+++ b/cmk/base/plugins/agent_based/utils/humidity.py
@@ -14,7 +14,7 @@ CheckParams = Union[
 
 def check_humidity(humidity: float, params: CheckParams) -> type_defs.CheckResult:
     levels_upper, levels_lower = None, None
-    if isinstance(params, dict):
+    if isinstance(params, (dict, Mapping)):
         levels_upper = params.get("levels") or None
         levels_lower = params.get("levels_lower") or None
     elif isinstance(params, (list, tuple)):


### PR DESCRIPTION
Standard rule "Humidity Levels" returns an object of type cmk.base.api.agent_based.type_defs.Parameters.

Example: Parameters({'levels': (70.0, 80.0), 'levels_lower': (1.0, 5.0)})

This does not match with isinstance(params, dict), so the parameters get ignored. Fixed by adding type "Mapping", so isinstance evaluates to True for this type of params.