### PR TITLE
fix heartbeat_crm: Master/Slave set is displayed as Clone Set

### DIFF
--- a/checks/heartbeat_crm
+++ b/checks/heartbeat_crm
@@ -360,7 +360,10 @@ def heartbeat_crm_parse_resources(info, show="resources"):
                 # Clone set
                 resource = _title(parts[2])
                 resources[resource] = []
-                mode = "cloneset"
+                if parts[-1] == "(promotable):":
+                    mode = "masterslaveset"
+                else:
+                    mode = "cloneset"
             elif line.startswith("Master/Slave Set:"):
                 # Master/Slave set
                 resource = _title(parts[2])


### PR DESCRIPTION
pacemaker in at least version 2.1.2 displays Master/Slave Set as Clone Sets: ====
<<<heartbeat_crm>>>
Cluster Summary:
_* Stack: corosync
_* Current DC: webproxy02 (version 2.1.2+20211124.ada5c3b36-150400.4.9.2-2.1.2+20211124.ada5c3b36) - partition with quorum _* Last updated: Tue Mar 28 07:15:09 2023
_* Last change:  Thu Mar  2 12:25:08 2023 by root via cibadmin on webproxy02 _* 2 nodes configured
_* 8 resource instances configured
Node List:
_* Online: [ webproxy01 webproxy02 ]
Full List of Resources:
_* SharedIP     (ocf:￼IPaddr2):        Started webproxy01
_* Clone Set: MS-conntrack [Conntrack] (promotable):
_  * Masters: [ webproxy01 ]
_  * Slaves: [ webproxy02 ]
_* Clone Set: cl-link-eth0 [link-eth0]:
_  * Started: [ webproxy01 webproxy02 ]
_* Clone Set: cl-link-eth1 [link-eth1]:
_  * Started: [ webproxy01 webproxy02 ]
_* apache       (systemd:apache2):       Started webproxy01
====
note MS-conntrack displayed as Clone Set, it is configured as a MS Set. The only distinguishing feature in output is the string "promotable", hence the additional condition check to change the handling to masterslaveset.
