### PR TITLE
check_levels(): show exceeded levels in summary

### DIFF
--- a/cmk/base/api/agent_based/utils.py
+++ b/cmk/base/api/agent_based/utils.py
@@ -350,6 +350,8 @@ def check_levels(
         have been exceeded and show these in the summary text.
         Otherwise, select the available levels, or None if neither is given.
         """
+        metric_levels: Optional[Tuple[float, float]]
+
         if levels_upper and levels_lower:
             metric_levels = (
                 levels_lower
@@ -445,6 +447,8 @@ def check_levels_predictive(
     have been exceeded and show these in the summary text.
     Otherwise, select the available levels, or None if neither is known.
     """
+    metric_levels: Optional[Tuple[float, float]]
+
     if levels_upper and levels_lower:
         metric_levels = (
             levels_lower
@@ -453,6 +457,7 @@ def check_levels_predictive(
         )
     else:
         metric_levels = levels_upper if levels_upper else levels_lower
+
     yield Metric(metric_name, value, levels=metric_levels, boundaries=boundaries)
     if ref_value:
         yield Metric("predict_%s" % metric_name, ref_value)

--- a/cmk/base/api/agent_based/utils.py
+++ b/cmk/base/api/agent_based/utils.py
@@ -355,7 +355,7 @@ def check_levels(
         if levels_upper and levels_lower:
             metric_levels = (
                 levels_lower
-                if value <= levels_lower[0] +(levels_upper[0]-levels_lower[0])/2
+                if value <= levels_lower[0] + (levels_upper[0] - levels_lower[0]) / 2
                 else levels_upper
             )
         else:
@@ -452,7 +452,7 @@ def check_levels_predictive(
     if levels_upper and levels_lower:
         metric_levels = (
             levels_lower
-            if value <= levels_lower[0] +(levels_upper[0]-levels_lower[0])/2
+            if value <= levels_lower[0] + (levels_upper[0] - levels_lower[0]) / 2
             else levels_upper
         )
     else:

--- a/cmk/base/api/agent_based/utils.py
+++ b/cmk/base/api/agent_based/utils.py
@@ -345,7 +345,21 @@ def check_levels(
     else:
         yield Result(state=value_state, summary=info_text + levels_text)
     if metric_name:
-        yield Metric(metric_name, value, levels=levels_upper, boundaries=boundaries)
+        """
+        If both lower and upper levels are passed, check which levels
+        have been exceeded and show these in the summary text.
+        Otherwise, select the available levels, or None if neither is given.
+        """
+        if levels_upper and levels_lower:
+            metric_levels = (
+				levels_lower
+	            if value <= levels_lower[0] +(levels_upper[0]-levels_lower[0])/2
+                else levels_upper
+			)
+        else:
+            metric_levels = levels_upper if levels_upper else levels_lower
+
+        yield Metric(metric_name, value, levels=metric_levels, boundaries=boundaries)
 
 
 def check_levels_predictive(
@@ -426,7 +440,20 @@ def check_levels_predictive(
         info_text = "%s%s" % (render_func(value), predictive_levels_msg)
 
     yield Result(state=value_state, summary=info_text + levels_text)
-    yield Metric(metric_name, value, levels=levels_upper, boundaries=boundaries)
+	"""
+	If both lower and upper levels are present, check which levels
+	have been exceeded and show these in the summary text.
+	Otherwise, select the available levels, or None if neither is known.
+	"""
+	if levels_upper and levels_lower:
+		metric_levels = (
+			levels_lower
+			if value <= levels_lower[0] +(levels_upper[0]-levels_lower[0])/2
+			else levels_upper
+		)
+	else:
+		metric_levels = levels_upper if levels_upper else levels_lower
+	yield Metric(metric_name, value, levels=metric_levels, boundaries=boundaries)
     if ref_value:
         yield Metric("predict_%s" % metric_name, ref_value)
 

--- a/cmk/base/api/agent_based/utils.py
+++ b/cmk/base/api/agent_based/utils.py
@@ -352,10 +352,10 @@ def check_levels(
         """
         if levels_upper and levels_lower:
             metric_levels = (
-				levels_lower
-	            if value <= levels_lower[0] +(levels_upper[0]-levels_lower[0])/2
+                levels_lower
+                if value <= levels_lower[0] +(levels_upper[0]-levels_lower[0])/2
                 else levels_upper
-			)
+            )
         else:
             metric_levels = levels_upper if levels_upper else levels_lower
 
@@ -440,20 +440,20 @@ def check_levels_predictive(
         info_text = "%s%s" % (render_func(value), predictive_levels_msg)
 
     yield Result(state=value_state, summary=info_text + levels_text)
-	"""
-	If both lower and upper levels are present, check which levels
-	have been exceeded and show these in the summary text.
-	Otherwise, select the available levels, or None if neither is known.
-	"""
-	if levels_upper and levels_lower:
-		metric_levels = (
-			levels_lower
-			if value <= levels_lower[0] +(levels_upper[0]-levels_lower[0])/2
-			else levels_upper
-		)
-	else:
-		metric_levels = levels_upper if levels_upper else levels_lower
-	yield Metric(metric_name, value, levels=metric_levels, boundaries=boundaries)
+    """
+    If both lower and upper levels are present, check which levels
+    have been exceeded and show these in the summary text.
+    Otherwise, select the available levels, or None if neither is known.
+    """
+    if levels_upper and levels_lower:
+        metric_levels = (
+            levels_lower
+            if value <= levels_lower[0] +(levels_upper[0]-levels_lower[0])/2
+            else levels_upper
+        )
+    else:
+        metric_levels = levels_upper if levels_upper else levels_lower
+    yield Metric(metric_name, value, levels=metric_levels, boundaries=boundaries)
     if ref_value:
         yield Metric("predict_%s" % metric_name, ref_value)
 


### PR DESCRIPTION
- cmk/base/api/agent_based/utils.py check_levels() and check_levels_predictive(): Select the correct set of levels that have been exceeded to pass to Metric(), so that they are shown in the summary output. Previously, "levels_upper" was always used, regardless of which levels had actually been exceeded.

