### PR TITLE
Now safe to only include types-lxml as dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,6 @@ docker = "*"  # used by test_docker test and mk_docker agent plugin
 dockerpty = "*"  # used by dockerized tests for opening debug shells
 freezegun = "*"  # used by various unit tests
 isort = "*"  # used as a plugin for editors
-lxml-stubs = "*"  # used for type checking
 mock = "*"  # used in checktestlib in unit tests
 pylint = "*"  # used by test/Makefile's test-pylint target
 hypothesis = "*"    # used by unit tests


### PR DESCRIPTION
## Proposed changes

`types-lxml` and `lxml-stubs` both act as external python annotation for `lxml`, but with different file layout, they can conflict with each other. `types-lxml` is now considered complete, and both `mypy` and `pyright` type checking tools issue no type warning in the few places lxml is used:

- `agent_azure_status.py`: OK
- `agent_netapp.py`: warns because type checker thinks [the code](https://github.com/tribe29/checkmk/blob/c6141cc548605ca001753d50dec7f4aca0c77648/cmk/special_agents/agent_netapp.py#L73-L77) imports `xml.etree.ElementTree` to overwrite `lxml.etree`. Without the fallback it has no lxml-related type warnings.

Above is verified with `types-lxml` version in `Pipfile.lock` (2023.2.11), as well as the most recent release (2023.3.28).